### PR TITLE
test: pin prod receipt manager equals receipt vault

### DIFF
--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -9,6 +9,7 @@ import {LibTestProd} from "../../lib/LibTestProd.sol";
 import {IERC20Metadata} from "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {IERC4626} from "openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
 import {IReceiptVaultV3} from "rain.vats/interface/IReceiptVaultV3.sol";
+import {IReceiptV3} from "rain.vats/interface/IReceiptV3.sol";
 import {
     IOffchainAssetReceiptVaultBeaconSetDeployerV1
 } from "rain.vats/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
@@ -43,6 +44,11 @@ contract LibProdTokensBaseTest is Test {
         assertEq(IERC20Metadata(wrappedTokenVault).symbol(), expectedWrappedVaultSymbol);
         assertEq(IERC4626(wrappedTokenVault).asset(), receiptVault, "wrapped vault asset mismatch");
         assertEq(address(IReceiptVaultV3(payable(receiptVault)).receipt()), receipt, "receipt address mismatch");
+        // The receipt's manager controls mint/burn. If a prod receipt's
+        // manager isn't its receipt vault, the vault can't mint receipts
+        // when users deposit nor burn receipts when users withdraw —
+        // every deposit and withdraw on this token would revert.
+        assertEq(IReceiptV3(receipt).manager(), receiptVault, "receipt manager != receipt vault");
 
         // All prod tokens on Base are behind the V1 OARV deployer's beacons.
         IOffchainAssetReceiptVaultBeaconSetDeployerV1 oarvDeployer = IOffchainAssetReceiptVaultBeaconSetDeployerV1(


### PR DESCRIPTION
## Summary
Adds the test #39 asks for. Each ERC-1155 receipt's `manager()` must equal its corresponding receipt vault.

The receipt's manager controls mint/burn — if a prod receipt's manager isn't its vault, every deposit and withdraw on that token would revert at the vault's attempt to mint or burn receipts.

All 13 prod tokens currently pass.

Closes #39.

## Test plan
- [x] `forge test --match-path test/src/lib/LibProdTokensBase.t.sol` — all 13 fork tests on Base pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation checks for production token configurations to verify correct vault and receipt token relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->