### PR TITLE
test: pin per-class proxy codehash consistency for prod tokens

### DIFF
--- a/src/lib/LibProdDeployV1.sol
+++ b/src/lib/LibProdDeployV1.sol
@@ -114,4 +114,28 @@ library LibProdDeployV1 {
     /// tests to verify deployment integrity.
     bytes32 constant PROD_STOX_UNIFIED_DEPLOYER_BASE_CODEHASH_V1 =
         0xb5167a6cfec58378938913cf93dd0c7cf0aab1501beb653b0b6e0be6f5b8e072;
+
+    /// @dev Expected codehash of every prod StoxReceipt proxy instance on
+    /// Base. All receipt proxies are `BeaconProxy`s pointing at the same
+    /// receipt beacon, so their runtime bytecode is identical. Initial
+    /// value scraped from `MSTR_RECEIPT`. Drift on any prod receipt
+    /// proxy means it was deployed through a different mechanism or
+    /// with different constructor args than its siblings.
+    bytes32 constant PROD_STOX_RECEIPT_PROXY_BASE_CODEHASH_V1 =
+        0x3a6a276173fa980d807d8cdc6e760a76be57ee8cc0d6b8522ca651e7d6e649b6;
+
+    /// @dev Expected codehash of every prod StoxReceiptVault proxy instance
+    /// on Base. All receipt vault proxies are `BeaconProxy`s pointing at
+    /// the same receipt vault beacon, so their runtime bytecode is
+    /// identical. Initial value scraped from `MSTR_RECEIPT_VAULT`.
+    bytes32 constant PROD_STOX_RECEIPT_VAULT_PROXY_BASE_CODEHASH_V1 =
+        0x458736ea3d3ad05745640e02a8e1110d707f793096e3ac278c304110f6d54689;
+
+    /// @dev Expected codehash of every prod StoxWrappedTokenVault proxy
+    /// instance on Base. All wrapped vault proxies are `BeaconProxy`s
+    /// pointing at the same wrapped vault beacon, so their runtime
+    /// bytecode is identical. Initial value scraped from
+    /// `MSTR_WRAPPED_TOKEN_VAULT`.
+    bytes32 constant PROD_STOX_WRAPPED_TOKEN_VAULT_PROXY_BASE_CODEHASH_V1 =
+        0x8227665ab0d770ac6d47cc6b17924f8e64c93ca12f3b4281e8949b67d36f3e44;
 }

--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -102,6 +102,31 @@ contract LibProdTokensBaseTest is Test {
         // calculation by ten orders of magnitude per missing decimal.
         assertEq(IERC20Metadata(receiptVault).decimals(), 18, "receipt vault decimals != 18");
         assertEq(IERC20Metadata(wrappedTokenVault).decimals(), 18, "wrapped vault decimals != 18");
+
+        // Per-class proxy codehash consistency. All receipt proxies are
+        // BeaconProxy instances pointing at the same beacon, so their
+        // runtime bytecode must be identical. Same for receipt vault
+        // proxies and wrapped vault proxies. A divergent codehash means
+        // a proxy was deployed through a different mechanism or with
+        // different constructor args than its siblings. The pinned
+        // values live in `LibProdDeployV1` so MSTR is no longer the
+        // canonical reference — every prod proxy is checked against an
+        // in-repo constant.
+        assertEq(
+            keccak256(receipt.code),
+            LibProdDeployV1.PROD_STOX_RECEIPT_PROXY_BASE_CODEHASH_V1,
+            "receipt proxy codehash mismatch"
+        );
+        assertEq(
+            keccak256(receiptVault.code),
+            LibProdDeployV1.PROD_STOX_RECEIPT_VAULT_PROXY_BASE_CODEHASH_V1,
+            "receipt vault proxy codehash mismatch"
+        );
+        assertEq(
+            keccak256(wrappedTokenVault.code),
+            LibProdDeployV1.PROD_STOX_WRAPPED_TOKEN_VAULT_PROXY_BASE_CODEHASH_V1,
+            "wrapped vault proxy codehash mismatch"
+        );
     }
 
     function testMstrTokenSetOnBase() external {


### PR DESCRIPTION
## Summary
Adds the test #37 asks for. All receipt proxies are `BeaconProxy` instances pointing at the same beacon, so their runtime bytecode must be identical. Same for receipt vault proxies and wrapped vault proxies.

Three new constants in `LibProdDeployV1`:
- `PROD_STOX_RECEIPT_PROXY_BASE_CODEHASH_V1`
- `PROD_STOX_RECEIPT_VAULT_PROXY_BASE_CODEHASH_V1`
- `PROD_STOX_WRAPPED_TOKEN_VAULT_PROXY_BASE_CODEHASH_V1`

Initial values scraped from MSTR's three proxies on the Base fork. Every prod token's three proxies are then asserted against the in-repo constants — MSTR is no longer the canonical reference, so drift on MSTR is detected the same way as drift on any other token.

A divergent codehash means a proxy was deployed through a different mechanism or with different constructor args than its siblings — the team needs to investigate.

All 13 prod tokens currently pass.

Closes #37.

## Test plan
- [x] `forge test --match-path test/src/lib/LibProdTokensBase.t.sol` — all 13 fork tests on Base pass