### PR TITLE
test: pin prod beacon impl bytecode + owner via rain.extrospection

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -3,7 +3,7 @@
     "rev": "43a6ed3a98f0141e1963b4b9136e8c80e2889bd1"
   },
   "lib/rain.extrospection": {
-    "rev": "60f35a0fc7e38fe6879c638ee25b46e88bfc9892"
+    "rev": "e32def40f2a5fda5f466ccd091bb22da3f6f8111"
   },
   "lib/rain.tofu.erc20-decimals": {
     "rev": "67b81b417e3f2311f71058d526e4c16518b393cc"

--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -12,16 +12,14 @@ import {IReceiptVaultV3} from "rain.vats/interface/IReceiptVaultV3.sol";
 import {
     IOffchainAssetReceiptVaultBeaconSetDeployerV1
 } from "rain.vats/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
+import {ERC1967_BEACON_SLOT} from "rain.extrospection/lib/LibExtrospectERC1967BeaconProxy.sol";
 
 /// @title LibProdTokensBaseTest
 /// @notice Fork tests verifying production token instances on Base.
 contract LibProdTokensBaseTest is Test {
-    /// @dev EIP-1967 beacon slot.
-    bytes32 constant BEACON_SLOT = 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50;
-
     /// Read the EIP-1967 beacon address from a proxy contract.
     function beaconOf(address proxy) internal view returns (address) {
-        return address(uint160(uint256(vm.load(proxy, BEACON_SLOT))));
+        return address(uint160(uint256(vm.load(proxy, ERC1967_BEACON_SLOT))));
     }
 
     /// Verify a token set (receipt, receipt vault, wrapped vault) is deployed,

--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -12,7 +12,10 @@ import {IReceiptVaultV3} from "rain.vats/interface/IReceiptVaultV3.sol";
 import {
     IOffchainAssetReceiptVaultBeaconSetDeployerV1
 } from "rain.vats/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
-import {ERC1967_BEACON_SLOT} from "rain.extrospection/lib/LibExtrospectERC1967BeaconProxy.sol";
+import {
+    ERC1967_BEACON_SLOT,
+    LibExtrospectERC1967BeaconProxy
+} from "rain.extrospection/lib/LibExtrospectERC1967BeaconProxy.sol";
 
 /// @title LibProdTokensBaseTest
 /// @notice Fork tests verifying production token instances on Base.
@@ -44,18 +47,47 @@ contract LibProdTokensBaseTest is Test {
         IOffchainAssetReceiptVaultBeaconSetDeployerV1 oarvDeployer = IOffchainAssetReceiptVaultBeaconSetDeployerV1(
             LibProdDeployV1.OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER
         );
-        assertEq(beaconOf(receipt), address(oarvDeployer.I_RECEIPT_BEACON()), "receipt beacon mismatch");
-        assertEq(
-            beaconOf(receiptVault),
-            address(oarvDeployer.I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON()),
-            "receipt vault beacon mismatch"
+        address receiptBeacon = address(oarvDeployer.I_RECEIPT_BEACON());
+        address receiptVaultBeacon = address(oarvDeployer.I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON());
+        // The wrapped vault beacon is not exposed by any deployer getter,
+        // so read it from the proxy's slot. All wrapped proxies share the
+        // same beacon, pinned via the MSTR check below.
+        address wrappedVaultBeacon = beaconOf(LibProdTokensBase.MSTR_WRAPPED_TOKEN_VAULT);
+
+        assertEq(beaconOf(receipt), receiptBeacon, "receipt beacon mismatch");
+        assertEq(beaconOf(receiptVault), receiptVaultBeacon, "receipt vault beacon mismatch");
+        assertEq(beaconOf(wrappedTokenVault), wrappedVaultBeacon, "wrapped vault beacon mismatch");
+
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                receiptBeacon, LibProdDeployV1.PROD_STOX_RECEIPT_IMPLEMENTATION_BASE_CODEHASH_V1
+            ),
+            "receipt beacon impl codehash mismatch"
         );
-        // The wrapped vault beacon is not exposed by any deployer getter.
-        // Assert all wrapped proxies share the same beacon as wtMSTR.
-        assertEq(
-            beaconOf(wrappedTokenVault),
-            beaconOf(LibProdTokensBase.MSTR_WRAPPED_TOKEN_VAULT),
-            "wrapped vault beacon mismatch"
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                receiptVaultBeacon, LibProdDeployV1.PROD_STOX_RECEIPT_VAULT_IMPLEMENTATION_BASE_CODEHASH_V1
+            ),
+            "receipt vault beacon impl codehash mismatch"
+        );
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconImplementationBytecode(
+                wrappedVaultBeacon, LibProdDeployV1.PROD_STOX_WRAPPED_TOKEN_VAULT_IMPLEMENTATION_BASE_CODEHASH_V1
+            ),
+            "wrapped vault beacon impl codehash mismatch"
+        );
+
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconOwner(receiptBeacon, LibProdDeployV1.BEACON_INITIAL_OWNER),
+            "receipt beacon owner mismatch"
+        );
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconOwner(receiptVaultBeacon, LibProdDeployV1.BEACON_INITIAL_OWNER),
+            "receipt vault beacon owner mismatch"
+        );
+        assertTrue(
+            LibExtrospectERC1967BeaconProxy.isBeaconOwner(wrappedVaultBeacon, LibProdDeployV1.BEACON_INITIAL_OWNER),
+            "wrapped vault beacon owner mismatch"
         );
     }
 


### PR DESCRIPTION
## Summary
- Bumps `lib/rain.extrospection` to `e32def4` (merge of rainlanguage/rain.extrospection#22), exposing the EIP-1967 slot constants and the `isBeacon*` predicates.
- `LibProdTokensBaseTest` swaps a hardcoded `BEACON_SLOT` literal for `ERC1967_BEACON_SLOT` (single source of truth for the slot address). `vm.load` remains the read mechanism — proxies have no on-chain getter for this slot. Addresses the proxy-side intent of #33.
- **New beacon-side coverage (per token, all 13 prod tokens on Base):** for each of the three beacons (receipt, receipt vault, wrapped vault), assert
  - `isBeaconImplementationBytecode(beacon, PROD_*_BASE_CODEHASH_V1)` — pins the runtime bytecode at the beacon's current implementation matches the constant in `LibProdDeployV1`.
  - `isBeaconOwner(beacon, BEACON_INITIAL_OWNER)` — pins the beacon's owner is `rainlang.eth`.

The previous tests only checked that proxies pointed at the right beacon address; they did not verify what was behind the beacon or who controlled it. A beacon upgrade or ownership transfer would have passed silently.

Beacon-side coverage gaps still open after this PR:
- #113 — pin beacon contract bytecode
- #114 — pin beacon addresses against explicit constants
- #115 — assert deployer bytecode in `LibProdTokensBaseTest`

Other follow-ups using rain.extrospection on the implementations:
- #110 — `checkNotMetamorphic`
- #111 — `checkNoSolidityCBORMetadata`
- #112 — opcode-set scan

## Test plan
- [x] `forge build` clean
- [x] `forge test --match-path test/src/lib/LibProdTokensBase.t.sol` — 13 fork tests on Base pass
- [x] Mutation-verified: flipping `PROD_STOX_RECEIPT_IMPLEMENTATION_BASE_CODEHASH_V1` fails the new `receipt beacon impl codehash mismatch` assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)