### PR TITLE
chore: bump rain.vats to f52c8b4 for IAuthorizableV1

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -9,6 +9,6 @@
     "rev": "67b81b417e3f2311f71058d526e4c16518b393cc"
   },
   "lib/rain.vats": {
-    "rev": "cad9ca4c9f230c97d481c58f635a33c774e22c07"
+    "rev": "f52c8b471c557d672c1f0ecec5e39b8ae8f337fe"
   }
 }


### PR DESCRIPTION
## Summary
Pulls in rainlanguage/rain.vats#293 (closes rainlanguage/rain.vats#292), which adds the `IAuthorizableV1` interface — a typed read-only interface exposing `OffchainAssetReceiptVault.authorizer()` so callers don't have to import the concrete contract or use a low-level call.

No source changes in this repo. Splits the dep bump out of #116 so that PR's diff shows only the test addition.

## Test plan
- [x] `forge build` clean
- [ ] CI green