### PR TITLE
chore: bump rain.vats to a522bc2 for ICertifiableV1

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -9,6 +9,6 @@
     "rev": "67b81b417e3f2311f71058d526e4c16518b393cc"
   },
   "lib/rain.vats": {
-    "rev": "f52c8b471c557d672c1f0ecec5e39b8ae8f337fe"
+    "rev": "a522bc26b6904c95119369955cd6ca4ac0db7097"
   }
 }


### PR DESCRIPTION
## Summary
Pulls in rainlanguage/rain.vats#295 (closes rainlanguage/rain.vats#294), which adds the `ICertifiableV1` interface — a typed read-only interface exposing `OffchainAssetReceiptVault.isCertificationExpired()` so callers don't have to import the concrete contract or use a low-level call.

No source changes in this repo. Unblocks #35 (cert expiry assertion in prod token tests). Same shape as #117 (which landed `IAuthorizableV1`).

## Test plan
- [x] `forge build` clean
- [ ] CI green