### PR TITLE
test: pin prod receipt vault certification not expired

### DIFF
--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -12,6 +12,7 @@ import {IReceiptVaultV3} from "rain.vats/interface/IReceiptVaultV3.sol";
 import {
     IOffchainAssetReceiptVaultBeaconSetDeployerV1
 } from "rain.vats/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
+import {ICertifiableV1} from "rain.vats/interface/ICertifiableV1.sol";
 import {
     ERC1967_BEACON_SLOT,
     LibExtrospectERC1967BeaconProxy
@@ -89,6 +90,12 @@ contract LibProdTokensBaseTest is Test {
             LibExtrospectERC1967BeaconProxy.isBeaconOwner(wrappedVaultBeacon, LibProdDeployV1.BEACON_INITIAL_OWNER),
             "wrapped vault beacon owner mismatch"
         );
+
+        // Receipt vault transfers are gated on `certifiedUntil`. An expired
+        // certification freezes all transfers on the affected token. Pin
+        // that every prod vault is currently within its certification
+        // window at the fork's block timestamp.
+        assertFalse(ICertifiableV1(receiptVault).isCertificationExpired(), "receipt vault certification expired");
     }
 
     function testMstrTokenSetOnBase() external {


### PR DESCRIPTION
## Summary
Adds the test #35 asks for. Every prod receipt vault on Base must have a non-expired `certifiedUntil` at the fork block. An expired certification freezes all transfers on the affected token.

Reads state via `ICertifiableV1.isCertificationExpired()` (added in rainlanguage/rain.vats#295, dep bumped here in #118 — already on main).

The check inside `checkTokenSet` is one line:

```solidity
assertFalse(ICertifiableV1(receiptVault).isCertificationExpired(), "receipt vault certification expired");
```

Catches drift if the fork pin moves forward past a cert-expiry date — the test fails so the team knows to recertify before pushing the pin. All 13 prod tokens currently pass.

Closes #35.

## Test plan
- [x] `forge test --match-path test/src/lib/LibProdTokensBase.t.sol` — all 13 fork tests on Base pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation checks to ensure receipt vault certifications remain active in token set configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->