### PR TITLE
feat: bitmap action types, stock split validation, CompletionFilter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/rain.vats"]
 	path = lib/rain.vats
 	url = https://github.com/rainlanguage/rain.vats
+[submodule "lib/rain.tofu.erc20-decimals"]
+	path = lib/rain.tofu.erc20-decimals
+	url = https://github.com/rainlanguage/rain.tofu.erc20-decimals

--- a/foundry.toml
+++ b/foundry.toml
@@ -20,6 +20,7 @@ remappings = [
   "rain.deploy/=lib/rain.deploy/src/",
   "rain.sol.codegen/=lib/rain.vats/lib/rain.flare/lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.sol.codegen/src/",
   "rain.math.float/=lib/rain.vats/lib/rain.flare/lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float/src/",
+  "rain.tofu.erc20-decimals/=lib/rain.tofu.erc20-decimals/src/",
 ]
 
 [rpc_endpoints]

--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,7 @@ remappings = [
   "openzeppelin-contracts-upgradeable/=lib/rain.vats/lib/openzeppelin-contracts-upgradeable/",
   "rain.deploy/=lib/rain.deploy/src/",
   "rain.sol.codegen/=lib/rain.vats/lib/rain.flare/lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.sol.codegen/src/",
+  "rain.math.float/=lib/rain.vats/lib/rain.flare/lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float/src/",
 ]
 
 [rpc_endpoints]

--- a/src/error/ErrCorporateAction.sol
+++ b/src/error/ErrCorporateAction.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+/// Thrown when scheduling an action with an effective time in the past.
+error EffectiveTimeInPast(uint64 effectiveTime, uint256 currentTime);
+
+/// Thrown when trying to cancel an action whose effectiveTime has passed.
+error ActionAlreadyComplete(uint256 actionIndex);
+
+/// Thrown when referencing an action that does not exist.
+error ActionDoesNotExist(uint256 actionIndex);
+
+/// Thrown when the external type hash has no known bitmap mapping.
+/// @param typeHash The unrecognised external identifier.
+error UnknownActionType(bytes32 typeHash);
+
+/// Thrown when accessing head/tail on a list with no scheduled actions.
+error NoActionsScheduled();

--- a/src/error/ErrStockSplit.sol
+++ b/src/error/ErrStockSplit.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {Float} from "rain.math.float/lib/LibDecimalFloat.sol";
+
+/// @notice Thrown when a stock split multiplier has a zero or negative coefficient.
+error InvalidSplitMultiplier();
+
+/// @notice Thrown when a stock split multiplier is too small to preserve any
+/// meaningful balance. Specifically, a multiplier that, when applied to 1e18
+/// (a reasonable "meaningful minimum" balance for an 18-decimal token), rounds
+/// to zero is rejected. Without this floor, an authorized scheduler could
+/// schedule a near-zero multiplier (e.g. `packLossless(1, -30)`) that wipes
+/// every holder's balance to 0 at the effective time.
+/// @param multiplier The offending multiplier.
+error MultiplierTooSmall(Float multiplier);
+
+/// @notice Thrown when a stock split multiplier is large enough to risk
+/// overflow when applied sequentially to realistic supplies. The bound is
+/// `trunc(1e18 * multiplier) <= 1e36`, corresponding to a 1e18x growth
+/// factor — far beyond any plausible real-world corporate action.
+/// @param multiplier The offending multiplier.
+error MultiplierTooLarge(Float multiplier);

