### PR TITLE
test: pin prod token decimals to 18

### DIFF
--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -96,6 +96,12 @@ contract LibProdTokensBaseTest is Test {
         // that every prod vault is currently within its certification
         // window at the fork's block timestamp.
         assertFalse(ICertifiableV1(receiptVault).isCertificationExpired(), "receipt vault certification expired");
+
+        // Integrators (DEXes, indexers, UIs) read `decimals()` to scale
+        // amounts. Drift from 18 silently shifts every off-chain
+        // calculation by ten orders of magnitude per missing decimal.
+        assertEq(IERC20Metadata(receiptVault).decimals(), 18, "receipt vault decimals != 18");
+        assertEq(IERC20Metadata(wrappedTokenVault).decimals(), 18, "wrapped vault decimals != 18");
     }
 
     function testMstrTokenSetOnBase() external {


### PR DESCRIPTION
## Summary
Adds the test #36 asks for. Every prod receipt vault and wrapped vault on Base must report `decimals() == 18`.

Drift from 18 silently shifts every off-chain integrator calculation (DEX prices, indexer formatting, UI display) by ten orders of magnitude per missing decimal. All 13 prod tokens currently pass.

Closes #36.

## Test plan
- [x] `forge test --match-path test/src/lib/LibProdTokensBase.t.sol` — all 13 fork tests on Base pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation checks to ensure receipt and wrapped token vaults maintain 18 decimal places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->