### PR TITLE
refactor: remove unreferenced LibCorporateAction.headNode/tailNode

### DIFF
--- a/src/error/ErrCorporateAction.sol
+++ b/src/error/ErrCorporateAction.sol
@@ -15,9 +15,6 @@ error ActionDoesNotExist(uint256 actionIndex);
 /// @param typeHash The unrecognised external identifier.
 error UnknownActionType(bytes32 typeHash);
 
-/// Thrown when accessing head/tail on a list with no scheduled actions.
-error NoActionsScheduled();
-
 /// Thrown when a traversal getter is called with a mask that contains no
 /// currently valid action-type bits — i.e.
 /// `mask & VALID_ACTION_TYPES_MASK == 0`. Every node's `actionType` has at

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -8,8 +8,7 @@ import {
     EffectiveTimeInPast,
     ActionAlreadyComplete,
     ActionDoesNotExist,
-    UnknownActionType,
-    NoActionsScheduled
+    UnknownActionType
 } from "../error/ErrCorporateAction.sol";
 
 /// @dev ERC-7201 namespaced storage location for corporate actions,
@@ -255,23 +254,4 @@ library LibCorporateAction {
         }
     }
 
-    /// @notice Return the head node of the list.
-    /// @dev Requires that at least one node has been scheduled (sentinel exists).
-    /// @return The head node, or the sentinel (index == 0) if the list is empty.
-    function headNode() internal view returns (CorporateActionNode storage) {
-        CorporateActionStorage storage s = getStorage();
-        if (s.nodes.length == 0) revert NoActionsScheduled();
-        if (s.head == 0) return s.nodes[0];
-        return s.nodes[s.head];
-    }
-
-    /// @notice Return the tail node of the list.
-    /// @dev Requires that at least one node has been scheduled (sentinel exists).
-    /// @return The tail node, or the sentinel (index == 0) if the list is empty.
-    function tailNode() internal view returns (CorporateActionNode storage) {
-        CorporateActionStorage storage s = getStorage();
-        if (s.nodes.length == 0) revert NoActionsScheduled();
-        if (s.tail == 0) return s.nodes[0];
-        return s.nodes[s.tail];
-    }
 }

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -253,5 +253,4 @@ library LibCorporateAction {
             current = LibCorporateActionNode.nextOfType(current, type(uint256).max, CompletionFilter.COMPLETED);
         }
     }
-
 }

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -16,7 +16,6 @@ import {
 } from "../../../src/lib/LibCorporateAction.sol";
 import {
     UnknownActionType,
-    NoActionsScheduled,
     EffectiveTimeInPast,
     ActionAlreadyComplete,
     ActionDoesNotExist,
@@ -140,14 +139,6 @@ contract CorporateActionHarness {
 
     function tail() external view returns (uint256) {
         return LibTestCorporateAction.tail();
-    }
-
-    function headNode() external view returns (CorporateActionNode memory) {
-        return LibCorporateAction.headNode();
-    }
-
-    function tailNode() external view returns (CorporateActionNode memory) {
-        return LibCorporateAction.tailNode();
     }
 
     /// Library-path readers — all go through `LibCorporateAction.getStorage()`,
@@ -736,18 +727,6 @@ contract StoxCorporateActionsFacetTest is Test {
         assertTrue(corporateActionHarness.totalSupplyBootstrapped(), "totalSupplyBootstrapped must be at offset 6");
     }
 
-    /// headNode and tailNode revert on a completely fresh list where no
-    /// action has ever been scheduled (nodes array has length 0).
-    function testHeadNodeRevertsOnFreshList() external {
-        vm.expectRevert(NoActionsScheduled.selector);
-        corporateActionHarness.headNode();
-    }
-
-    function testTailNodeRevertsOnFreshList() external {
-        vm.expectRevert(NoActionsScheduled.selector);
-        corporateActionHarness.tailNode();
-    }
-
     /// Cancel the head node when a tail exists.
     function testCancelHeadWithTail() external {
         corporateActionHarness.schedule(1, 1500, "");
@@ -992,22 +971,6 @@ contract StoxCorporateActionsFacetTest is Test {
         vm.warp(3000);
 
         assertEq(corporateActionHarness.countCompleted(), 2, "cancelled node excluded from count");
-    }
-
-    /// headNode and tailNode return correct data after scheduling.
-    function testHeadNodeAndTailNodeReturnCorrectData() external {
-        corporateActionHarness.schedule(1, 1500, hex"AA");
-        corporateActionHarness.schedule(2, 2500, hex"BB");
-
-        CorporateActionNode memory h = corporateActionHarness.headNode();
-        assertEq(h.actionType, 1);
-        assertEq(h.effectiveTime, 1500);
-        assertEq(h.parameters, hex"AA");
-
-        CorporateActionNode memory t = corporateActionHarness.tailNode();
-        assertEq(t.actionType, 2);
-        assertEq(t.effectiveTime, 2500);
-        assertEq(t.parameters, hex"BB");
     }
 
     /// Cancel at index == nodes.length reverts.


### PR DESCRIPTION
## Summary

- Delete `LibCorporateAction.headNode()` / `tailNode()` — no callers in src/. Production code uses `LibCorporateActionNode.nextOfType(0, ...)` and `prevOfType(0, ...)` directly.
- Delete the `NoActionsScheduled` error — only thrower was these two functions.
- Delete the three tests that exercised the removed functions (`testHeadNodeRevertsOnFreshList`, `testTailNodeRevertsOnFreshList`, `testHeadNodeAndTailNodeReturnCorrectData`).

Empty-list safety is still enforced at every external entry point that walks the list (`getActionParameters`, traversal getters).

Closes #56.

## Test plan
- [x] `forge build`
- [x] full suite — 447 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed internal utility functions from the corporate action management system to streamline the codebase.
  * Consolidated error handling by removing a custom error declaration.

* **Tests**
  * Updated test suite and harness to reflect removal of library functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->