### PR TITLE
test(failing): pin prod receipt vault authorizer consistency

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -9,6 +9,6 @@
     "rev": "67b81b417e3f2311f71058d526e4c16518b393cc"
   },
   "lib/rain.vats": {
-    "rev": "cad9ca4c9f230c97d481c58f635a33c774e22c07"
+    "rev": "f52c8b471c557d672c1f0ecec5e39b8ae8f337fe"
   }
 }

--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -12,6 +12,7 @@ import {IReceiptVaultV3} from "rain.vats/interface/IReceiptVaultV3.sol";
 import {
     IOffchainAssetReceiptVaultBeaconSetDeployerV1
 } from "rain.vats/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
+import {IAuthorizableV1} from "rain.vats/interface/IAuthorizableV1.sol";
 import {
     ERC1967_BEACON_SLOT,
     LibExtrospectERC1967BeaconProxy
@@ -89,6 +90,14 @@ contract LibProdTokensBaseTest is Test {
             LibExtrospectERC1967BeaconProxy.isBeaconOwner(wrappedVaultBeacon, LibProdDeployV1.BEACON_INITIAL_OWNER),
             "wrapped vault beacon owner mismatch"
         );
+
+        // Every prod receipt vault must report a non-zero authorizer,
+        // and all 13 prod token sets must share the same authorizer
+        // contract. Inconsistency would mean one vault is configured
+        // against a different permission boundary than its siblings.
+        address mstrAuthorizer = address(IAuthorizableV1(LibProdTokensBase.MSTR_RECEIPT_VAULT).authorizer());
+        assertTrue(mstrAuthorizer != address(0), "mstr authorizer is zero");
+        assertEq(address(IAuthorizableV1(receiptVault).authorizer()), mstrAuthorizer, "authorizer differs from mstr's");
     }
 
     function testMstrTokenSetOnBase() external {


### PR DESCRIPTION
## Summary
Implements the test from #34: every prod receipt vault on Base must report a non-zero authorizer AND all 13 prod token sets must share the same authorizer contract.

**This PR ships a deliberately failing test as a forcing function.** Two prod tokens diverge from the rest. The test landing as red is the point — it surfaces the drift to anyone who touches the prod-token suite.

## Drift observed (fork against Base)

| Group | Tokens | Authorizer |
|---|---|---|
| Majority (11/13) | MSTR, TSLA, COIN, SPYM, SIVR, CRCL, NVDA, IAU, PPLT, AMZN, BMNR | `0x35f9fA9d80aAF2B0fB27f0FF015641B3408d7456` |
| Outlier | IBHG | `0x6E0F1c31Fca4Ff07cD0C3e8658b1e3a473f3393a` |
| Outlier | SGOV | `0xED3A1Ab65a25dfc82F4A7B89203EEc9BCb2D4f01` |

None of these match the V2 constants in `LibProdDeployV2` (`STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1` = `0x667d2Ab…`, `STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_PAYMENT_MINT_AUTHORIZER_V1` = `0x72b2a39…`). The prod vaults are V1-era and use authorizers that don't appear as constants anywhere in the repo.

## Three reads, one needs picking

1. **Misconfiguration** — IBHG/SGOV were deployed against the wrong authorizer by mistake. Fix prod to point them at `0x35f9fA9d80…`. Test stays as-is.
2. **Intentional per-token authorizer** — IBHG (corporate-bond ETF) and SGOV (Treasury) have different transfer-restriction rules vs. equity tokens. #34's premise is wrong; relax the test to non-zero only and document the per-token expectation in `LibProdTokensBase`.
3. **Cohort split** — IBHG/SGOV are a different deployment generation. Partition the test by cohort, assert consistency within each cohort, document which token belongs to which.

Whoever picks this up needs to (a) talk to whoever signed the IBHG/SGOV deployments to confirm intent, (b) look up the three authorizer addresses on basescan to identify what they actually are, (c) decide which read above applies and act on it.

## Mechanical changes
- Bumps `lib/rain.vats` to `f52c8b4` (PR rainlanguage/rain.vats#293, issue rainlanguage/rain.vats#292) — adds `IAuthorizableV1`, the typed read-only interface for `OffchainAssetReceiptVault.authorizer()`. Without this, the test would have to pull the concrete contract or use a low-level call.
- `LibProdTokensBaseTest.checkTokenSet` reads each vault's authorizer via `IAuthorizableV1`, asserts non-zero and equality against `MSTR_RECEIPT_VAULT`'s authorizer.

Closes #34 only after the drift question above is resolved (do not merge while red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated submodule reference to latest revision.

* **Tests**
  * Enhanced test validation for permission-boundary consistency across token sets, including authorizer verification and baseline comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->