### PR TITLE
test: pin prod wrapped vault supply invariant

### DIFF
--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -127,6 +127,17 @@ contract LibProdTokensBaseTest is Test {
             LibProdDeployV1.PROD_STOX_WRAPPED_TOKEN_VAULT_PROXY_BASE_CODEHASH_V1,
             "wrapped vault proxy codehash mismatch"
         );
+
+        // Wrapped vault claims (totalAssets) cannot exceed total receipt
+        // vault shares minted (totalSupply). The wrapped vault's holdings
+        // of the receipt vault are a subset of all minted receipt-vault
+        // shares — others may hold receipt-vault shares directly.
+        // Violation indicates an accounting bug.
+        assertLe(
+            IERC4626(wrappedTokenVault).totalAssets(),
+            IERC20Metadata(receiptVault).totalSupply(),
+            "wrapped vault totalAssets > receipt vault totalSupply"
+        );
     }
 
     function testMstrTokenSetOnBase() external {


### PR DESCRIPTION
## Summary
Adds the test #40 asks for. Each prod wrapped token vault's `totalAssets()` must not exceed its receipt vault's `totalSupply()`.

The wrapped vault holds receipt-vault shares as its underlying. Its `totalAssets()` is therefore a subset of the receipt vault's total minted supply — others may hold receipt-vault shares directly. A violation indicates an accounting bug.

All 13 prod tokens currently pass.

Closes #40.

## Test plan
- [x] `forge test --match-path test/src/lib/LibProdTokensBase.t.sol` — all 13 fork tests on Base pass