--- a/src/interface/ICorporateActionsV1.sol
+++ b/src/interface/ICorporateActionsV1.sol
@@ -187,7 +187,8 @@ interface ICorporateActionsV1 {
     /// effective times are possible.
     ///
     /// @param typeHash External identifier for the action type, e.g.
-    /// keccak256("StockSplit"). Resolved to an internal bitmap by the lib.
+    /// keccak256("st0x.corporate-actions.stock-split"). Resolved to an internal
+    /// bitmap by the lib.
     /// @param effectiveTime When the action takes effect. Must be in the future.
     /// @param parameters ABI-encoded parameters specific to the action type.
     /// @return actionIndex Handle for the scheduled action.

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 import {CorporateActionNode, CompletionFilter, LibCorporateActionNode} from "./LibCorporateActionNode.sol";
 import {LibStockSplit} from "./LibStockSplit.sol";

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -82,11 +82,7 @@ library LibCorporateAction {
     /// @param typeHash External identifier, e.g. keccak256("StockSplit").
     /// @param parameters ABI-encoded parameters for the action type.
     /// @return actionType The internal bitmap for this type.
-    function resolveActionType(bytes32 typeHash, bytes memory parameters)
-        internal
-        pure
-        returns (uint256 actionType)
-    {
+    function resolveActionType(bytes32 typeHash, bytes memory parameters) internal pure returns (uint256 actionType) {
         if (typeHash == STOCK_SPLIT_TYPE_HASH) {
             LibStockSplit.validateParameters(parameters);
             return ACTION_TYPE_STOCK_SPLIT;

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 
 import {CorporateActionNode, CompletionFilter, LibCorporateActionNode} from "./LibCorporateActionNode.sol";
 import {LibStockSplit} from "./LibStockSplit.sol";
+import {Float} from "rain.math.float/lib/LibDecimalFloat.sol";
 import {
     EffectiveTimeInPast,
     ActionAlreadyComplete,
@@ -78,7 +79,7 @@ library LibCorporateAction {
     /// @return actionType The internal bitmap for this type.
     function resolveActionType(bytes32 typeHash, bytes calldata parameters) internal returns (uint256 actionType) {
         if (typeHash == STOCK_SPLIT_TYPE_HASH) {
-            LibStockSplit.validateParameters(parameters);
+            LibStockSplit.validateMultiplier(abi.decode(parameters, (Float)));
             return ACTION_TYPE_STOCK_SPLIT;
         }
         revert UnknownActionType(typeHash);
@@ -252,17 +253,5 @@ library LibCorporateAction {
         if (s.nodes.length == 0) revert NoActionsScheduled();
         if (s.tail == 0) return s.nodes[0];
         return s.nodes[s.tail];
-    }
-
-    /// @notice Return the 1-based index of the head node, or 0 if the list is empty.
-    /// @return The head index. 0 means "no head" (empty list).
-    function head() internal view returns (uint256) {
-        return getStorage().head;
-    }
-
-    /// @notice Return the 1-based index of the tail node, or 0 if the list is empty.
-    /// @return The tail index. 0 means "no tail" (empty list).
-    function tail() internal view returns (uint256) {
-        return getStorage().tail;
     }
 }

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -4,6 +4,13 @@ pragma solidity =0.8.25;
 
 import {CorporateActionNode, CompletionFilter, LibCorporateActionNode} from "./LibCorporateActionNode.sol";
 import {LibStockSplit} from "./LibStockSplit.sol";
+import {
+    EffectiveTimeInPast,
+    ActionAlreadyComplete,
+    ActionDoesNotExist,
+    UnknownActionType,
+    NoActionsScheduled
+} from "../error/ErrCorporateAction.sol";
 
 /// @dev ERC-7201 namespaced storage location for corporate actions.
 /// keccak256(abi.encode(uint256(keccak256("rain.storage.corporate-action.1")) - 1)) & ~bytes32(uint256(0xff))
@@ -20,22 +27,6 @@ bytes32 constant STOCK_SPLIT_TYPE_HASH = keccak256("st0x.corporate-actions.stock
 
 /// @dev Bitmap action type for stock splits (forward and reverse).
 uint256 constant ACTION_TYPE_STOCK_SPLIT = 1 << 0;
-
-/// Thrown when scheduling an action with an effective time in the past.
-error EffectiveTimeInPast(uint64 effectiveTime, uint256 currentTime);
-
-/// Thrown when trying to cancel an action whose effectiveTime has passed.
-error ActionAlreadyComplete(uint256 actionIndex);
-
-/// Thrown when referencing an action that does not exist.
-error ActionDoesNotExist(uint256 actionIndex);
-
-/// Thrown when the external type hash has no known bitmap mapping.
-/// @param typeHash The unrecognised external identifier.
-error UnknownActionType(bytes32 typeHash);
-
-/// Thrown when accessing head/tail on a list with no scheduled actions.
-error NoActionsScheduled();
 
 /// @title LibCorporateAction
 /// @notice Library for corporate action diamond storage. Uses ERC-7201

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -76,7 +76,7 @@ library LibCorporateAction {
     /// @param typeHash External identifier, e.g. keccak256("st0x.corporate-actions.stock-split").
     /// @param parameters ABI-encoded parameters for the action type.
     /// @return actionType The internal bitmap for this type.
-    function resolveActionType(bytes32 typeHash, bytes memory parameters) internal returns (uint256 actionType) {
+    function resolveActionType(bytes32 typeHash, bytes calldata parameters) internal returns (uint256 actionType) {
         if (typeHash == STOCK_SPLIT_TYPE_HASH) {
             LibStockSplit.validateParameters(parameters);
             return ACTION_TYPE_STOCK_SPLIT;

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -76,7 +76,7 @@ library LibCorporateAction {
     /// @param typeHash External identifier, e.g. keccak256("st0x.corporate-actions.stock-split").
     /// @param parameters ABI-encoded parameters for the action type.
     /// @return actionType The internal bitmap for this type.
-    function resolveActionType(bytes32 typeHash, bytes memory parameters) internal pure returns (uint256 actionType) {
+    function resolveActionType(bytes32 typeHash, bytes memory parameters) internal returns (uint256 actionType) {
         if (typeHash == STOCK_SPLIT_TYPE_HASH) {
             LibStockSplit.validateParameters(parameters);
             return ACTION_TYPE_STOCK_SPLIT;

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -3,6 +3,7 @@
 pragma solidity =0.8.25;
 
 import {CorporateActionNode, CompletionFilter, LibCorporateActionNode} from "./LibCorporateActionNode.sol";
+import {LibStockSplit} from "./LibStockSplit.sol";
 
 /// @dev ERC-7201 namespaced storage location for corporate actions.
 /// keccak256(abi.encode(uint256(keccak256("rain.storage.corporate-action.1")) - 1)) & ~bytes32(uint256(0xff))
@@ -13,6 +14,12 @@ bytes32 constant SCHEDULE_CORPORATE_ACTION = keccak256("SCHEDULE_CORPORATE_ACTIO
 
 /// @dev Permission hash for cancelling a corporate action via the authorizer.
 bytes32 constant CANCEL_CORPORATE_ACTION = keccak256("CANCEL_CORPORATE_ACTION");
+
+/// @dev External identifier for stock splits.
+bytes32 constant STOCK_SPLIT_TYPE_HASH = keccak256("StockSplit");
+
+/// @dev Bitmap action type for stock splits (forward and reverse).
+uint256 constant ACTION_TYPE_STOCK_SPLIT = 1 << 0;
 
 /// Thrown when scheduling an action with an effective time in the past.
 error EffectiveTimeInPast(uint64 effectiveTime, uint256 currentTime);
@@ -72,13 +79,18 @@ library LibCorporateAction {
 
     /// @notice Map an external type identifier to its internal bitmap and
     /// validate parameters. Reverts if the type hash is not recognised.
-    /// Subsequent PRs add concrete type mappings.
     /// @param typeHash External identifier, e.g. keccak256("StockSplit").
     /// @param parameters ABI-encoded parameters for the action type.
     /// @return actionType The internal bitmap for this type.
-    function resolveActionType(bytes32 typeHash, bytes memory parameters) internal pure returns (uint256 actionType) {
-        // Concrete types are added by subsequent PRs.
-        (actionType, parameters);
+    function resolveActionType(bytes32 typeHash, bytes memory parameters)
+        internal
+        pure
+        returns (uint256 actionType)
+    {
+        if (typeHash == STOCK_SPLIT_TYPE_HASH) {
+            LibStockSplit.validateParameters(parameters);
+            return ACTION_TYPE_STOCK_SPLIT;
+        }
         revert UnknownActionType(typeHash);
     }
 

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -16,7 +16,7 @@ bytes32 constant SCHEDULE_CORPORATE_ACTION = keccak256("SCHEDULE_CORPORATE_ACTIO
 bytes32 constant CANCEL_CORPORATE_ACTION = keccak256("CANCEL_CORPORATE_ACTION");
 
 /// @dev External identifier for stock splits.
-bytes32 constant STOCK_SPLIT_TYPE_HASH = keccak256("StockSplit");
+bytes32 constant STOCK_SPLIT_TYPE_HASH = keccak256("st0x.corporate-actions.stock-split");
 
 /// @dev Bitmap action type for stock splits (forward and reverse).
 uint256 constant ACTION_TYPE_STOCK_SPLIT = 1 << 0;
@@ -82,7 +82,7 @@ library LibCorporateAction {
 
     /// @notice Map an external type identifier to its internal bitmap and
     /// validate parameters. Reverts if the type hash is not recognised.
-    /// @param typeHash External identifier, e.g. keccak256("StockSplit").
+    /// @param typeHash External identifier, e.g. keccak256("st0x.corporate-actions.stock-split").
     /// @param parameters ABI-encoded parameters for the action type.
     /// @return actionType The internal bitmap for this type.
     function resolveActionType(bytes32 typeHash, bytes memory parameters) internal pure returns (uint256 actionType) {

--- a/src/lib/LibCorporateActionNode.sol
+++ b/src/lib/LibCorporateActionNode.sol
@@ -25,13 +25,21 @@ struct CorporateActionNode {
     bytes parameters;
 }
 
-/// @dev Filter for traversal based on completion status.
-/// - ALL: return any matching node regardless of completion.
-/// - COMPLETED: return only nodes with effectiveTime <= block.timestamp.
-///   Since the list is time-ordered and completed nodes are contiguous at
-///   the front, forward walks stop early at the first pending node.
-/// - PENDING: return only nodes with effectiveTime > block.timestamp.
-///   Forward walks skip completed nodes at the front.
+/// @dev Filter for traversal based on completion status. The list is
+/// time-ordered ascending: completed nodes (effectiveTime <= now) are
+/// contiguous at the front (head side), pending nodes contiguous at the
+/// back (tail side).
+///
+/// - ALL: return any matching node regardless of completion. No early break.
+/// - COMPLETED: return only nodes with `effectiveTime <= block.timestamp`.
+///   Forward walks stop early at the first pending node (optimization). A
+///   backward walk returns the first completed match it finds while walking
+///   back from the tail through the pending section; no early break is
+///   beneficial on the backward direction.
+/// - PENDING: return only nodes with `effectiveTime > block.timestamp`.
+///   A forward walk skips completed nodes at the front before returning the
+///   first pending match (no early break). A backward walk stops early at
+///   the first completed node it encounters (optimization).
 enum CompletionFilter {
     ALL,
     COMPLETED,

--- a/src/lib/LibCorporateActionNode.sol
+++ b/src/lib/LibCorporateActionNode.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 import {LibCorporateAction} from "./LibCorporateAction.sol";
 

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -55,13 +55,19 @@ library LibStockSplit {
     /// @param parameters ABI-encoded Float.
     function validateParameters(bytes memory parameters) internal pure {
         Float multiplier = abi.decode(parameters, (Float));
+        // Only the coefficient is needed for the sign check; the exponent is
+        // irrelevant because a negative/zero coefficient is rejected regardless.
+        //slither-disable-next-line unused-return
         (int256 coefficient,) = LibDecimalFloat.unpack(multiplier);
         if (coefficient <= 0) revert InvalidSplitMultiplier();
 
         // Apply `multiplier` to 1e18 and truncate to uint256. Used for both
         // the floor and the ceiling check. The `int256(1e18)` cast is safe
         // because `1e18` is a compile-time constant far below `2^255`.
+        // The second return value is the loss flag; we only need the truncated
+        // value for bounds comparison.
         // forge-lint: disable-next-line(unsafe-typecast)
+        //slither-disable-next-line unused-return
         (uint256 applied,) = LibDecimalFloat.toFixedDecimalLossy(
             LibDecimalFloat.mul(LibDecimalFloat.packLossless(int256(1e18), 0), multiplier), 0
         );

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -4,26 +4,61 @@ pragma solidity =0.8.25;
 
 import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
 
-/// Thrown when a stock split multiplier is invalid (zero or negative).
+/// @notice Thrown when a stock split multiplier has a zero or negative coefficient.
 error InvalidSplitMultiplier();
+
+/// @notice Thrown when a stock split multiplier is too small to preserve any
+/// meaningful balance. Specifically, a multiplier that, when applied to 1e18
+/// (a reasonable "meaningful minimum" balance for an 18-decimal token), rounds
+/// to zero is rejected. Without this floor, an authorized scheduler could
+/// schedule a near-zero multiplier (e.g. `packLossless(1, -30)`) that wipes
+/// every holder's balance to 0 at the effective time.
+/// @param multiplier The offending multiplier.
+error MultiplierTooSmall(Float multiplier);
+
+/// @notice Thrown when a stock split multiplier is large enough to risk
+/// overflow when applied sequentially to realistic supplies. The bound is
+/// `trunc(1e18 * multiplier) <= 1e36`, corresponding to a 1e18x growth
+/// factor — far beyond any plausible real-world corporate action.
+/// @param multiplier The offending multiplier.
+error MultiplierTooLarge(Float multiplier);
 
 /// @title LibStockSplit
 /// @notice Validation and encoding for stock split parameters.
 library LibStockSplit {
-    /// @notice Validate that encoded parameters contain a valid stock split
-    /// multiplier. The multiplier must be a positive non-zero Rain float.
+    /// @notice Validate that encoded parameters contain a usable stock split
+    /// multiplier.
+    ///
+    /// Rules:
+    /// 1. The unpacked `coefficient` must be strictly positive — rejects
+    ///    zero and negative coefficients (`InvalidSplitMultiplier`).
+    /// 2. `trunc(1e18 * multiplier)` must be at least `1` — rejects
+    ///    near-zero multipliers that would truncate every realistic balance
+    ///    to zero on the first rebase pass (`MultiplierTooSmall`).
+    /// 3. `trunc(1e18 * multiplier)` must be at most `1e36` — rejects
+    ///    near-saturation multipliers that would risk overflow when applied
+    ///    sequentially to realistic supplies (`MultiplierTooLarge`).
+    ///
+    /// The bounds are deliberately conservative. The largest historical real
+    /// stock split was roughly 1000x (= 1e3), well inside the ceiling, and
+    /// the smallest realistic reverse split would be around 1/1000 (= 1e-3),
+    /// well above the floor. An authorized scheduler that wants to apply a
+    /// multiplier outside these bounds is almost certainly misconfigured.
+    ///
     /// @param parameters ABI-encoded Float.
     function validateParameters(bytes memory parameters) internal pure {
         Float multiplier = abi.decode(parameters, (Float));
         (int256 coefficient,) = LibDecimalFloat.unpack(multiplier);
         if (coefficient <= 0) revert InvalidSplitMultiplier();
-    }
 
-    /// @notice Encode a stock split multiplier as parameters bytes.
-    /// @param multiplier The Rain float multiplier.
-    /// @return parameters ABI-encoded Float.
-    function encodeParameters(Float multiplier) internal pure returns (bytes memory) {
-        return abi.encode(multiplier);
+        // Apply `multiplier` to 1e18 and truncate to uint256. Used for both
+        // the floor and the ceiling check.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        (uint256 applied,) = LibDecimalFloat.toFixedDecimalLossy(
+            LibDecimalFloat.mul(LibDecimalFloat.packLossless(int256(1e18), 0), multiplier), 0
+        );
+        if (applied == 0) revert MultiplierTooSmall(multiplier);
+        if (applied > 1e36) revert MultiplierTooLarge(multiplier);
     }
 
     /// @notice Decode a stock split multiplier from parameters bytes.

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
 import {LibTOFUTokenDecimals} from "rain.tofu.erc20-decimals/lib/LibTOFUTokenDecimals.sol";

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -7,12 +7,11 @@ import {LibTOFUTokenDecimals} from "rain.tofu.erc20-decimals/lib/LibTOFUTokenDec
 import {InvalidSplitMultiplier, MultiplierTooSmall, MultiplierTooLarge} from "../error/ErrStockSplit.sol";
 
 /// @title LibStockSplit
-/// @notice Validation and encoding for stock split parameters.
+/// @notice Validation for stock split multipliers.
 library LibStockSplit {
-    /// @notice Validate that encoded parameters contain a usable stock split
-    /// multiplier. Reads the vault's decimals via the TOFU singleton to scale
-    /// the bounds per-token. Under delegatecall from the vault, `address(this)`
-    /// resolves to the vault.
+    /// @notice Validate a stock split multiplier. Reads the vault's decimals
+    /// via the TOFU singleton to scale the bounds per-token. Under delegatecall
+    /// from the vault, `address(this)` resolves to the vault.
     ///
     /// Rules:
     /// 1. Multiplier must be strictly positive — rejects zero and negative
@@ -31,10 +30,8 @@ library LibStockSplit {
     /// the smallest realistic reverse split would be around 1/1000 (= 1e-3),
     /// well above the floor.
     ///
-    /// @param parameters ABI-encoded Float.
-    function validateParameters(bytes calldata parameters) internal {
-        Float multiplier = abi.decode(parameters, (Float));
-
+    /// @param multiplier The stock split multiplier as a Float.
+    function validateMultiplier(Float multiplier) internal {
         // Reject zero and negative multipliers.
         if (LibDecimalFloat.lte(multiplier, LibDecimalFloat.FLOAT_ZERO)) {
             revert InvalidSplitMultiplier();
@@ -55,17 +52,5 @@ library LibStockSplit {
         // applied sequentially.
         Float ceiling = LibDecimalFloat.fromFixedDecimalLosslessPacked(10 ** decimals, 0);
         if (LibDecimalFloat.gt(multiplier, ceiling)) revert MultiplierTooLarge(multiplier);
-    }
-
-    /// @notice Decode a stock split multiplier from parameters bytes.
-    /// @dev Performs no bounds checking. Callers must only invoke on
-    /// parameters that have been validated via `validateParameters` (which
-    /// `resolveActionType` guarantees at schedule time). Decoding orphaned or
-    /// pre-validation parameters is unsafe if called outside schedule-time
-    /// code paths.
-    /// @param parameters ABI-encoded Float.
-    /// @return multiplier The Rain float multiplier.
-    function decodeParameters(bytes memory parameters) internal pure returns (Float) {
-        return abi.decode(parameters, (Float));
     }
 }

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -45,6 +45,13 @@ library LibStockSplit {
     /// well above the floor. An authorized scheduler that wants to apply a
     /// multiplier outside these bounds is almost certainly misconfigured.
     ///
+    /// @dev Pathologically large multipliers (e.g. `packLossless(1, 100)`) may
+    /// saturate or revert inside `LibDecimalFloat.mul` / `toFixedDecimalLossy`
+    /// before reaching the `applied > 1e36` branch. In that case the
+    /// user-visible error is the float library's revert, not
+    /// `MultiplierTooLarge`. This is acceptable — the scheduler is authorized
+    /// and such inputs indicate misconfiguration either way.
+    ///
     /// @param parameters ABI-encoded Float.
     function validateParameters(bytes memory parameters) internal pure {
         Float multiplier = abi.decode(parameters, (Float));
@@ -63,6 +70,11 @@ library LibStockSplit {
     }
 
     /// @notice Decode a stock split multiplier from parameters bytes.
+    /// @dev Performs no bounds checking. Callers must only invoke on
+    /// parameters that have been validated via `validateParameters` (which
+    /// `resolveActionType` guarantees at schedule time). Decoding orphaned or
+    /// pre-validation parameters is unsafe if called outside schedule-time
+    /// code paths.
     /// @param parameters ABI-encoded Float.
     /// @return multiplier The Rain float multiplier.
     function decodeParameters(bytes memory parameters) internal pure returns (Float) {

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -3,25 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
-
-/// @notice Thrown when a stock split multiplier has a zero or negative coefficient.
-error InvalidSplitMultiplier();
-
-/// @notice Thrown when a stock split multiplier is too small to preserve any
-/// meaningful balance. Specifically, a multiplier that, when applied to 1e18
-/// (a reasonable "meaningful minimum" balance for an 18-decimal token), rounds
-/// to zero is rejected. Without this floor, an authorized scheduler could
-/// schedule a near-zero multiplier (e.g. `packLossless(1, -30)`) that wipes
-/// every holder's balance to 0 at the effective time.
-/// @param multiplier The offending multiplier.
-error MultiplierTooSmall(Float multiplier);
-
-/// @notice Thrown when a stock split multiplier is large enough to risk
-/// overflow when applied sequentially to realistic supplies. The bound is
-/// `trunc(1e18 * multiplier) <= 1e36`, corresponding to a 1e18x growth
-/// factor — far beyond any plausible real-world corporate action.
-/// @param multiplier The offending multiplier.
-error MultiplierTooLarge(Float multiplier);
+import {InvalidSplitMultiplier, MultiplierTooSmall, MultiplierTooLarge} from "../error/ErrStockSplit.sol";
 
 /// @title LibStockSplit
 /// @notice Validation and encoding for stock split parameters.

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -32,7 +32,7 @@ library LibStockSplit {
     /// well above the floor.
     ///
     /// @param parameters ABI-encoded Float.
-    function validateParameters(bytes memory parameters) internal {
+    function validateParameters(bytes calldata parameters) internal {
         Float multiplier = abi.decode(parameters, (Float));
 
         // Reject zero and negative multipliers.

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
+
+/// Thrown when a stock split multiplier is invalid (zero or negative).
+error InvalidSplitMultiplier();
+
+/// @title LibStockSplit
+/// @notice Validation and encoding for stock split parameters.
+library LibStockSplit {
+    /// @notice Validate that encoded parameters contain a valid stock split
+    /// multiplier. The multiplier must be a positive non-zero Rain float.
+    /// @param parameters ABI-encoded Float.
+    function validateParameters(bytes memory parameters) internal pure {
+        Float multiplier = abi.decode(parameters, (Float));
+        (int256 coefficient,) = LibDecimalFloat.unpack(multiplier);
+        if (coefficient <= 0) revert InvalidSplitMultiplier();
+    }
+
+    /// @notice Encode a stock split multiplier as parameters bytes.
+    /// @param multiplier The Rain float multiplier.
+    /// @return parameters ABI-encoded Float.
+    function encodeParameters(Float multiplier) internal pure returns (bytes memory) {
+        return abi.encode(multiplier);
+    }
+
+    /// @notice Decode a stock split multiplier from parameters bytes.
+    /// @param parameters ABI-encoded Float.
+    /// @return multiplier The Rain float multiplier.
+    function decodeParameters(bytes memory parameters) internal pure returns (Float) {
+        return abi.decode(parameters, (Float));
+    }
+}

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -52,7 +52,8 @@ library LibStockSplit {
         if (coefficient <= 0) revert InvalidSplitMultiplier();
 
         // Apply `multiplier` to 1e18 and truncate to uint256. Used for both
-        // the floor and the ceiling check.
+        // the floor and the ceiling check. The `int256(1e18)` cast is safe
+        // because `1e18` is a compile-time constant far below `2^255`.
         // forge-lint: disable-next-line(unsafe-typecast)
         (uint256 applied,) = LibDecimalFloat.toFixedDecimalLossy(
             LibDecimalFloat.mul(LibDecimalFloat.packLossless(int256(1e18), 0), multiplier), 0

--- a/src/lib/LibStockSplit.sol
+++ b/src/lib/LibStockSplit.sol
@@ -3,58 +3,58 @@
 pragma solidity =0.8.25;
 
 import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
+import {LibTOFUTokenDecimals} from "rain.tofu.erc20-decimals/lib/LibTOFUTokenDecimals.sol";
 import {InvalidSplitMultiplier, MultiplierTooSmall, MultiplierTooLarge} from "../error/ErrStockSplit.sol";
 
 /// @title LibStockSplit
 /// @notice Validation and encoding for stock split parameters.
 library LibStockSplit {
     /// @notice Validate that encoded parameters contain a usable stock split
-    /// multiplier.
+    /// multiplier. Reads the vault's decimals via the TOFU singleton to scale
+    /// the bounds per-token. Under delegatecall from the vault, `address(this)`
+    /// resolves to the vault.
     ///
     /// Rules:
-    /// 1. The unpacked `coefficient` must be strictly positive — rejects
-    ///    zero and negative coefficients (`InvalidSplitMultiplier`).
-    /// 2. `trunc(1e18 * multiplier)` must be at least `1` — rejects
-    ///    near-zero multipliers that would truncate every realistic balance
-    ///    to zero on the first rebase pass (`MultiplierTooSmall`).
-    /// 3. `trunc(1e18 * multiplier)` must be at most `1e36` — rejects
-    ///    near-saturation multipliers that would risk overflow when applied
-    ///    sequentially to realistic supplies (`MultiplierTooLarge`).
+    /// 1. Multiplier must be strictly positive — rejects zero and negative
+    ///    values (`InvalidSplitMultiplier`).
+    /// 2. Multiplier must be at least the value of 1 smallest-unit in Float
+    ///    terms (`fromFixedDecimal(1, decimals)` = `10^(-decimals)`) — rejects
+    ///    multipliers that would truncate a 1-wei balance to zero on the
+    ///    first rebase pass (`MultiplierTooSmall`).
+    /// 3. Multiplier must be at most the value of 1 whole token represented
+    ///    as a raw smallest-unit count (`fromFixedDecimal(10^decimals, 0)`) —
+    ///    rejects near-saturation multipliers that risk overflow on
+    ///    sequential application (`MultiplierTooLarge`).
     ///
     /// The bounds are deliberately conservative. The largest historical real
     /// stock split was roughly 1000x (= 1e3), well inside the ceiling, and
     /// the smallest realistic reverse split would be around 1/1000 (= 1e-3),
-    /// well above the floor. An authorized scheduler that wants to apply a
-    /// multiplier outside these bounds is almost certainly misconfigured.
-    ///
-    /// @dev Pathologically large multipliers (e.g. `packLossless(1, 100)`) may
-    /// saturate or revert inside `LibDecimalFloat.mul` / `toFixedDecimalLossy`
-    /// before reaching the `applied > 1e36` branch. In that case the
-    /// user-visible error is the float library's revert, not
-    /// `MultiplierTooLarge`. This is acceptable — the scheduler is authorized
-    /// and such inputs indicate misconfiguration either way.
+    /// well above the floor.
     ///
     /// @param parameters ABI-encoded Float.
-    function validateParameters(bytes memory parameters) internal pure {
+    function validateParameters(bytes memory parameters) internal {
         Float multiplier = abi.decode(parameters, (Float));
-        // Only the coefficient is needed for the sign check; the exponent is
-        // irrelevant because a negative/zero coefficient is rejected regardless.
-        //slither-disable-next-line unused-return
-        (int256 coefficient,) = LibDecimalFloat.unpack(multiplier);
-        if (coefficient <= 0) revert InvalidSplitMultiplier();
 
-        // Apply `multiplier` to 1e18 and truncate to uint256. Used for both
-        // the floor and the ceiling check. The `int256(1e18)` cast is safe
-        // because `1e18` is a compile-time constant far below `2^255`.
-        // The second return value is the loss flag; we only need the truncated
-        // value for bounds comparison.
-        // forge-lint: disable-next-line(unsafe-typecast)
-        //slither-disable-next-line unused-return
-        (uint256 applied,) = LibDecimalFloat.toFixedDecimalLossy(
-            LibDecimalFloat.mul(LibDecimalFloat.packLossless(int256(1e18), 0), multiplier), 0
-        );
-        if (applied == 0) revert MultiplierTooSmall(multiplier);
-        if (applied > 1e36) revert MultiplierTooLarge(multiplier);
+        // Reject zero and negative multipliers.
+        if (LibDecimalFloat.lte(multiplier, LibDecimalFloat.FLOAT_ZERO)) {
+            revert InvalidSplitMultiplier();
+        }
+
+        // TOFU the vault's decimals — snapshot on first call, verify
+        // consistency on subsequent calls. `address(this)` is the vault
+        // under delegatecall.
+        uint8 decimals = LibTOFUTokenDecimals.safeDecimalsForToken(address(this));
+
+        // Floor: one smallest-unit balance in Float terms. Below this, a
+        // 1-wei balance truncates to zero on rebase.
+        Float floor = LibDecimalFloat.fromFixedDecimalLosslessPacked(1, decimals);
+        if (LibDecimalFloat.lt(multiplier, floor)) revert MultiplierTooSmall(multiplier);
+
+        // Ceiling: a 1-whole-token balance's raw smallest-unit count in
+        // Float terms (i.e. 10^decimals). Above this risks overflow when
+        // applied sequentially.
+        Float ceiling = LibDecimalFloat.fromFixedDecimalLosslessPacked(10 ** decimals, 0);
+        if (LibDecimalFloat.gt(multiplier, ceiling)) revert MultiplierTooLarge(multiplier);
     }
 
     /// @notice Decode a stock split multiplier from parameters bytes.

--- a/test/concrete/DecimalsMock.sol
+++ b/test/concrete/DecimalsMock.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @title DecimalsMock
+/// @notice Base test contract that exposes a constructor-configurable
+/// `decimals()` so test harnesses can stand in for ERC20-ish callers when
+/// the code under test reads decimals via `address(this)`.
+abstract contract DecimalsMock {
+    uint8 internal immutable _DECIMALS;
+
+    constructor(uint8 decimals_) {
+        _DECIMALS = decimals_;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _DECIMALS;
+    }
+}

--- a/test/concrete/StockSplitHarness.sol
+++ b/test/concrete/StockSplitHarness.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {LibCorporateAction} from "../../src/lib/LibCorporateAction.sol";
+import {CorporateActionNode, CompletionFilter, LibCorporateActionNode} from "../../src/lib/LibCorporateActionNode.sol";
+import {DecimalsMock} from "./DecimalsMock.sol";
+
+/// @title StockSplitHarness
+/// @notice Test harness exposing `LibCorporateAction` and
+/// `LibCorporateActionNode` internals as external functions. Implements
+/// `decimals()` so the TOFU singleton has something to read when
+/// `validateParameters` is called on the harness's own context.
+contract StockSplitHarness is DecimalsMock {
+    constructor(uint8 decimals_) DecimalsMock(decimals_) {}
+
+    function resolveAndSchedule(bytes32 typeHash, uint64 effectiveTime, bytes calldata parameters)
+        external
+        returns (uint256)
+    {
+        uint256 actionType = LibCorporateAction.resolveActionType(typeHash, parameters);
+        return LibCorporateAction.schedule(actionType, effectiveTime, parameters);
+    }
+
+    function resolveActionType(bytes32 typeHash, bytes calldata parameters) external returns (uint256) {
+        return LibCorporateAction.resolveActionType(typeHash, parameters);
+    }
+
+    function nextOfType(uint256 cursor, uint256 mask, CompletionFilter filter) external view returns (uint256) {
+        return LibCorporateActionNode.nextOfType(cursor, mask, filter);
+    }
+
+    function countCompleted() external view returns (uint256) {
+        return LibCorporateAction.countCompleted();
+    }
+
+    function getNode(uint256 actionIndex) external view returns (CorporateActionNode memory) {
+        return LibCorporateAction.getStorage().nodes[actionIndex];
+    }
+}

--- a/test/concrete/StockSplitValidationHarness.sol
+++ b/test/concrete/StockSplitValidationHarness.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Float} from "rain.math.float/lib/LibDecimalFloat.sol";
+import {LibStockSplit} from "../../src/lib/LibStockSplit.sol";
+import {DecimalsMock} from "./DecimalsMock.sol";
+
+/// @title StockSplitValidationHarness
+/// @notice Test harness exposing `LibStockSplit.validateMultiplier` as an
+/// external function. Implements `decimals()` so the TOFU singleton has
+/// something to read when validation resolves `address(this)` decimals.
+contract StockSplitValidationHarness is DecimalsMock {
+    constructor(uint8 decimals_) DecimalsMock(decimals_) {}
+
+    function validate(Float multiplier) external {
+        LibStockSplit.validateMultiplier(multiplier);
+    }
+}

--- a/test/lib/LibTestCorporateAction.sol
+++ b/test/lib/LibTestCorporateAction.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {LibCorporateAction} from "../../src/lib/LibCorporateAction.sol";
+
+/// @title LibTestCorporateAction
+/// @notice Test-only helpers for reading the 1-based head/tail indices of
+/// the corporate action linked list. Production code walks the list via
+/// `LibCorporateActionNode.nextOfType` / `prevOfType` starting from 0, so it
+/// never needs raw index access. Tests inspect these directly to verify
+/// link ordering after insertion and cancellation.
+library LibTestCorporateAction {
+    /// @notice The 1-based index of the head node, or 0 if the list is empty.
+    function head() internal view returns (uint256) {
+        return LibCorporateAction.getStorage().head;
+    }
+
+    /// @notice The 1-based index of the tail node, or 0 if the list is empty.
+    function tail() internal view returns (uint256) {
+        return LibCorporateAction.getStorage().tail;
+    }
+}

--- a/test/lib/LibTestTofu.sol
+++ b/test/lib/LibTestTofu.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Vm} from "forge-std/Vm.sol";
+import {LibRainDeploy} from "rain.deploy/lib/LibRainDeploy.sol";
+import {LibTOFUTokenDecimals} from "rain.tofu.erc20-decimals/lib/LibTOFUTokenDecimals.sol";
+
+/// @title LibTestTofu
+/// @notice Test helpers for deploying the TOFU singleton in the local EVM.
+library LibTestTofu {
+    /// Etches the Zoltu factory and deploys the TOFU singleton so that
+    /// `LibTOFUTokenDecimals.safeDecimalsForToken` resolves to the real
+    /// singleton at the expected address.
+    function deployTofu(Vm vm) internal {
+        LibRainDeploy.etchZoltuFactory(vm);
+        LibRainDeploy.deployZoltu(LibTOFUTokenDecimals.TOFU_DECIMALS_EXPECTED_CREATION_CODE);
+    }
+}

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -11,13 +11,15 @@ import {
     SCHEDULE_CORPORATE_ACTION,
     CANCEL_CORPORATE_ACTION,
     STOCK_SPLIT_TYPE_HASH,
-    ACTION_TYPE_STOCK_SPLIT,
+    ACTION_TYPE_STOCK_SPLIT
+} from "../../../src/lib/LibCorporateAction.sol";
+import {
     UnknownActionType,
     NoActionsScheduled,
     EffectiveTimeInPast,
     ActionAlreadyComplete,
     ActionDoesNotExist
-} from "../../../src/lib/LibCorporateAction.sol";
+} from "../../../src/error/ErrCorporateAction.sol";
 import {IAuthorizeV1, Unauthorized} from "rain.vats/interface/IAuthorizeV1.sol";
 import {
     CorporateActionNode,
@@ -25,7 +27,7 @@ import {
     LibCorporateActionNode
 } from "../../../src/lib/LibCorporateActionNode.sol";
 import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
-import {InvalidSplitMultiplier} from "../../../src/lib/LibStockSplit.sol";
+import {InvalidSplitMultiplier} from "../../../src/error/ErrStockSplit.sol";
 
 /// @dev Mock authorizer used by the facet tests. Records the most recent
 /// `authorize` call so tests can assert the per-action context that the facet

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -25,6 +25,7 @@ import {
     LibCorporateActionNode
 } from "../../../src/lib/LibCorporateActionNode.sol";
 import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
+import {InvalidSplitMultiplier} from "../../../src/lib/LibStockSplit.sol";
 
 /// @dev Mock authorizer used by the facet tests. Records the most recent
 /// `authorize` call so tests can assert the per-action context that the facet
@@ -638,7 +639,6 @@ contract StoxCorporateActionsFacetTest is Test {
         );
     }
 
-
     /// headNode and tailNode revert on a completely fresh list where no
     /// action has ever been scheduled (nodes array has length 0).
     function testHeadNodeRevertsOnFreshList() external {
@@ -1040,5 +1040,106 @@ contract StoxCorporateActionsFacetTest is Test {
 
         vm.prank(ALICE);
         facetViaHarness.cancelCorporateAction(actionIndex);
+    }
+
+    /// Schedule returns the correct actionIndex.
+    function testScheduleViaFacetReturnsActionIndex() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory parameters = abi.encode(twoX);
+
+        vm.prank(ALICE);
+        uint256 id1 = facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 1500, parameters);
+
+        vm.prank(ALICE);
+        uint256 id2 = facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 2000, parameters);
+
+        assertEq(id1, 1);
+        assertEq(id2, 2);
+    }
+
+    /// completedActionCount reflects completed stock splits via the facet.
+    function testCompletedActionCountViaFacet() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory parameters = abi.encode(twoX);
+
+        vm.prank(ALICE);
+        facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 1500, parameters);
+
+        assertEq(facetViaHarness.completedActionCount(), 0);
+
+        vm.warp(2000);
+        assertEq(facetViaHarness.completedActionCount(), 1);
+    }
+
+    /// Schedule with invalid multiplier reverts through the facet.
+    function testScheduleInvalidMultiplierRevertsViaFacet() external {
+        Float zero = LibDecimalFloat.packLossless(0, 0);
+        bytes memory parameters = abi.encode(zero);
+
+        vm.prank(ALICE);
+        vm.expectRevert(InvalidSplitMultiplier.selector);
+        facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 1500, parameters);
+    }
+
+    /// Schedule with past effectiveTime reverts through the facet.
+    function testSchedulePastTimeRevertsViaFacet() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory parameters = abi.encode(twoX);
+
+        vm.prank(ALICE);
+        vm.expectRevert(abi.encodeWithSelector(EffectiveTimeInPast.selector, uint64(500), block.timestamp));
+        facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 500, parameters);
+    }
+
+    /// Cancel a completed action reverts through the facet.
+    function testCancelCompletedRevertsViaFacet() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory parameters = abi.encode(twoX);
+
+        vm.prank(ALICE);
+        uint256 id = facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 1500, parameters);
+
+        vm.warp(2000);
+
+        vm.prank(ALICE);
+        vm.expectRevert(abi.encodeWithSelector(ActionAlreadyComplete.selector, id));
+        facetViaHarness.cancelCorporateAction(id);
+    }
+
+    /// Cancel non-existent action reverts through the facet.
+    function testCancelNonExistentRevertsViaFacet() external {
+        vm.prank(ALICE);
+        vm.expectRevert(abi.encodeWithSelector(ActionDoesNotExist.selector, uint256(99)));
+        facetViaHarness.cancelCorporateAction(99);
+    }
+
+    /// Full lifecycle through the facet: schedule, verify pending, complete,
+    /// verify completed, cancel a second pending action.
+    function testFullLifecycleViaFacet() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        Float threeX = LibDecimalFloat.packLossless(3, 0);
+
+        vm.prank(ALICE);
+        uint256 id1 = facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 1500, abi.encode(twoX));
+
+        vm.prank(ALICE);
+        uint256 id2 = facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 3000, abi.encode(threeX));
+
+        assertEq(facetViaHarness.completedActionCount(), 0);
+
+        vm.warp(2000);
+        assertEq(facetViaHarness.completedActionCount(), 1);
+
+        vm.prank(ALICE);
+        facetViaHarness.cancelCorporateAction(id2);
+
+        assertEq(facetViaHarness.completedActionCount(), 1);
+
+        vm.warp(4000);
+        // Still 1 — cancelled action doesn't complete.
+        assertEq(facetViaHarness.completedActionCount(), 1);
+
+        assertEq(id1, 1);
+        assertEq(id2, 2);
     }
 }

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -9,6 +9,8 @@ import {
     CORPORATE_ACTION_STORAGE_LOCATION,
     SCHEDULE_CORPORATE_ACTION,
     CANCEL_CORPORATE_ACTION,
+    STOCK_SPLIT_TYPE_HASH,
+    ACTION_TYPE_STOCK_SPLIT,
     UnknownActionType,
     EffectiveTimeInPast,
     ActionAlreadyComplete,
@@ -20,6 +22,7 @@ import {
     CompletionFilter,
     LibCorporateActionNode
 } from "../../../src/lib/LibCorporateActionNode.sol";
+import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
 
 /// @dev Mock authorizer used by the facet tests. Records the most recent
 /// `authorize` call so tests can assert the per-action context that the facet
@@ -633,6 +636,7 @@ contract StoxCorporateActionsFacetTest is Test {
         );
     }
 
+
     /// headNode and tailNode revert on a completely fresh list where no
     /// action has ever been scheduled (nodes array has length 0).
     function testHeadNodeRevertsOnFreshList() external {
@@ -1001,5 +1005,38 @@ contract StoxCorporateActionsFacetTest is Test {
         assertEq(n2.actionType, 2, "harness2 has type 2");
         assertEq(n1.parameters, hex"AA");
         assertEq(n2.parameters, hex"BB");
+    }
+
+    /// Audit P2-4: `scheduleCorporateAction` emits `CorporateActionScheduled`
+    /// with the right indexed sender, indexed actionIndex, action type, and
+    /// effective time. Asserts the public event API consumed by offchain
+    /// indexers.
+    function testScheduleCorporateActionEmitsEvent() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory parameters = abi.encode(twoX);
+        uint64 effectiveTime = 1500;
+
+        vm.expectEmit(true, true, false, true, address(facetViaHarness));
+        emit StoxCorporateActionsFacet.CorporateActionScheduled(ALICE, 1, ACTION_TYPE_STOCK_SPLIT, effectiveTime);
+
+        vm.prank(ALICE);
+        uint256 actionIndex = facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, effectiveTime, parameters);
+        assertEq(actionIndex, 1);
+    }
+
+    /// Audit P2-4: `cancelCorporateAction` emits `CorporateActionCancelled`
+    /// with the right indexed sender and indexed actionIndex.
+    function testCancelCorporateActionEmitsEvent() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory parameters = abi.encode(twoX);
+
+        vm.prank(ALICE);
+        uint256 actionIndex = facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 1500, parameters);
+
+        vm.expectEmit(true, true, false, false, address(facetViaHarness));
+        emit StoxCorporateActionsFacet.CorporateActionCancelled(ALICE, actionIndex);
+
+        vm.prank(ALICE);
+        facetViaHarness.cancelCorporateAction(actionIndex);
     }
 }

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std/Test.sol";
 import {StoxCorporateActionsFacet} from "../../../src/concrete/StoxCorporateActionsFacet.sol";
+import {ICorporateActionsV1} from "../../../src/interface/ICorporateActionsV1.sol";
 import {
     LibCorporateAction,
     CORPORATE_ACTION_STORAGE_LOCATION,
@@ -1017,7 +1018,7 @@ contract StoxCorporateActionsFacetTest is Test {
         uint64 effectiveTime = 1500;
 
         vm.expectEmit(true, true, false, true, address(facetViaHarness));
-        emit StoxCorporateActionsFacet.CorporateActionScheduled(ALICE, 1, ACTION_TYPE_STOCK_SPLIT, effectiveTime);
+        emit ICorporateActionsV1.CorporateActionScheduled(ALICE, 1, ACTION_TYPE_STOCK_SPLIT, effectiveTime);
 
         vm.prank(ALICE);
         uint256 actionIndex = facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, effectiveTime, parameters);
@@ -1034,7 +1035,7 @@ contract StoxCorporateActionsFacetTest is Test {
         uint256 actionIndex = facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 1500, parameters);
 
         vm.expectEmit(true, true, false, false, address(facetViaHarness));
-        emit StoxCorporateActionsFacet.CorporateActionCancelled(ALICE, actionIndex);
+        emit ICorporateActionsV1.CorporateActionCancelled(ALICE, actionIndex);
 
         vm.prank(ALICE);
         facetViaHarness.cancelCorporateAction(actionIndex);

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -28,6 +28,7 @@ import {
 } from "../../../src/lib/LibCorporateActionNode.sol";
 import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
 import {InvalidSplitMultiplier} from "../../../src/error/ErrStockSplit.sol";
+import {LibTestTofu} from "../../lib/LibTestTofu.sol";
 
 /// @dev Mock authorizer used by the facet tests. Records the most recent
 /// `authorize` call so tests can assert the per-action context that the facet
@@ -62,6 +63,7 @@ contract MockAuthorizer is IAuthorizeV1 {
 contract DelegatecallHarness {
     address public immutable FACET;
     IAuthorizeV1 public authorizer;
+    uint8 public constant decimals = 18;
 
     constructor(address facet_) {
         FACET = facet_;
@@ -88,7 +90,9 @@ contract DelegatecallHarness {
 
 /// @dev Harness to test library functions directly.
 contract CorporateActionHarness {
-    function resolveActionType(bytes32 typeHash, bytes memory parameters) external pure returns (uint256) {
+    uint8 public constant decimals = 18;
+
+    function resolveActionType(bytes32 typeHash, bytes memory parameters) external returns (uint256) {
         return LibCorporateAction.resolveActionType(typeHash, parameters);
     }
 
@@ -143,6 +147,7 @@ contract StoxCorporateActionsFacetTest is Test {
     address internal constant ALICE = address(0xA11CE);
 
     function setUp() public {
+        LibTestTofu.deployTofu(vm);
         facetImpl = new StoxCorporateActionsFacet();
         harness = new DelegatecallHarness(address(facetImpl));
         facetViaHarness = StoxCorporateActionsFacet(address(harness));

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -29,6 +29,7 @@ import {
 import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
 import {InvalidSplitMultiplier} from "../../../src/error/ErrStockSplit.sol";
 import {LibTestTofu} from "../../lib/LibTestTofu.sol";
+import {LibTestCorporateAction} from "../../lib/LibTestCorporateAction.sol";
 
 /// @dev Mock authorizer used by the facet tests. Records the most recent
 /// `authorize` call so tests can assert the per-action context that the facet
@@ -121,11 +122,11 @@ contract CorporateActionHarness {
     }
 
     function head() external view returns (uint256) {
-        return LibCorporateAction.head();
+        return LibTestCorporateAction.head();
     }
 
     function tail() external view returns (uint256) {
-        return LibCorporateAction.tail();
+        return LibTestCorporateAction.tail();
     }
 
     function headNode() external view returns (CorporateActionNode memory) {

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -285,7 +285,7 @@ contract StoxCorporateActionsFacetTest is Test {
     /// authorizer lookup, so the order of checks matches the modifier.
     function testScheduleCorporateActionDirectCallReverts() external {
         vm.expectRevert(StoxCorporateActionsFacet.FacetMustBeDelegatecalled.selector);
-        facetImpl.scheduleCorporateAction(keccak256("StockSplit"), uint64(block.timestamp + 1), hex"");
+        facetImpl.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, uint64(block.timestamp + 1), hex"");
     }
 
     /// Direct call to `cancelCorporateAction` on the standalone facet reverts

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -92,7 +92,7 @@ contract DelegatecallHarness {
 contract CorporateActionHarness {
     uint8 public constant decimals = 18;
 
-    function resolveActionType(bytes32 typeHash, bytes memory parameters) external returns (uint256) {
+    function resolveActionType(bytes32 typeHash, bytes calldata parameters) external returns (uint256) {
         return LibCorporateAction.resolveActionType(typeHash, parameters);
     }
 

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -1042,6 +1042,62 @@ contract StoxCorporateActionsFacetTest is Test {
         facetViaHarness.cancelCorporateAction(actionIndex);
     }
 
+    /// Authorizer receives the correct context for a real stock split schedule.
+    function testScheduleStockSplitForwardsCorrectContext() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory parameters = abi.encode(twoX);
+        uint64 effectiveTime = 1500;
+
+        vm.expectCall(
+            address(mockAuthorizer),
+            abi.encodeWithSelector(
+                IAuthorizeV1.authorize.selector,
+                ALICE,
+                SCHEDULE_CORPORATE_ACTION,
+                abi.encode(STOCK_SPLIT_TYPE_HASH, effectiveTime, parameters)
+            )
+        );
+
+        vm.prank(ALICE);
+        facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, effectiveTime, parameters);
+
+        assertEq(mockAuthorizer.lastUser(), ALICE);
+        assertEq(mockAuthorizer.lastPermission(), SCHEDULE_CORPORATE_ACTION);
+    }
+
+    /// Authorizer denial with valid stock split params still reverts.
+    function testScheduleStockSplitAuthorizerDenied() external {
+        mockAuthorizer.setDenyMode(true);
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory parameters = abi.encode(twoX);
+
+        vm.prank(ALICE);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Unauthorized.selector,
+                ALICE,
+                SCHEDULE_CORPORATE_ACTION,
+                abi.encode(STOCK_SPLIT_TYPE_HASH, uint64(1500), parameters)
+            )
+        );
+        facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, 1500, parameters);
+    }
+
+    /// Fuzz: schedule random valid stock splits, actionIndex is sequential.
+    function testFuzzScheduleStockSplitsSequentialIndex(uint8 count) external {
+        count = uint8(bound(count, 1, 15));
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory parameters = abi.encode(twoX);
+
+        for (uint256 i = 0; i < count; i++) {
+            vm.prank(ALICE);
+            // forge-lint: disable-next-line(unsafe-typecast)
+            uint256 id =
+                facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_TYPE_HASH, uint64(1001 + i * 100), parameters);
+            assertEq(id, i + 1, "actionIndex must be sequential");
+        }
+    }
+
     /// Schedule returns the correct actionIndex.
     function testScheduleViaFacetReturnsActionIndex() external {
         Float twoX = LibDecimalFloat.packLossless(2, 0);

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -17,8 +17,23 @@ import {
 } from "../../../src/lib/LibCorporateActionNode.sol";
 import {LibStockSplit} from "../../../src/lib/LibStockSplit.sol";
 import {InvalidSplitMultiplier, MultiplierTooSmall, MultiplierTooLarge} from "../../../src/error/ErrStockSplit.sol";
+import {LibTestTofu} from "../../lib/LibTestTofu.sol";
 
-contract StockSplitHarness {
+abstract contract DecimalsMock {
+    uint8 internal immutable _DECIMALS;
+
+    constructor(uint8 decimals_) {
+        _DECIMALS = decimals_;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _DECIMALS;
+    }
+}
+
+contract StockSplitHarness is DecimalsMock {
+    constructor(uint8 decimals_) DecimalsMock(decimals_) {}
+
     function resolveAndSchedule(bytes32 typeHash, uint64 effectiveTime, bytes memory parameters)
         external
         returns (uint256)
@@ -27,7 +42,7 @@ contract StockSplitHarness {
         return LibCorporateAction.schedule(actionType, effectiveTime, parameters);
     }
 
-    function resolveActionType(bytes32 typeHash, bytes memory parameters) external pure returns (uint256) {
+    function resolveActionType(bytes32 typeHash, bytes memory parameters) external returns (uint256) {
         return LibCorporateAction.resolveActionType(typeHash, parameters);
     }
 
@@ -44,8 +59,10 @@ contract StockSplitHarness {
     }
 }
 
-contract ValidationHarness {
-    function validate(bytes memory parameters) external pure {
+contract ValidationHarness is DecimalsMock {
+    constructor(uint8 decimals_) DecimalsMock(decimals_) {}
+
+    function validate(bytes memory parameters) external {
         LibStockSplit.validateParameters(parameters);
     }
 }
@@ -54,11 +71,12 @@ contract LibStockSplitValidationTest is Test {
     ValidationHarness internal v;
 
     function setUp() public {
-        v = new ValidationHarness();
+        LibTestTofu.deployTofu(vm);
+        v = new ValidationHarness(18);
     }
 
     /// Valid multiplier passes validation.
-    function testValidMultiplier() external view {
+    function testValidMultiplier() external {
         Float twoX = LibDecimalFloat.packLossless(2, 0);
         v.validate(abi.encode(twoX));
     }
@@ -95,7 +113,7 @@ contract LibStockSplitValidationTest is Test {
 
     /// Audit P1-1 / P2-2: the exact floor boundary, `1e-18`, must pass.
     /// `trunc(1e18 * 1e-18) == 1`.
-    function testFloorBoundaryMultiplierPasses() external view {
+    function testFloorBoundaryMultiplierPasses() external {
         Float boundary = LibDecimalFloat.packLossless(1, -18);
         v.validate(abi.encode(boundary));
     }
@@ -109,13 +127,13 @@ contract LibStockSplitValidationTest is Test {
     }
 
     /// Audit P1-1 / P2-2: a large-but-realistic 1000x split must pass.
-    function testLargeButRealisticSplitPasses() external view {
+    function testLargeButRealisticSplitPasses() external {
         Float thousandX = LibDecimalFloat.packLossless(1000, 0);
         v.validate(abi.encode(thousandX));
     }
 
     /// Fractional multiplier (1/3 reverse split) is valid.
-    function testFractionalMultiplierValid() external view {
+    function testFractionalMultiplierValid() external {
         Float oneThird = LibDecimalFloat.div(LibDecimalFloat.packLossless(1, 0), LibDecimalFloat.packLossless(3, 0));
         v.validate(abi.encode(oneThird));
     }
@@ -129,7 +147,7 @@ contract LibStockSplitValidationTest is Test {
     }
 
     /// Exact ceiling boundary: 1e18 multiplier gives trunc(1e18 * 1e18) = 1e36.
-    function testExactCeilingBoundaryPasses() external view {
+    function testExactCeilingBoundaryPasses() external {
         Float ceiling = LibDecimalFloat.packLossless(1, 18);
         v.validate(abi.encode(ceiling));
     }
@@ -150,7 +168,7 @@ contract LibStockSplitValidationTest is Test {
     }
 
     /// Fuzz: any positive multiplier within bounds passes validation.
-    function testFuzzValidMultiplier(uint64 coeff, int8 exp) external view {
+    function testFuzzValidMultiplier(uint64 coeff, int8 exp) external {
         vm.assume(coeff > 0);
         exp = int8(bound(exp, -17, 17));
         // forge-lint: disable-next-line(unsafe-typecast)
@@ -204,11 +222,12 @@ contract LibStockSplitResolveTest is Test {
     StockSplitHarness internal h;
 
     function setUp() public {
-        h = new StockSplitHarness();
+        LibTestTofu.deployTofu(vm);
+        h = new StockSplitHarness(18);
     }
 
     /// STOCK_SPLIT_TYPE_HASH resolves to ACTION_TYPE_STOCK_SPLIT.
-    function testResolveStockSplit() external view {
+    function testResolveStockSplit() external {
         Float twoX = LibDecimalFloat.packLossless(2, 0);
         uint256 bitmap = h.resolveActionType(STOCK_SPLIT_TYPE_HASH, abi.encode(twoX));
         assertEq(bitmap, ACTION_TYPE_STOCK_SPLIT);
@@ -233,7 +252,8 @@ contract LibStockSplitLifecycleTest is Test {
     StockSplitHarness internal h;
 
     function setUp() public {
-        h = new StockSplitHarness();
+        LibTestTofu.deployTofu(vm);
+        h = new StockSplitHarness(18);
         vm.warp(1000);
     }
 

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -34,8 +34,8 @@ contract StockSplitHarness {
         return LibCorporateAction.countCompleted();
     }
 
-    function getNode(uint256 actionRef) external view returns (CorporateActionNode memory) {
-        return LibCorporateAction.getStorage().nodes[actionRef];
+    function getNode(uint256 actionIndex) external view returns (CorporateActionNode memory) {
+        return LibCorporateAction.getStorage().nodes[actionIndex];
     }
 }
 

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -10,7 +10,7 @@ import {
     STOCK_SPLIT_TYPE_HASH,
     UnknownActionType
 } from "src/lib/LibCorporateAction.sol";
-import {CorporateActionNode, LibCorporateActionNode} from "src/lib/LibCorporateActionNode.sol";
+import {CorporateActionNode, CompletionFilter, LibCorporateActionNode} from "src/lib/LibCorporateActionNode.sol";
 import {LibStockSplit, InvalidSplitMultiplier} from "src/lib/LibStockSplit.sol";
 
 contract StockSplitHarness {
@@ -26,8 +26,8 @@ contract StockSplitHarness {
         return LibCorporateAction.resolveActionType(typeHash, parameters);
     }
 
-    function nextCompletedOfType(uint256 cursor, uint256 mask) external view returns (uint256) {
-        return LibCorporateActionNode.nextCompletedOfType(cursor, mask);
+    function nextOfType(uint256 cursor, uint256 mask, CompletionFilter filter) external view returns (uint256) {
+        return LibCorporateActionNode.nextOfType(cursor, mask, filter);
     }
 
     function countCompleted() external view returns (uint256) {
@@ -127,7 +127,7 @@ contract LibStockSplitLifecycleTest is Test {
         vm.warp(2000);
         assertEq(h.countCompleted(), 1);
 
-        uint256 completed = h.nextCompletedOfType(0, ACTION_TYPE_STOCK_SPLIT);
+        uint256 completed = h.nextOfType(0, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.COMPLETED);
         assertEq(completed, 1);
 
         CorporateActionNode memory node = h.getNode(1);

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -34,7 +34,7 @@ abstract contract DecimalsMock {
 contract StockSplitHarness is DecimalsMock {
     constructor(uint8 decimals_) DecimalsMock(decimals_) {}
 
-    function resolveAndSchedule(bytes32 typeHash, uint64 effectiveTime, bytes memory parameters)
+    function resolveAndSchedule(bytes32 typeHash, uint64 effectiveTime, bytes calldata parameters)
         external
         returns (uint256)
     {
@@ -42,7 +42,7 @@ contract StockSplitHarness is DecimalsMock {
         return LibCorporateAction.schedule(actionType, effectiveTime, parameters);
     }
 
-    function resolveActionType(bytes32 typeHash, bytes memory parameters) external returns (uint256) {
+    function resolveActionType(bytes32 typeHash, bytes calldata parameters) external returns (uint256) {
         return LibCorporateAction.resolveActionType(typeHash, parameters);
     }
 
@@ -62,7 +62,7 @@ contract StockSplitHarness is DecimalsMock {
 contract ValidationHarness is DecimalsMock {
     constructor(uint8 decimals_) DecimalsMock(decimals_) {}
 
-    function validate(bytes memory parameters) external {
+    function validate(bytes calldata parameters) external {
         LibStockSplit.validateParameters(parameters);
     }
 }

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -164,6 +164,35 @@ contract LibStockSplitValidationTest is Test {
         assertEq(ACTION_TYPE_STOCK_SPLIT, 1);
         assertEq(STOCK_SPLIT_TYPE_HASH, keccak256("StockSplit"));
     }
+
+    /// ACTION_TYPE_STOCK_SPLIT has exactly one bit set.
+    function testActionTypeSingleBit() external pure {
+        assertEq(ACTION_TYPE_STOCK_SPLIT & (ACTION_TYPE_STOCK_SPLIT - 1), 0);
+        assertTrue(ACTION_TYPE_STOCK_SPLIT != 0);
+    }
+
+    /// Fuzz: encode/decode roundtrip preserves arbitrary valid multipliers.
+    function testFuzzDecodeRoundtrip(uint64 coeff, int8 exp) external pure {
+        vm.assume(coeff > 0);
+        exp = int8(bound(exp, -17, 17));
+        // forge-lint: disable-next-line(unsafe-typecast)
+        Float multiplier = LibDecimalFloat.packLossless(int256(uint256(coeff)), int256(exp));
+        bytes memory encoded = abi.encode(multiplier);
+        Float decoded = LibStockSplit.decodeParameters(encoded);
+        assertEq(Float.unwrap(decoded), Float.unwrap(multiplier));
+    }
+
+    /// Fuzz: multipliers below floor always revert.
+    function testFuzzBelowFloorReverts(uint8 coeff, int16 exp) external {
+        vm.assume(coeff > 0);
+        // Bound exponent low enough that even coeff=255 produces below-floor.
+        // 255e-21 * 1e18 = 255e-3 = 0.255 → trunc = 0.
+        exp = int16(bound(exp, -100, -21));
+        // forge-lint: disable-next-line(unsafe-typecast)
+        Float multiplier = LibDecimalFloat.packLossless(int256(uint256(coeff)), int256(exp));
+        vm.expectRevert();
+        v.validate(abi.encode(multiplier));
+    }
 }
 
 contract LibStockSplitResolveTest is Test {
@@ -248,5 +277,35 @@ contract LibStockSplitLifecycleTest is Test {
 
         // ALL returns all three.
         assertEq(h.countCompleted(), 2);
+    }
+
+    /// Stored node has correct actionType bitmap and decodable parameters
+    /// after scheduling through resolveAndSchedule.
+    function testStoredNodeDataAfterSchedule() external {
+        Float fiveX = LibDecimalFloat.packLossless(5, 0);
+        uint256 id = h.resolveAndSchedule(STOCK_SPLIT_TYPE_HASH, 1500, abi.encode(fiveX));
+
+        CorporateActionNode memory node = h.getNode(id);
+        assertEq(node.actionType, ACTION_TYPE_STOCK_SPLIT, "bitmap is stock split");
+        assertEq(node.effectiveTime, 1500, "effectiveTime stored");
+
+        Float stored = LibStockSplit.decodeParameters(node.parameters);
+        assertEq(Float.unwrap(stored), Float.unwrap(fiveX), "multiplier round-trips");
+    }
+
+    /// Two stock splits with different multipliers store independently.
+    function testTwoSplitsDifferentMultipliersStoreIndependently() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        Float oneThird = LibDecimalFloat.div(LibDecimalFloat.packLossless(1, 0), LibDecimalFloat.packLossless(3, 0));
+
+        uint256 id1 = h.resolveAndSchedule(STOCK_SPLIT_TYPE_HASH, 1500, abi.encode(twoX));
+        uint256 id2 = h.resolveAndSchedule(STOCK_SPLIT_TYPE_HASH, 2000, abi.encode(oneThird));
+
+        Float stored1 = LibStockSplit.decodeParameters(h.getNode(id1).parameters);
+        Float stored2 = LibStockSplit.decodeParameters(h.getNode(id2).parameters);
+
+        assertEq(Float.unwrap(stored1), Float.unwrap(twoX));
+        assertEq(Float.unwrap(stored2), Float.unwrap(oneThird));
+        assertTrue(Float.unwrap(stored1) != Float.unwrap(stored2), "different multipliers stored");
     }
 }

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -26,8 +26,9 @@ contract StockSplitHarness {
         return LibCorporateAction.resolveActionType(typeHash, parameters);
     }
 
-    function firstCompletedOfType(uint256 mask) external view returns (uint256) {
-        return LibCorporateAction.firstCompletedOfType(mask).index;
+    function nextCompletedOfType(uint256 cursor, uint256 mask) external view returns (uint256) {
+        LibCorporateAction.CorporateActionStorage storage s = LibCorporateAction.getStorage();
+        return LibCorporateAction.nextCompletedOfType(s.nodes[cursor], mask).index;
     }
 
     function countCompleted() external view returns (uint256) {
@@ -127,7 +128,7 @@ contract LibStockSplitLifecycleTest is Test {
         vm.warp(2000);
         assertEq(h.countCompleted(), 1);
 
-        uint256 completed = h.firstCompletedOfType(ACTION_TYPE_STOCK_SPLIT);
+        uint256 completed = h.nextCompletedOfType(0, ACTION_TYPE_STOCK_SPLIT);
         assertEq(completed, 1);
 
         CorporateActionNode memory node = h.getNode(1);

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -6,11 +6,11 @@ import {Test} from "forge-std/Test.sol";
 import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
 import {
     LibCorporateAction,
-    CorporateActionNode,
     ACTION_TYPE_STOCK_SPLIT,
     STOCK_SPLIT_TYPE_HASH,
     UnknownActionType
 } from "src/lib/LibCorporateAction.sol";
+import {CorporateActionNode, LibCorporateActionNode} from "src/lib/LibCorporateActionNode.sol";
 import {LibStockSplit, InvalidSplitMultiplier} from "src/lib/LibStockSplit.sol";
 
 contract StockSplitHarness {
@@ -28,7 +28,7 @@ contract StockSplitHarness {
 
     function nextCompletedOfType(uint256 cursor, uint256 mask) external view returns (uint256) {
         LibCorporateAction.CorporateActionStorage storage s = LibCorporateAction.getStorage();
-        return LibCorporateAction.nextCompletedOfType(s.nodes[cursor], mask).index;
+        return LibCorporateActionNode.nextCompletedOfType(s.nodes[cursor], mask).index;
     }
 
     function countCompleted() external view returns (uint256) {

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -26,8 +26,8 @@ contract StockSplitHarness {
         return LibCorporateAction.resolveActionType(typeHash, parameters);
     }
 
-    function nextCompletedOfType(uint256 cursor, uint256 mask) external view returns (uint256) {
-        return LibCorporateAction.nextCompletedOfType(cursor, mask);
+    function firstCompletedOfType(uint256 mask) external view returns (uint256) {
+        return LibCorporateAction.firstCompletedOfType(mask).index;
     }
 
     function countCompleted() external view returns (uint256) {
@@ -127,7 +127,7 @@ contract LibStockSplitLifecycleTest is Test {
         vm.warp(2000);
         assertEq(h.countCompleted(), 1);
 
-        uint256 completed = h.nextCompletedOfType(0, ACTION_TYPE_STOCK_SPLIT);
+        uint256 completed = h.firstCompletedOfType(ACTION_TYPE_STOCK_SPLIT);
         assertEq(completed, 1);
 
         CorporateActionNode memory node = h.getNode(1);

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -26,9 +26,8 @@ contract StockSplitHarness {
         return LibCorporateAction.resolveActionType(typeHash, parameters);
     }
 
-    function nextCompletedOfType(uint256 cursor, uint256 mask) external view returns (uint256) {
-        LibCorporateAction.CorporateActionStorage storage s = LibCorporateAction.getStorage();
-        return LibCorporateActionNode.nextCompletedOfType(s.nodes[cursor], mask).index;
+    function nextOfType(uint256 cursor, uint256 mask, bool completed) external view returns (uint256) {
+        return LibCorporateActionNode.nextOfType(cursor, mask, completed);
     }
 
     function countCompleted() external view returns (uint256) {
@@ -128,7 +127,7 @@ contract LibStockSplitLifecycleTest is Test {
         vm.warp(2000);
         assertEq(h.countCompleted(), 1);
 
-        uint256 completed = h.nextCompletedOfType(0, ACTION_TYPE_STOCK_SPLIT);
+        uint256 completed = h.nextOfType(0, ACTION_TYPE_STOCK_SPLIT, true);
         assertEq(completed, 1);
 
         CorporateActionNode memory node = h.getNode(1);

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -34,8 +34,8 @@ contract StockSplitHarness {
         return LibCorporateAction.countCompleted();
     }
 
-    function getNode(uint256 actionId) external view returns (CorporateActionNode memory) {
-        return LibCorporateAction.getStorage().nodes[actionId];
+    function getNode(uint256 actionRef) external view returns (CorporateActionNode memory) {
+        return LibCorporateAction.getStorage().nodes[actionRef];
     }
 }
 

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -9,9 +9,18 @@ import {
     ACTION_TYPE_STOCK_SPLIT,
     STOCK_SPLIT_TYPE_HASH,
     UnknownActionType
-} from "src/lib/LibCorporateAction.sol";
-import {CorporateActionNode, CompletionFilter, LibCorporateActionNode} from "src/lib/LibCorporateActionNode.sol";
-import {LibStockSplit, InvalidSplitMultiplier, MultiplierTooSmall, MultiplierTooLarge} from "src/lib/LibStockSplit.sol";
+} from "../../../src/lib/LibCorporateAction.sol";
+import {
+    CorporateActionNode,
+    CompletionFilter,
+    LibCorporateActionNode
+} from "../../../src/lib/LibCorporateActionNode.sol";
+import {
+    LibStockSplit,
+    InvalidSplitMultiplier,
+    MultiplierTooSmall,
+    MultiplierTooLarge
+} from "../../../src/lib/LibStockSplit.sol";
 
 contract StockSplitHarness {
     function resolveAndSchedule(bytes32 typeHash, uint64 effectiveTime, bytes memory parameters)
@@ -190,7 +199,7 @@ contract LibStockSplitValidationTest is Test {
         exp = int16(bound(exp, -100, -21));
         // forge-lint: disable-next-line(unsafe-typecast)
         Float multiplier = LibDecimalFloat.packLossless(int256(uint256(coeff)), int256(exp));
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, multiplier));
         v.validate(abi.encode(multiplier));
     }
 }
@@ -275,7 +284,15 @@ contract LibStockSplitLifecycleTest is Test {
         assertEq(p1, id3);
         assertEq(h.nextOfType(p1, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.PENDING), 0);
 
-        // ALL returns all three.
+        // ALL walks all three in time order.
+        uint256 a1 = h.nextOfType(0, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.ALL);
+        assertEq(a1, id1);
+        uint256 a2 = h.nextOfType(a1, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.ALL);
+        assertEq(a2, id2);
+        uint256 a3 = h.nextOfType(a2, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.ALL);
+        assertEq(a3, id3);
+        assertEq(h.nextOfType(a3, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.ALL), 0);
+
         assertEq(h.countCompleted(), 2);
     }
 

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -18,54 +18,8 @@ import {
 import {LibStockSplit} from "../../../src/lib/LibStockSplit.sol";
 import {InvalidSplitMultiplier, MultiplierTooSmall, MultiplierTooLarge} from "../../../src/error/ErrStockSplit.sol";
 import {LibTestTofu} from "../../lib/LibTestTofu.sol";
-
-abstract contract DecimalsMock {
-    uint8 internal immutable _DECIMALS;
-
-    constructor(uint8 decimals_) {
-        _DECIMALS = decimals_;
-    }
-
-    function decimals() external view returns (uint8) {
-        return _DECIMALS;
-    }
-}
-
-contract StockSplitHarness is DecimalsMock {
-    constructor(uint8 decimals_) DecimalsMock(decimals_) {}
-
-    function resolveAndSchedule(bytes32 typeHash, uint64 effectiveTime, bytes calldata parameters)
-        external
-        returns (uint256)
-    {
-        uint256 actionType = LibCorporateAction.resolveActionType(typeHash, parameters);
-        return LibCorporateAction.schedule(actionType, effectiveTime, parameters);
-    }
-
-    function resolveActionType(bytes32 typeHash, bytes calldata parameters) external returns (uint256) {
-        return LibCorporateAction.resolveActionType(typeHash, parameters);
-    }
-
-    function nextOfType(uint256 cursor, uint256 mask, CompletionFilter filter) external view returns (uint256) {
-        return LibCorporateActionNode.nextOfType(cursor, mask, filter);
-    }
-
-    function countCompleted() external view returns (uint256) {
-        return LibCorporateAction.countCompleted();
-    }
-
-    function getNode(uint256 actionIndex) external view returns (CorporateActionNode memory) {
-        return LibCorporateAction.getStorage().nodes[actionIndex];
-    }
-}
-
-contract ValidationHarness is DecimalsMock {
-    constructor(uint8 decimals_) DecimalsMock(decimals_) {}
-
-    function validate(bytes calldata parameters) external {
-        LibStockSplit.validateParameters(parameters);
-    }
-}
+import {StockSplitHarness} from "../../concrete/StockSplitHarness.sol";
+import {StockSplitValidationHarness as ValidationHarness} from "../../concrete/StockSplitValidationHarness.sol";
 
 contract LibStockSplitValidationTest is Test {
     ValidationHarness internal v;
@@ -78,14 +32,14 @@ contract LibStockSplitValidationTest is Test {
     /// Valid multiplier passes validation.
     function testValidMultiplier() external {
         Float twoX = LibDecimalFloat.packLossless(2, 0);
-        v.validate(abi.encode(twoX));
+        v.validate(twoX);
     }
 
     /// Zero multiplier reverts — covers the `coefficient == 0` branch.
     function testZeroMultiplierReverts() external {
         Float zero = LibDecimalFloat.packLossless(0, 0);
         vm.expectRevert(InvalidSplitMultiplier.selector);
-        v.validate(abi.encode(zero));
+        v.validate(zero);
     }
 
     /// Audit P2-1: negative coefficient reverts — covers the `coefficient < 0`
@@ -93,14 +47,14 @@ contract LibStockSplitValidationTest is Test {
     function testNegativeCoefficientMultiplierReverts() external {
         Float negative = LibDecimalFloat.packLossless(-2, 0);
         vm.expectRevert(InvalidSplitMultiplier.selector);
-        v.validate(abi.encode(negative));
+        v.validate(negative);
     }
 
     /// Audit P2-1: negative coefficient with non-zero exponent also reverts.
     function testNegativeCoefficientWithExponentReverts() external {
         Float negative = LibDecimalFloat.packLossless(-1, 18);
         vm.expectRevert(InvalidSplitMultiplier.selector);
-        v.validate(abi.encode(negative));
+        v.validate(negative);
     }
 
     /// Audit P1-1 / P2-2: near-zero multiplier (`1e-30`) must revert.
@@ -108,14 +62,14 @@ contract LibStockSplitValidationTest is Test {
     function testNearZeroMultiplierReverts() external {
         Float tooSmall = LibDecimalFloat.packLossless(1, -30);
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, tooSmall));
-        v.validate(abi.encode(tooSmall));
+        v.validate(tooSmall);
     }
 
     /// Audit P1-1 / P2-2: the exact floor boundary, `1e-18`, must pass.
     /// `trunc(1e18 * 1e-18) == 1`.
     function testFloorBoundaryMultiplierPasses() external {
         Float boundary = LibDecimalFloat.packLossless(1, -18);
-        v.validate(abi.encode(boundary));
+        v.validate(boundary);
     }
 
     /// Audit P1-1 / P2-2: near-saturation multiplier (`1e30`) must revert.
@@ -123,33 +77,33 @@ contract LibStockSplitValidationTest is Test {
     function testNearSaturationMultiplierReverts() external {
         Float tooLarge = LibDecimalFloat.packLossless(1, 30);
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooLarge.selector, tooLarge));
-        v.validate(abi.encode(tooLarge));
+        v.validate(tooLarge);
     }
 
     /// Audit P1-1 / P2-2: a large-but-realistic 1000x split must pass.
     function testLargeButRealisticSplitPasses() external {
         Float thousandX = LibDecimalFloat.packLossless(1000, 0);
-        v.validate(abi.encode(thousandX));
+        v.validate(thousandX);
     }
 
     /// Fractional multiplier (1/3 reverse split) is valid.
     function testFractionalMultiplierValid() external {
         Float oneThird = LibDecimalFloat.div(LibDecimalFloat.packLossless(1, 0), LibDecimalFloat.packLossless(3, 0));
-        v.validate(abi.encode(oneThird));
+        v.validate(oneThird);
     }
 
     /// Decode-after-abi.encode roundtrip preserves the multiplier.
     function testEncodeDecodeRoundtrip() external pure {
         Float threeX = LibDecimalFloat.packLossless(3, 0);
         bytes memory encoded = abi.encode(threeX);
-        Float decoded = LibStockSplit.decodeParameters(encoded);
+        Float decoded = abi.decode(encoded, (Float));
         assertEq(Float.unwrap(decoded), Float.unwrap(threeX));
     }
 
     /// Exact ceiling boundary: 1e18 multiplier gives trunc(1e18 * 1e18) = 1e36.
     function testExactCeilingBoundaryPasses() external {
         Float ceiling = LibDecimalFloat.packLossless(1, 18);
-        v.validate(abi.encode(ceiling));
+        v.validate(ceiling);
     }
 
     /// Just above ceiling: 1e18 + epsilon must revert.
@@ -157,14 +111,14 @@ contract LibStockSplitValidationTest is Test {
         // 1.000001e18 → trunc(1e18 * 1.000001e18) > 1e36
         Float aboveCeiling = LibDecimalFloat.packLossless(1000001, 12);
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooLarge.selector, aboveCeiling));
-        v.validate(abi.encode(aboveCeiling));
+        v.validate(aboveCeiling);
     }
 
     /// Just below floor: 9e-19 must revert (trunc(1e18 * 9e-19) = 0).
     function testBelowFloorReverts() external {
         Float belowFloor = LibDecimalFloat.packLossless(9, -19);
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, belowFloor));
-        v.validate(abi.encode(belowFloor));
+        v.validate(belowFloor);
     }
 
     /// Fuzz: any positive multiplier within bounds passes validation.
@@ -179,7 +133,7 @@ contract LibStockSplitValidationTest is Test {
             LibDecimalFloat.mul(LibDecimalFloat.packLossless(int256(1e18), 0), multiplier), 0
         );
         vm.assume(applied >= 1 && applied <= 1e36);
-        v.validate(abi.encode(multiplier));
+        v.validate(multiplier);
     }
 
     /// Constants have expected values.
@@ -201,7 +155,7 @@ contract LibStockSplitValidationTest is Test {
         // forge-lint: disable-next-line(unsafe-typecast)
         Float multiplier = LibDecimalFloat.packLossless(int256(uint256(coeff)), int256(exp));
         bytes memory encoded = abi.encode(multiplier);
-        Float decoded = LibStockSplit.decodeParameters(encoded);
+        Float decoded = abi.decode(encoded, (Float));
         assertEq(Float.unwrap(decoded), Float.unwrap(multiplier));
     }
 
@@ -214,7 +168,7 @@ contract LibStockSplitValidationTest is Test {
         // forge-lint: disable-next-line(unsafe-typecast)
         Float multiplier = LibDecimalFloat.packLossless(int256(uint256(coeff)), int256(exp));
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, multiplier));
-        v.validate(abi.encode(multiplier));
+        v.validate(multiplier);
     }
 }
 
@@ -231,27 +185,27 @@ contract LibStockSplitValidation6DecimalsTest is Test {
     /// Floor for 6 decimals: 1e-6 passes.
     function testFloorBoundaryPasses() external {
         Float boundary = LibDecimalFloat.packLossless(1, -6);
-        v.validate(abi.encode(boundary));
+        v.validate(boundary);
     }
 
     /// Below floor for 6 decimals: 1e-7 reverts.
     function testBelowFloorReverts() external {
         Float tooSmall = LibDecimalFloat.packLossless(1, -7);
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, tooSmall));
-        v.validate(abi.encode(tooSmall));
+        v.validate(tooSmall);
     }
 
     /// Ceiling for 6 decimals: 1e6 passes.
     function testCeilingBoundaryPasses() external {
         Float ceiling = LibDecimalFloat.packLossless(1, 6);
-        v.validate(abi.encode(ceiling));
+        v.validate(ceiling);
     }
 
     /// Above ceiling for 6 decimals: 1e7 reverts.
     function testAboveCeilingReverts() external {
         Float tooLarge = LibDecimalFloat.packLossless(1, 7);
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooLarge.selector, tooLarge));
-        v.validate(abi.encode(tooLarge));
+        v.validate(tooLarge);
     }
 
     /// A multiplier that would pass for 18-decimals (1e-18) must revert for
@@ -259,13 +213,13 @@ contract LibStockSplitValidation6DecimalsTest is Test {
     function testEighteenDecimalFloorRejectedForSixDecimals() external {
         Float eighteenFloor = LibDecimalFloat.packLossless(1, -18);
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, eighteenFloor));
-        v.validate(abi.encode(eighteenFloor));
+        v.validate(eighteenFloor);
     }
 
     /// A realistic 2x split still passes for 6-decimal tokens.
     function testRealisticSplitPasses() external {
         Float twoX = LibDecimalFloat.packLossless(2, 0);
-        v.validate(abi.encode(twoX));
+        v.validate(twoX);
     }
 }
 
@@ -286,12 +240,12 @@ contract LibStockSplitValidationFuzzDecimalsTest is Test {
 
         // Floor boundary passes.
         Float floor = LibDecimalFloat.packLossless(1, -decimalsSigned);
-        v.validate(abi.encode(floor));
+        v.validate(floor);
 
         // Just below floor reverts.
         Float belowFloor = LibDecimalFloat.packLossless(1, -(decimalsSigned + 1));
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, belowFloor));
-        v.validate(abi.encode(belowFloor));
+        v.validate(belowFloor);
     }
 
     /// For any decimals in a realistic range, the ceiling boundary
@@ -305,12 +259,12 @@ contract LibStockSplitValidationFuzzDecimalsTest is Test {
 
         // Ceiling boundary passes.
         Float ceiling = LibDecimalFloat.packLossless(1, decimalsSigned);
-        v.validate(abi.encode(ceiling));
+        v.validate(ceiling);
 
         // Just above ceiling reverts.
         Float aboveCeiling = LibDecimalFloat.packLossless(1, decimalsSigned + 1);
         vm.expectRevert(abi.encodeWithSelector(MultiplierTooLarge.selector, aboveCeiling));
-        v.validate(abi.encode(aboveCeiling));
+        v.validate(aboveCeiling);
     }
 
     /// A realistic multiplier (2x) passes for any realistic decimals value.
@@ -319,7 +273,7 @@ contract LibStockSplitValidationFuzzDecimalsTest is Test {
         ValidationHarness v = new ValidationHarness(decimals);
 
         Float twoX = LibDecimalFloat.packLossless(2, 0);
-        v.validate(abi.encode(twoX));
+        v.validate(twoX);
     }
 }
 
@@ -376,7 +330,7 @@ contract LibStockSplitLifecycleTest is Test {
         assertEq(completed, 1);
 
         CorporateActionNode memory node = h.getNode(1);
-        Float stored = LibStockSplit.decodeParameters(node.parameters);
+        Float stored = abi.decode(node.parameters, (Float));
         assertEq(Float.unwrap(stored), Float.unwrap(threeX));
     }
 
@@ -427,7 +381,7 @@ contract LibStockSplitLifecycleTest is Test {
         assertEq(node.actionType, ACTION_TYPE_STOCK_SPLIT, "bitmap is stock split");
         assertEq(node.effectiveTime, 1500, "effectiveTime stored");
 
-        Float stored = LibStockSplit.decodeParameters(node.parameters);
+        Float stored = abi.decode(node.parameters, (Float));
         assertEq(Float.unwrap(stored), Float.unwrap(fiveX), "multiplier round-trips");
     }
 
@@ -439,8 +393,8 @@ contract LibStockSplitLifecycleTest is Test {
         uint256 id1 = h.resolveAndSchedule(STOCK_SPLIT_TYPE_HASH, 1500, abi.encode(twoX));
         uint256 id2 = h.resolveAndSchedule(STOCK_SPLIT_TYPE_HASH, 2000, abi.encode(oneThird));
 
-        Float stored1 = LibStockSplit.decodeParameters(h.getNode(id1).parameters);
-        Float stored2 = LibStockSplit.decodeParameters(h.getNode(id2).parameters);
+        Float stored1 = abi.decode(h.getNode(id1).parameters, (Float));
+        Float stored2 = abi.decode(h.getNode(id2).parameters, (Float));
 
         assertEq(Float.unwrap(stored1), Float.unwrap(twoX));
         assertEq(Float.unwrap(stored2), Float.unwrap(oneThird));

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -7,20 +7,16 @@ import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
 import {
     LibCorporateAction,
     ACTION_TYPE_STOCK_SPLIT,
-    STOCK_SPLIT_TYPE_HASH,
-    UnknownActionType
+    STOCK_SPLIT_TYPE_HASH
 } from "../../../src/lib/LibCorporateAction.sol";
+import {UnknownActionType} from "../../../src/error/ErrCorporateAction.sol";
 import {
     CorporateActionNode,
     CompletionFilter,
     LibCorporateActionNode
 } from "../../../src/lib/LibCorporateActionNode.sol";
-import {
-    LibStockSplit,
-    InvalidSplitMultiplier,
-    MultiplierTooSmall,
-    MultiplierTooLarge
-} from "../../../src/lib/LibStockSplit.sol";
+import {LibStockSplit} from "../../../src/lib/LibStockSplit.sol";
+import {InvalidSplitMultiplier, MultiplierTooSmall, MultiplierTooLarge} from "../../../src/error/ErrStockSplit.sol";
 
 contract StockSplitHarness {
     function resolveAndSchedule(bytes32 typeHash, uint64 effectiveTime, bytes memory parameters)

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {Float, LibDecimalFloat} from "rain.math.float/lib/LibDecimalFloat.sol";
+import {
+    LibCorporateAction,
+    CorporateActionNode,
+    ACTION_TYPE_STOCK_SPLIT,
+    STOCK_SPLIT_TYPE_HASH,
+    UnknownActionType
+} from "src/lib/LibCorporateAction.sol";
+import {LibStockSplit, InvalidSplitMultiplier} from "src/lib/LibStockSplit.sol";
+
+contract StockSplitHarness {
+    function resolveAndSchedule(bytes32 typeHash, uint64 effectiveTime, bytes memory parameters)
+        external
+        returns (uint256)
+    {
+        uint256 actionType = LibCorporateAction.resolveActionType(typeHash, parameters);
+        return LibCorporateAction.schedule(actionType, effectiveTime, parameters);
+    }
+
+    function resolveActionType(bytes32 typeHash, bytes memory parameters) external pure returns (uint256) {
+        return LibCorporateAction.resolveActionType(typeHash, parameters);
+    }
+
+    function nextCompletedOfType(uint256 cursor, uint256 mask) external view returns (uint256) {
+        return LibCorporateAction.nextCompletedOfType(cursor, mask);
+    }
+
+    function countCompleted() external view returns (uint256) {
+        return LibCorporateAction.countCompleted();
+    }
+
+    function getNode(uint256 actionId) external view returns (CorporateActionNode memory) {
+        return LibCorporateAction.getStorage().nodes[actionId];
+    }
+}
+
+contract ValidationHarness {
+    function validate(bytes memory parameters) external pure {
+        LibStockSplit.validateParameters(parameters);
+    }
+}
+
+contract LibStockSplitValidationTest is Test {
+    ValidationHarness internal v;
+
+    function setUp() public {
+        v = new ValidationHarness();
+    }
+
+    /// Valid multiplier passes validation.
+    function testValidMultiplier() external view {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        v.validate(abi.encode(twoX));
+    }
+
+    /// Zero multiplier reverts.
+    function testZeroMultiplierReverts() external {
+        Float zero = LibDecimalFloat.packLossless(0, 0);
+        vm.expectRevert(InvalidSplitMultiplier.selector);
+        v.validate(abi.encode(zero));
+    }
+
+    /// Fractional multiplier (1/3 reverse split) is valid.
+    function testFractionalMultiplierValid() external view {
+        Float oneThird = LibDecimalFloat.div(LibDecimalFloat.packLossless(1, 0), LibDecimalFloat.packLossless(3, 0));
+        v.validate(abi.encode(oneThird));
+    }
+
+    /// Encode/decode roundtrip preserves the multiplier.
+    function testEncodeDecodeRoundtrip() external pure {
+        Float threeX = LibDecimalFloat.packLossless(3, 0);
+        bytes memory encoded = LibStockSplit.encodeParameters(threeX);
+        Float decoded = LibStockSplit.decodeParameters(encoded);
+        assertEq(Float.unwrap(decoded), Float.unwrap(threeX));
+    }
+}
+
+contract LibStockSplitResolveTest is Test {
+    StockSplitHarness internal h;
+
+    function setUp() public {
+        h = new StockSplitHarness();
+    }
+
+    /// STOCK_SPLIT_TYPE_HASH resolves to ACTION_TYPE_STOCK_SPLIT.
+    function testResolveStockSplit() external view {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        uint256 bitmap = h.resolveActionType(STOCK_SPLIT_TYPE_HASH, abi.encode(twoX));
+        assertEq(bitmap, ACTION_TYPE_STOCK_SPLIT);
+    }
+
+    /// Resolve with invalid parameters reverts during validation.
+    function testResolveStockSplitZeroMultiplierReverts() external {
+        Float zero = LibDecimalFloat.packLossless(0, 0);
+        vm.expectRevert(InvalidSplitMultiplier.selector);
+        h.resolveActionType(STOCK_SPLIT_TYPE_HASH, abi.encode(zero));
+    }
+
+    /// Unknown type hash reverts.
+    function testResolveUnknownTypeReverts() external {
+        bytes32 unknown = keccak256("Dividend");
+        vm.expectRevert(abi.encodeWithSelector(UnknownActionType.selector, unknown));
+        h.resolveActionType(unknown, "");
+    }
+}
+
+contract LibStockSplitLifecycleTest is Test {
+    StockSplitHarness internal h;
+
+    function setUp() public {
+        h = new StockSplitHarness();
+        vm.warp(1000);
+    }
+
+    /// Stock split full lifecycle: resolve, schedule, complete, walk, read multiplier.
+    function testStockSplitLifecycle() external {
+        Float threeX = LibDecimalFloat.packLossless(3, 0);
+        uint256 id = h.resolveAndSchedule(STOCK_SPLIT_TYPE_HASH, 1500, abi.encode(threeX));
+        assertEq(id, 1);
+        assertEq(h.countCompleted(), 0);
+
+        vm.warp(2000);
+        assertEq(h.countCompleted(), 1);
+
+        uint256 completed = h.nextCompletedOfType(0, ACTION_TYPE_STOCK_SPLIT);
+        assertEq(completed, 1);
+
+        CorporateActionNode memory node = h.getNode(1);
+        Float stored = LibStockSplit.decodeParameters(node.parameters);
+        assertEq(Float.unwrap(stored), Float.unwrap(threeX));
+    }
+}

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -11,7 +11,7 @@ import {
     UnknownActionType
 } from "src/lib/LibCorporateAction.sol";
 import {CorporateActionNode, CompletionFilter, LibCorporateActionNode} from "src/lib/LibCorporateActionNode.sol";
-import {LibStockSplit, InvalidSplitMultiplier} from "src/lib/LibStockSplit.sol";
+import {LibStockSplit, InvalidSplitMultiplier, MultiplierTooSmall, MultiplierTooLarge} from "src/lib/LibStockSplit.sol";
 
 contract StockSplitHarness {
     function resolveAndSchedule(bytes32 typeHash, uint64 effectiveTime, bytes memory parameters)
@@ -58,11 +58,55 @@ contract LibStockSplitValidationTest is Test {
         v.validate(abi.encode(twoX));
     }
 
-    /// Zero multiplier reverts.
+    /// Zero multiplier reverts — covers the `coefficient == 0` branch.
     function testZeroMultiplierReverts() external {
         Float zero = LibDecimalFloat.packLossless(0, 0);
         vm.expectRevert(InvalidSplitMultiplier.selector);
         v.validate(abi.encode(zero));
+    }
+
+    /// Audit P2-1: negative coefficient reverts — covers the `coefficient < 0`
+    /// branch of the `<= 0` check that `testZeroMultiplierReverts` does not hit.
+    function testNegativeCoefficientMultiplierReverts() external {
+        Float negative = LibDecimalFloat.packLossless(-2, 0);
+        vm.expectRevert(InvalidSplitMultiplier.selector);
+        v.validate(abi.encode(negative));
+    }
+
+    /// Audit P2-1: negative coefficient with non-zero exponent also reverts.
+    function testNegativeCoefficientWithExponentReverts() external {
+        Float negative = LibDecimalFloat.packLossless(-1, 18);
+        vm.expectRevert(InvalidSplitMultiplier.selector);
+        v.validate(abi.encode(negative));
+    }
+
+    /// Audit P1-1 / P2-2: near-zero multiplier (`1e-30`) must revert.
+    /// Floor check: `trunc(1e18 * 1e-30) == 0` → `MultiplierTooSmall`.
+    function testNearZeroMultiplierReverts() external {
+        Float tooSmall = LibDecimalFloat.packLossless(1, -30);
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, tooSmall));
+        v.validate(abi.encode(tooSmall));
+    }
+
+    /// Audit P1-1 / P2-2: the exact floor boundary, `1e-18`, must pass.
+    /// `trunc(1e18 * 1e-18) == 1`.
+    function testFloorBoundaryMultiplierPasses() external view {
+        Float boundary = LibDecimalFloat.packLossless(1, -18);
+        v.validate(abi.encode(boundary));
+    }
+
+    /// Audit P1-1 / P2-2: near-saturation multiplier (`1e30`) must revert.
+    /// Ceiling check: `trunc(1e18 * 1e30) == 1e48 > 1e36` → `MultiplierTooLarge`.
+    function testNearSaturationMultiplierReverts() external {
+        Float tooLarge = LibDecimalFloat.packLossless(1, 30);
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooLarge.selector, tooLarge));
+        v.validate(abi.encode(tooLarge));
+    }
+
+    /// Audit P1-1 / P2-2: a large-but-realistic 1000x split must pass.
+    function testLargeButRealisticSplitPasses() external view {
+        Float thousandX = LibDecimalFloat.packLossless(1000, 0);
+        v.validate(abi.encode(thousandX));
     }
 
     /// Fractional multiplier (1/3 reverse split) is valid.
@@ -71,10 +115,10 @@ contract LibStockSplitValidationTest is Test {
         v.validate(abi.encode(oneThird));
     }
 
-    /// Encode/decode roundtrip preserves the multiplier.
+    /// Decode-after-abi.encode roundtrip preserves the multiplier.
     function testEncodeDecodeRoundtrip() external pure {
         Float threeX = LibDecimalFloat.packLossless(3, 0);
-        bytes memory encoded = LibStockSplit.encodeParameters(threeX);
+        bytes memory encoded = abi.encode(threeX);
         Float decoded = LibStockSplit.decodeParameters(encoded);
         assertEq(Float.unwrap(decoded), Float.unwrap(threeX));
     }

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -122,6 +122,49 @@ contract LibStockSplitValidationTest is Test {
         Float decoded = LibStockSplit.decodeParameters(encoded);
         assertEq(Float.unwrap(decoded), Float.unwrap(threeX));
     }
+
+    /// Exact ceiling boundary: 1e18 multiplier gives trunc(1e18 * 1e18) = 1e36.
+    function testExactCeilingBoundaryPasses() external view {
+        Float ceiling = LibDecimalFloat.packLossless(1, 18);
+        v.validate(abi.encode(ceiling));
+    }
+
+    /// Just above ceiling: 1e18 + epsilon must revert.
+    function testAboveCeilingReverts() external {
+        // 1.000001e18 → trunc(1e18 * 1.000001e18) > 1e36
+        Float aboveCeiling = LibDecimalFloat.packLossless(1000001, 12);
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooLarge.selector, aboveCeiling));
+        v.validate(abi.encode(aboveCeiling));
+    }
+
+    /// Just below floor: 9e-19 must revert (trunc(1e18 * 9e-19) = 0).
+    function testBelowFloorReverts() external {
+        Float belowFloor = LibDecimalFloat.packLossless(9, -19);
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, belowFloor));
+        v.validate(abi.encode(belowFloor));
+    }
+
+    /// Fuzz: any positive multiplier within bounds passes validation.
+    function testFuzzValidMultiplier(uint64 coeff, int8 exp) external view {
+        vm.assume(coeff > 0);
+        exp = int8(bound(exp, -17, 17));
+        // forge-lint: disable-next-line(unsafe-typecast)
+        Float multiplier = LibDecimalFloat.packLossless(int256(uint256(coeff)), int256(exp));
+        // Compute applied value to check bounds.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        (uint256 applied,) = LibDecimalFloat.toFixedDecimalLossy(
+            LibDecimalFloat.mul(LibDecimalFloat.packLossless(int256(1e18), 0), multiplier), 0
+        );
+        vm.assume(applied >= 1 && applied <= 1e36);
+        v.validate(abi.encode(multiplier));
+    }
+
+    /// Constants have expected values.
+    function testConstantValues() external pure {
+        assertEq(ACTION_TYPE_STOCK_SPLIT, 1);
+        assertEq(STOCK_SPLIT_TYPE_HASH, keccak256("StockSplit"));
+    }
+
 }
 
 contract LibStockSplitResolveTest is Test {
@@ -177,5 +220,34 @@ contract LibStockSplitLifecycleTest is Test {
         CorporateActionNode memory node = h.getNode(1);
         Float stored = LibStockSplit.decodeParameters(node.parameters);
         assertEq(Float.unwrap(stored), Float.unwrap(threeX));
+    }
+
+    /// Multiple stock splits: schedule 3, complete 2, verify filtering.
+    function testMultipleStockSplitsFiltered() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        Float threeX = LibDecimalFloat.packLossless(3, 0);
+        Float halfX = LibDecimalFloat.div(LibDecimalFloat.packLossless(1, 0), LibDecimalFloat.packLossless(2, 0));
+
+        uint256 id1 = h.resolveAndSchedule(STOCK_SPLIT_TYPE_HASH, 1500, abi.encode(twoX));
+        uint256 id2 = h.resolveAndSchedule(STOCK_SPLIT_TYPE_HASH, 2000, abi.encode(threeX));
+        uint256 id3 = h.resolveAndSchedule(STOCK_SPLIT_TYPE_HASH, 3000, abi.encode(halfX));
+
+        // Complete first two.
+        vm.warp(2500);
+
+        // COMPLETED filter returns id1 then id2.
+        uint256 c1 = h.nextOfType(0, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.COMPLETED);
+        assertEq(c1, id1);
+        uint256 c2 = h.nextOfType(c1, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.COMPLETED);
+        assertEq(c2, id2);
+        assertEq(h.nextOfType(c2, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.COMPLETED), 0);
+
+        // PENDING filter returns only id3.
+        uint256 p1 = h.nextOfType(0, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.PENDING);
+        assertEq(p1, id3);
+        assertEq(h.nextOfType(p1, ACTION_TYPE_STOCK_SPLIT, CompletionFilter.PENDING), 0);
+
+        // ALL returns all three.
+        assertEq(h.countCompleted(), 2);
     }
 }

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -218,6 +218,111 @@ contract LibStockSplitValidationTest is Test {
     }
 }
 
+/// @dev Validation tests with a 6-decimal harness (USDC-like) to verify
+/// the bounds scale with the vault's decimals.
+contract LibStockSplitValidation6DecimalsTest is Test {
+    ValidationHarness internal v;
+
+    function setUp() public {
+        LibTestTofu.deployTofu(vm);
+        v = new ValidationHarness(6);
+    }
+
+    /// Floor for 6 decimals: 1e-6 passes.
+    function testFloorBoundaryPasses() external {
+        Float boundary = LibDecimalFloat.packLossless(1, -6);
+        v.validate(abi.encode(boundary));
+    }
+
+    /// Below floor for 6 decimals: 1e-7 reverts.
+    function testBelowFloorReverts() external {
+        Float tooSmall = LibDecimalFloat.packLossless(1, -7);
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, tooSmall));
+        v.validate(abi.encode(tooSmall));
+    }
+
+    /// Ceiling for 6 decimals: 1e6 passes.
+    function testCeilingBoundaryPasses() external {
+        Float ceiling = LibDecimalFloat.packLossless(1, 6);
+        v.validate(abi.encode(ceiling));
+    }
+
+    /// Above ceiling for 6 decimals: 1e7 reverts.
+    function testAboveCeilingReverts() external {
+        Float tooLarge = LibDecimalFloat.packLossless(1, 7);
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooLarge.selector, tooLarge));
+        v.validate(abi.encode(tooLarge));
+    }
+
+    /// A multiplier that would pass for 18-decimals (1e-18) must revert for
+    /// a 6-decimal vault because it's below the per-token floor.
+    function testEighteenDecimalFloorRejectedForSixDecimals() external {
+        Float eighteenFloor = LibDecimalFloat.packLossless(1, -18);
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, eighteenFloor));
+        v.validate(abi.encode(eighteenFloor));
+    }
+
+    /// A realistic 2x split still passes for 6-decimal tokens.
+    function testRealisticSplitPasses() external {
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        v.validate(abi.encode(twoX));
+    }
+}
+
+/// @dev Fuzz tests that parameterize over the vault's decimals.
+contract LibStockSplitValidationFuzzDecimalsTest is Test {
+    function setUp() public {
+        LibTestTofu.deployTofu(vm);
+    }
+
+    /// For any decimals in a realistic range, the floor boundary
+    /// (10^-decimals) passes and just below it (10^-(decimals+1)) reverts.
+    function testFuzzFloorBoundary(uint8 decimals) external {
+        decimals = uint8(bound(decimals, 1, 36));
+        ValidationHarness v = new ValidationHarness(decimals);
+
+        // forge-lint: disable-next-line(unsafe-typecast)
+        int256 decimalsSigned = int256(uint256(decimals));
+
+        // Floor boundary passes.
+        Float floor = LibDecimalFloat.packLossless(1, -decimalsSigned);
+        v.validate(abi.encode(floor));
+
+        // Just below floor reverts.
+        Float belowFloor = LibDecimalFloat.packLossless(1, -(decimalsSigned + 1));
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooSmall.selector, belowFloor));
+        v.validate(abi.encode(belowFloor));
+    }
+
+    /// For any decimals in a realistic range, the ceiling boundary
+    /// (10^decimals) passes and just above it (10^(decimals+1)) reverts.
+    function testFuzzCeilingBoundary(uint8 decimals) external {
+        decimals = uint8(bound(decimals, 1, 36));
+        ValidationHarness v = new ValidationHarness(decimals);
+
+        // forge-lint: disable-next-line(unsafe-typecast)
+        int256 decimalsSigned = int256(uint256(decimals));
+
+        // Ceiling boundary passes.
+        Float ceiling = LibDecimalFloat.packLossless(1, decimalsSigned);
+        v.validate(abi.encode(ceiling));
+
+        // Just above ceiling reverts.
+        Float aboveCeiling = LibDecimalFloat.packLossless(1, decimalsSigned + 1);
+        vm.expectRevert(abi.encodeWithSelector(MultiplierTooLarge.selector, aboveCeiling));
+        v.validate(abi.encode(aboveCeiling));
+    }
+
+    /// A realistic multiplier (2x) passes for any realistic decimals value.
+    function testFuzzRealisticMultiplierPasses(uint8 decimals) external {
+        decimals = uint8(bound(decimals, 1, 36));
+        ValidationHarness v = new ValidationHarness(decimals);
+
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        v.validate(abi.encode(twoX));
+    }
+}
+
 contract LibStockSplitResolveTest is Test {
     StockSplitHarness internal h;
 

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -164,7 +164,6 @@ contract LibStockSplitValidationTest is Test {
         assertEq(ACTION_TYPE_STOCK_SPLIT, 1);
         assertEq(STOCK_SPLIT_TYPE_HASH, keccak256("StockSplit"));
     }
-
 }
 
 contract LibStockSplitResolveTest is Test {

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -26,8 +26,8 @@ contract StockSplitHarness {
         return LibCorporateAction.resolveActionType(typeHash, parameters);
     }
 
-    function nextOfType(uint256 cursor, uint256 mask, bool completed) external view returns (uint256) {
-        return LibCorporateActionNode.nextOfType(cursor, mask, completed);
+    function nextCompletedOfType(uint256 cursor, uint256 mask) external view returns (uint256) {
+        return LibCorporateActionNode.nextCompletedOfType(cursor, mask);
     }
 
     function countCompleted() external view returns (uint256) {
@@ -127,7 +127,7 @@ contract LibStockSplitLifecycleTest is Test {
         vm.warp(2000);
         assertEq(h.countCompleted(), 1);
 
-        uint256 completed = h.nextOfType(0, ACTION_TYPE_STOCK_SPLIT, true);
+        uint256 completed = h.nextCompletedOfType(0, ACTION_TYPE_STOCK_SPLIT);
         assertEq(completed, 1);
 
         CorporateActionNode memory node = h.getNode(1);

--- a/test/src/lib/LibStockSplit.t.sol
+++ b/test/src/lib/LibStockSplit.t.sol
@@ -162,7 +162,7 @@ contract LibStockSplitValidationTest is Test {
     /// Constants have expected values.
     function testConstantValues() external pure {
         assertEq(ACTION_TYPE_STOCK_SPLIT, 1);
-        assertEq(STOCK_SPLIT_TYPE_HASH, keccak256("StockSplit"));
+        assertEq(STOCK_SPLIT_TYPE_HASH, keccak256("st0x.corporate-actions.stock-split"));
     }
 
     /// ACTION_TYPE_STOCK_SPLIT has exactly one bit set.


### PR DESCRIPTION
## Summary

Registers the stock split action type with parameter validation and adds the `CompletionFilter` enum for traversal. **PR 3 of 9.**

### What this adds

- **Type registration**: `STOCK_SPLIT_TYPE_HASH = keccak256("StockSplit")` maps to `ACTION_TYPE_STOCK_SPLIT = 1 << 0`. `resolveActionType()` validates parameters and returns the bitmap.
- **`LibStockSplit`**: `validateParameters` (positive coefficient, floor/ceiling bounds), `decodeParameters` (ABI decode to Rain Float).
- **Multiplier bounds**: `trunc(1e18 * multiplier) >= 1` (floor) and `<= 1e36` (ceiling). Rejects near-zero wipe-outs and overflow-risk multipliers.
- **`CompletionFilter` enum**: `ALL`, `COMPLETED`, `PENDING` — used by traversal getters to disambiguate time-based filtering with early-break optimizations.

### How it fits

Builds on the linked list (PR2) to make stock splits a concrete, validated action type. The rebase system (PR4) uses `decodeParameters` to read multipliers during migration.

## Test plan

- [x] `forge test --match-contract LibStockSplit` — validation, resolve, lifecycle tests all passing
- [x] Negative coefficient, near-zero, near-saturation boundary tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stock-split corporate-action support with strict multiplier validation and type resolution.

* **Documentation**
  * Clarified node traversal/filter behavior and updated example action-type identifier.

* **Tests**
  * Added extensive unit and integration tests for validation, encoding/decoding, resolution, lifecycle, events, reverts, filtering, and indexing.

* **Chores**
  * Added config remappings, a submodule for token-decimals, and standardized error definitions for corporate-action and stock-split failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->