### PR TITLE
docs: document the corporate-action extension model (#85)

### DIFF
--- a/src/interface/ICorporateActionsV1.sol
+++ b/src/interface/ICorporateActionsV1.sol
@@ -138,6 +138,75 @@ uint256 constant VALID_ACTION_TYPES_MASK = ACTION_TYPE_STOCK_SPLIT_V1 | ACTION_T
 /// other — a batch read returns the same values as calling `balanceOf` per
 /// element.
 ///
+/// EXTENSION MODEL:
+///
+/// New action types are added as new bitmap bits + new type hashes,
+/// alongside existing types in the same chronological linked list. The
+/// model is **add a new type next to the old one**, not "evolve the old
+/// type in place". To add a new type:
+///
+/// 1. Pick a new bitmap bit: `ACTION_TYPE_FOO_V1 = 1 << N`. The bitmap is
+///    `uint256` so 256 types are addressable.
+/// 2. Namespace a new type hash: `keccak256("st0x.corporate-actions.foo.1")`.
+///    The trailing `.1` is the schema version; bumping it to `.2` (with
+///    a corresponding `ACTION_TYPE_FOO_V2 = 1 << M`) is how an existing
+///    type is "versioned" — the V1 nodes keep decoding with V1 logic,
+///    V2 nodes dispatch to V2 logic, both coexist in one list.
+/// 3. Create a new library `LibFoo` with `validateV1`, `encodeParametersV1`,
+///    `decodeParametersV1` — a single-point-of-change for the type's
+///    on-chain schema. Co-locating the codec with the validator keeps the
+///    schema definition in one place.
+/// 4. Extend `LibCorporateAction.resolveActionType`'s if-chain to dispatch
+///    the new type hash to the new validator + encoder. This is the
+///    intentional extension point — adding a type is a core-library edit
+///    and a vault redeployment, not a runtime registration.
+/// 5. Extend any consumer that walks the list (today
+///    `LibRebase.migratedBalance` for stock splits only) to handle the
+///    new action type where relevant. Consumers mask against the
+///    specific bit(s) they care about — not equality — so forward-
+///    compatibility is preserved when new bits land.
+/// 6. Deploy a new vault implementation. Upgrade the beacon.
+///
+/// Old nodes keep decoding with their old libraries; new nodes dispatch
+/// to the new library via their action-type bit. Both coexist in one
+/// linked list, time-ordered.
+///
+/// **What the model handles cleanly:**
+///   - New action types with different parameter shapes (the type-erased
+///     `bytes` payload is exactly this).
+///   - Versioning an existing type (new `_V2` bit + new type hash; old
+///     `_V1` nodes keep decoding under the old codec).
+///   - Single chronological linked list across all types — consumers
+///     traverse in time order regardless of action-type mix.
+///
+/// **What the model does NOT auto-handle — design discipline applies:**
+///   - **Underlying-type drift in `Float` (or any other dependency
+///     library).** The V1 decoder calls `abi.decode(params, (Float))`
+///     directly. If `rain.math.float` ships a new release with a
+///     different mantissa width, old stored parameters silently corrupt
+///     when re-decoded. Mitigation: pin the dependency at a specific
+///     commit and never bump it across a deployed version. If the
+///     dependency must be upgraded, that's a `_V2` action type with a
+///     new type hash — old `_V1` parameters keep decoding under the old
+///     pinned dependency.
+///   - **In-place migration of stored parameters.** Storage bytes do
+///     NOT auto-translate. "Re-encode all V1 nodes as V2" requires
+///     explicit migration code that walks the list, decodes as V1,
+///     re-encodes as V2, and writes back while preserving
+///     `effectiveTime` ordering and `prev`/`next` pointers. The default
+///     policy is "never migrate, always add a new version" — write any
+///     migration code defensively if that policy ever changes.
+///   - **Type-level pause / disable.** `cancelCorporateAction(actionIndex)`
+///     unlinks one specific node. There is no "disable action type X
+///     across the list" primitive; cancelling N pending nodes of type X
+///     takes N transactions. If a type-level pause becomes operationally
+///     necessary it would need a new storage flag and a new entry point.
+///   - **Off-chain discovery of new types.** Indexers learn new bitmap
+///     bits and type hashes from the CHANGELOG / release notes — there
+///     is no on-chain registry of `(bit, typeHash, name)` mappings.
+///     Acceptable at the expected scale (dozens of types lifetime, not
+///     hundreds).
+///
 /// @dev **Action type bitmap.** The `actionType` field returned by the four
 /// traversal getters is a single-bit mask identifying the action's type.
 /// The canonical constants — `ACTION_TYPE_STOCK_SPLIT_V1`,


### PR DESCRIPTION
## Summary
Adds an EXTENSION MODEL section to the `ICorporateActionsV1` NatSpec explaining the corporate-action extension contract.

Documents:
- **How to add a new action type** — 5 numbered steps (new bitmap bit + new type hash + new codec library + dispatch in `resolveActionType` + extend consumer walks + redeploy).
- **What the design handles cleanly** — additive new types, schema-versioned existing types, single chronological list across all types.
- **What requires discipline rather than runtime support** — `Float` underlying drift (pin the dependency or version the type), in-place storage migration (default policy: never migrate), type-level pause (no primitive — use per-node cancel), off-chain discovery (CHANGELOG, no on-chain registry).

Resolves issue #85 (\"seems fine\" + \"add docs\"). No code changes.

## Test plan
- [x] build clean
- No tests added — doc-only PR.

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation outlining how to extend the corporate actions system with new action types, including guidance on dispatcher logic extensions and consumer migration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->