### PR TITLE
refactor: rename cursor params/returns to actionId on public API (#128)

### DIFF
--- a/src/concrete/StoxCorporateActionsFacet.sol
+++ b/src/concrete/StoxCorporateActionsFacet.sol
@@ -69,7 +69,7 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
     // is bounded by the trust model documented at the contract level: the
     // authorizer is the canonical permission boundary, and any re-entry
     // through it is, by definition, an authorized sequence of calls. Each
-    // re-entrant `schedule` independently captures its own `actionIndex`
+    // re-entrant `schedule` independently captures its own `actionId`
     // from `s.nodes.length - 1` and the linked-list insert is atomic per
     // call, so interleaved invocations cannot corrupt the list.
     // slither-disable-next-line reentrancy-events
@@ -77,25 +77,25 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
         external
         override
         onlyDelegatecalled
-        returns (uint256 actionIndex)
+        returns (uint256 actionId)
     {
         _authorize(msg.sender, SCHEDULE_CORPORATE_ACTION, abi.encode(typeHash, effectiveTime, parameters));
         uint256 actionType = LibCorporateAction.resolveActionType(typeHash, parameters);
-        actionIndex = LibCorporateAction.schedule(actionType, effectiveTime, parameters);
-        emit CorporateActionScheduled(msg.sender, actionIndex, actionType, effectiveTime);
+        actionId = LibCorporateAction.schedule(actionType, effectiveTime, parameters);
+        emit CorporateActionScheduled(msg.sender, actionId, actionType, effectiveTime);
     }
 
     /// @inheritdoc ICorporateActionsV1
     // Same trust model as `scheduleCorporateAction`. The outer call's
-    // `actionIndex` is captured from calldata before `_authorize`, so a
+    // `actionId` is captured from calldata before `_authorize`, so a
     // re-entrant cancel during the authorizer callback can only act on
     // whatever index the (trusted) authorizer chooses to cancel — it
     // cannot redirect the outer call's target.
     // slither-disable-next-line reentrancy-events
-    function cancelCorporateAction(uint256 actionIndex) external override onlyDelegatecalled {
-        _authorize(msg.sender, CANCEL_CORPORATE_ACTION, abi.encode(actionIndex));
-        LibCorporateAction.cancel(actionIndex);
-        emit CorporateActionCancelled(msg.sender, actionIndex);
+    function cancelCorporateAction(uint256 actionId) external override onlyDelegatecalled {
+        _authorize(msg.sender, CANCEL_CORPORATE_ACTION, abi.encode(actionId));
+        LibCorporateAction.cancel(actionId);
+        emit CorporateActionCancelled(msg.sender, actionId);
     }
 
     /// @inheritdoc ICorporateActionsV1
@@ -104,7 +104,7 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
         view
         override
         onlyDelegatecalled
-        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionId, uint256 actionType, uint64 effectiveTime)
     {
         // False positive: tuple pass-through — `return lib.tupleFn(...)` re-emits every
         // component as this function's own return, nothing is discarded.
@@ -118,7 +118,7 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
         view
         override
         onlyDelegatecalled
-        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionId, uint256 actionType, uint64 effectiveTime)
     {
         // False positive: tuple pass-through — `return lib.tupleFn(...)` re-emits every
         // component as this function's own return, nothing is discarded.
@@ -127,35 +127,35 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
     }
 
     /// @inheritdoc ICorporateActionsV1
-    function nextOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
+    function nextOfType(uint256 fromId, uint256 mask, CompletionFilter filter)
         external
         view
         override
         onlyDelegatecalled
-        returns (uint256 nextActionIndex, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 nextActionId, uint256 actionType, uint64 effectiveTime)
     {
         // False positive: tuple pass-through — `return lib.tupleFn(...)` re-emits every
         // component as this function's own return, nothing is discarded.
         // slither-disable-next-line unused-return
-        return LibCorporateActionNode.nextActionOfType(fromIndex, mask, filter);
+        return LibCorporateActionNode.nextActionOfType(fromId, mask, filter);
     }
 
     /// @inheritdoc ICorporateActionsV1
-    function prevOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
+    function prevOfType(uint256 fromId, uint256 mask, CompletionFilter filter)
         external
         view
         override
         onlyDelegatecalled
-        returns (uint256 prevActionIndex, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 prevActionId, uint256 actionType, uint64 effectiveTime)
     {
         // False positive: tuple pass-through — `return lib.tupleFn(...)` re-emits every
         // component as this function's own return, nothing is discarded.
         // slither-disable-next-line unused-return
-        return LibCorporateActionNode.prevActionOfType(fromIndex, mask, filter);
+        return LibCorporateActionNode.prevActionOfType(fromId, mask, filter);
     }
 
     /// @inheritdoc ICorporateActionsV1
-    function getActionParameters(uint256 actionIndex)
+    function getActionParameters(uint256 actionId)
         external
         view
         override
@@ -166,8 +166,8 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
         // Bounds check covers `NODE_NONE` (= type(uint256).max) implicitly:
         // `s.nodes.length` is bounded by realistic schedule cadence, so any
         // sentinel value comparable to max uint256 is >= length.
-        if (actionIndex >= s.nodes.length) revert ActionDoesNotExist(actionIndex);
-        parameters = s.nodes[actionIndex].parameters;
+        if (actionId >= s.nodes.length) revert ActionDoesNotExist(actionId);
+        parameters = s.nodes[actionId].parameters;
     }
 
     /// @dev Authorize via the vault's authorizer. Since this facet is
@@ -179,7 +179,7 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
     /// @param permission The bytes32 permission constant identifying the action.
     /// @param data ABI-encoded action context. For schedule:
     /// `abi.encode(bytes32 typeHash, uint64 effectiveTime, bytes parameters)`.
-    /// For cancel: `abi.encode(uint256 actionIndex)`.
+    /// For cancel: `abi.encode(uint256 actionId)`.
     function _authorize(address user, bytes32 permission, bytes memory data) internal {
         IAuthorizeV1 auth = OffchainAssetReceiptVault(payable(address(this))).authorizer();
         auth.authorize(user, permission, data);

--- a/src/concrete/StoxCorporateActionsFacet.sol
+++ b/src/concrete/StoxCorporateActionsFacet.sol
@@ -104,7 +104,7 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
         view
         override
         onlyDelegatecalled
-        returns (uint256 cursor, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
     {
         // False positive: tuple pass-through — `return lib.tupleFn(...)` re-emits every
         // component as this function's own return, nothing is discarded.
@@ -118,7 +118,7 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
         view
         override
         onlyDelegatecalled
-        returns (uint256 cursor, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
     {
         // False positive: tuple pass-through — `return lib.tupleFn(...)` re-emits every
         // component as this function's own return, nothing is discarded.
@@ -127,35 +127,35 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
     }
 
     /// @inheritdoc ICorporateActionsV1
-    function nextOfType(uint256 cursor, uint256 mask, CompletionFilter filter)
+    function nextOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
         external
         view
         override
         onlyDelegatecalled
-        returns (uint256 nextCursor, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 nextActionIndex, uint256 actionType, uint64 effectiveTime)
     {
         // False positive: tuple pass-through — `return lib.tupleFn(...)` re-emits every
         // component as this function's own return, nothing is discarded.
         // slither-disable-next-line unused-return
-        return LibCorporateActionNode.nextActionOfType(cursor, mask, filter);
+        return LibCorporateActionNode.nextActionOfType(fromIndex, mask, filter);
     }
 
     /// @inheritdoc ICorporateActionsV1
-    function prevOfType(uint256 cursor, uint256 mask, CompletionFilter filter)
+    function prevOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
         external
         view
         override
         onlyDelegatecalled
-        returns (uint256 prevCursor, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 prevActionIndex, uint256 actionType, uint64 effectiveTime)
     {
         // False positive: tuple pass-through — `return lib.tupleFn(...)` re-emits every
         // component as this function's own return, nothing is discarded.
         // slither-disable-next-line unused-return
-        return LibCorporateActionNode.prevActionOfType(cursor, mask, filter);
+        return LibCorporateActionNode.prevActionOfType(fromIndex, mask, filter);
     }
 
     /// @inheritdoc ICorporateActionsV1
-    function getActionParameters(uint256 cursor)
+    function getActionParameters(uint256 actionIndex)
         external
         view
         override
@@ -166,8 +166,8 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
         // Bounds check covers `NODE_NONE` (= type(uint256).max) implicitly:
         // `s.nodes.length` is bounded by realistic schedule cadence, so any
         // sentinel value comparable to max uint256 is >= length.
-        if (cursor >= s.nodes.length) revert ActionDoesNotExist(cursor);
-        parameters = s.nodes[cursor].parameters;
+        if (actionIndex >= s.nodes.length) revert ActionDoesNotExist(actionIndex);
+        parameters = s.nodes[actionIndex].parameters;
     }
 
     /// @dev Authorize via the vault's authorizer. Since this facet is

--- a/src/concrete/StoxReceipt.sol
+++ b/src/concrete/StoxReceipt.sol
@@ -69,18 +69,18 @@ contract StoxReceipt is Receipt {
     /// applied.
     /// @param account The holder whose `(account, id)` migration state changed.
     /// @param id The receipt id.
-    /// @param fromActionIndex The action index the `(account, id)` cursor
+    /// @param fromActionId The action id the `(account, id)` cursor
     /// was at before this migration. The default 0 is the vault's bootstrap
     /// node.
-    /// @param toActionIndex The action index the `(account, id)` cursor is
+    /// @param toActionId The action id the `(account, id)` cursor is
     /// at after this migration.
     /// @param oldBalance The raw stored balance before rasterization.
     /// @param newBalance The raw stored balance after rasterization.
     event ReceiptAccountMigrated(
         address indexed account,
         uint256 indexed id,
-        uint256 fromActionIndex,
-        uint256 toActionIndex,
+        uint256 fromActionId,
+        uint256 toActionId,
         uint256 oldBalance,
         uint256 newBalance
     );

--- a/src/concrete/StoxReceipt.sol
+++ b/src/concrete/StoxReceipt.sol
@@ -69,16 +69,18 @@ contract StoxReceipt is Receipt {
     /// applied.
     /// @param account The holder whose `(account, id)` migration state changed.
     /// @param id The receipt id.
-    /// @param fromCursor The `(account, id)` cursor before this migration.
-    /// The default 0 is the vault's bootstrap node.
-    /// @param toCursor The `(account, id)` cursor after this migration.
+    /// @param fromActionIndex The action index the `(account, id)` cursor
+    /// was at before this migration. The default 0 is the vault's bootstrap
+    /// node.
+    /// @param toActionIndex The action index the `(account, id)` cursor is
+    /// at after this migration.
     /// @param oldBalance The raw stored balance before rasterization.
     /// @param newBalance The raw stored balance after rasterization.
     event ReceiptAccountMigrated(
         address indexed account,
         uint256 indexed id,
-        uint256 fromCursor,
-        uint256 toCursor,
+        uint256 fromActionIndex,
+        uint256 toActionIndex,
         uint256 oldBalance,
         uint256 newBalance
     );

--- a/src/concrete/StoxReceiptVault.sol
+++ b/src/concrete/StoxReceiptVault.sol
@@ -43,13 +43,14 @@ contract StoxReceiptVault is OffchainAssetReceiptVault {
     /// `_migrateAccount`, before the mint / burn / transfer delta is
     /// applied.
     /// @param account The account whose migration state changed.
-    /// @param fromCursor The account's migration cursor before this
-    /// migration. The default 0 corresponds to the bootstrap node (idx 0)
-    /// — every fresh holder starts there because the cursor mapping
-    /// defaults to 0 and bootstrap is identity for splits, so "no
+    /// @param fromActionIndex The action index the account's cursor was at
+    /// before this migration. The default 0 corresponds to the bootstrap
+    /// node (idx 0) — every fresh holder starts there because the cursor
+    /// mapping defaults to 0 and bootstrap is identity for splits, so "no
     /// migration applied" and "migrated through the identity bootstrap"
     /// are the same state.
-    /// @param toCursor The account's migration cursor after this migration.
+    /// @param toActionIndex The action index the account's cursor is at
+    /// after this migration.
     /// @param oldBalance The account's **stored** balance before rasterization
     /// — i.e. the value returned by `LibERC20Storage.underlyingBalance(account)` at
     /// the moment the migration starts, NOT the post-rebase effective balance.
@@ -57,7 +58,7 @@ contract StoxReceiptVault is OffchainAssetReceiptVault {
     /// For a single forward 2x split applied to a pre-rebase stored balance of
     /// 100, this is 200.
     event AccountMigrated(
-        address indexed account, uint256 fromCursor, uint256 toCursor, uint256 oldBalance, uint256 newBalance
+        address indexed account, uint256 fromActionIndex, uint256 toActionIndex, uint256 oldBalance, uint256 newBalance
     );
 
     /// @notice Returns `account`'s ERC20 balance including any pending rebase

--- a/src/concrete/StoxReceiptVault.sol
+++ b/src/concrete/StoxReceiptVault.sol
@@ -43,13 +43,13 @@ contract StoxReceiptVault is OffchainAssetReceiptVault {
     /// `_migrateAccount`, before the mint / burn / transfer delta is
     /// applied.
     /// @param account The account whose migration state changed.
-    /// @param fromActionIndex The action index the account's cursor was at
+    /// @param fromActionId The action id the account's cursor was at
     /// before this migration. The default 0 corresponds to the bootstrap
     /// node (idx 0) — every fresh holder starts there because the cursor
     /// mapping defaults to 0 and bootstrap is identity for splits, so "no
     /// migration applied" and "migrated through the identity bootstrap"
     /// are the same state.
-    /// @param toActionIndex The action index the account's cursor is at
+    /// @param toActionId The action id the account's cursor is at
     /// after this migration.
     /// @param oldBalance The account's **stored** balance before rasterization
     /// — i.e. the value returned by `LibERC20Storage.underlyingBalance(account)` at
@@ -58,7 +58,7 @@ contract StoxReceiptVault is OffchainAssetReceiptVault {
     /// For a single forward 2x split applied to a pre-rebase stored balance of
     /// 100, this is 200.
     event AccountMigrated(
-        address indexed account, uint256 fromActionIndex, uint256 toActionIndex, uint256 oldBalance, uint256 newBalance
+        address indexed account, uint256 fromActionId, uint256 toActionId, uint256 oldBalance, uint256 newBalance
     );
 
     /// @notice Returns `account`'s ERC20 balance including any pending rebase

--- a/src/error/ErrCorporateAction.sol
+++ b/src/error/ErrCorporateAction.sol
@@ -6,10 +6,10 @@ pragma solidity ^0.8.25;
 error EffectiveTimeInPast(uint64 effectiveTime, uint256 currentTime);
 
 /// Thrown when trying to cancel an action whose effectiveTime has passed.
-error ActionAlreadyComplete(uint256 actionIndex);
+error ActionAlreadyComplete(uint256 actionId);
 
 /// Thrown when referencing an action that does not exist.
-error ActionDoesNotExist(uint256 actionIndex);
+error ActionDoesNotExist(uint256 actionId);
 
 /// Thrown when the external type hash has no known bitmap mapping.
 /// @param typeHash The unrecognised external identifier.

--- a/src/interface/ICorporateActionsV1.sol
+++ b/src/interface/ICorporateActionsV1.sol
@@ -258,27 +258,27 @@ interface ICorporateActionsV1 {
     /// `oldBalance` and `newBalance` may be equal when the rasterized
     /// value coincides with the pre-rebase value.
     /// @param account The account whose balance was migrated.
-    /// @param fromCursor The account's migration cursor before this migration.
-    /// @param toCursor The account's migration cursor after this migration.
+    /// @param fromActionIndex The action index the account's cursor was at before this migration.
+    /// @param toActionIndex The action index the account's cursor is at after this migration.
     /// @param oldBalance The stored balance before rasterization.
     /// @param newBalance The stored balance after rasterization.
     event AccountMigrated(
-        address indexed account, uint256 fromCursor, uint256 toCursor, uint256 oldBalance, uint256 newBalance
+        address indexed account, uint256 fromActionIndex, uint256 toActionIndex, uint256 oldBalance, uint256 newBalance
     );
 
     /// @notice Emitted whenever a `(account, id)` pair's receipt-side
     /// migration cursor advances.
     /// @param account The account whose receipt balance was migrated.
     /// @param id The ERC-1155 token ID.
-    /// @param fromCursor The account's migration cursor before this migration.
-    /// @param toCursor The account's migration cursor after this migration.
+    /// @param fromActionIndex The action index the cursor was at before this migration.
+    /// @param toActionIndex The action index the cursor is at after this migration.
     /// @param oldBalance The stored balance before rasterization.
     /// @param newBalance The stored balance after rasterization.
     event ReceiptAccountMigrated(
         address indexed account,
         uint256 indexed id,
-        uint256 fromCursor,
-        uint256 toCursor,
+        uint256 fromActionIndex,
+        uint256 toActionIndex,
         uint256 oldBalance,
         uint256 newBalance
     );
@@ -334,14 +334,14 @@ interface ICorporateActionsV1 {
     ///   passed (the typical choice for oracles reading historical state);
     /// - `PENDING` returns the most recent scheduled action whose effectiveTime
     ///   has not yet passed.
-    /// @return cursor Opaque handle for continued traversal via `prevOfType`.
+    /// @return actionIndex Opaque handle for continued traversal via `prevOfType`.
     /// `NODE_NONE` (`type(uint256).max`) if no matching action exists.
     /// @return actionType The action's bitmap type (0 if none).
     /// @return effectiveTime The action's effective timestamp (0 if none).
     function latestActionOfType(uint256 mask, CompletionFilter filter)
         external
         view
-        returns (uint256 cursor, uint256 actionType, uint64 effectiveTime);
+        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime);
 
     /// @notice Find the earliest action matching a type mask and completion
     /// filter. Entry point for walking the list forward from the head.
@@ -349,19 +349,19 @@ interface ICorporateActionsV1 {
     /// for the validity rules; `InvalidMask` reverts apply here too.
     /// @param filter Completion filter — see `latestActionOfType` for the
     /// semantics of `ALL` / `COMPLETED` / `PENDING`.
-    /// @return cursor Opaque handle for continued traversal via `nextOfType`.
+    /// @return actionIndex Opaque handle for continued traversal via `nextOfType`.
     /// `NODE_NONE` (`type(uint256).max`) if no matching action exists.
     /// @return actionType The action's bitmap type (0 if none).
     /// @return effectiveTime The action's effective timestamp (0 if none).
     function earliestActionOfType(uint256 mask, CompletionFilter filter)
         external
         view
-        returns (uint256 cursor, uint256 actionType, uint64 effectiveTime);
+        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime);
 
-    /// @notice Walk forward from a cursor to the next matching action.
-    /// @param cursor The cursor returned by a previous traversal call.
+    /// @notice Walk forward from an action index to the next matching action.
+    /// @param fromIndex The action index returned by a previous traversal call.
     /// Pass `NODE_NONE` to start from the head of the list (head-inclusive).
-    /// If the action at this cursor has been cancelled since it was
+    /// If the action at this index has been cancelled since it was
     /// obtained, its `next` pointer was set to `NODE_NONE` by
     /// `cancelCorporateAction` and the walk returns `NODE_NONE`
     /// immediately — restart from `earliestActionOfType` to recover the
@@ -369,33 +369,33 @@ interface ICorporateActionsV1 {
     /// @param mask Bitmap mask to filter action types — see `latestActionOfType`
     /// for the validity rules; `InvalidMask` reverts apply here too.
     /// @param filter Completion filter — see `latestActionOfType`.
-    /// @return nextCursor Opaque handle for the next match, or `NODE_NONE`
+    /// @return nextActionIndex Opaque handle for the next match, or `NODE_NONE`
     /// if none.
     /// @return actionType The action's bitmap type (0 if none).
     /// @return effectiveTime The action's effective timestamp (0 if none).
-    function nextOfType(uint256 cursor, uint256 mask, CompletionFilter filter)
+    function nextOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
         external
         view
-        returns (uint256 nextCursor, uint256 actionType, uint64 effectiveTime);
+        returns (uint256 nextActionIndex, uint256 actionType, uint64 effectiveTime);
 
-    /// @notice Walk backward from a cursor to the previous matching action.
-    /// @param cursor The cursor returned by a previous traversal call.
+    /// @notice Walk backward from an action index to the previous matching action.
+    /// @param fromIndex The action index returned by a previous traversal call.
     /// Pass `NODE_NONE` to start from the tail of the list (tail-inclusive).
-    /// If the action at this cursor has been cancelled since it was
+    /// If the action at this index has been cancelled since it was
     /// obtained, its `prev` pointer was set to `NODE_NONE` and the walk
     /// returns `NODE_NONE` immediately — restart from `latestActionOfType`
     /// to recover the new list tail.
     /// @param mask Bitmap mask to filter action types — see `latestActionOfType`
     /// for the validity rules; `InvalidMask` reverts apply here too.
     /// @param filter Completion filter — see `latestActionOfType`.
-    /// @return prevCursor Opaque handle for the previous match, or
+    /// @return prevActionIndex Opaque handle for the previous match, or
     /// `NODE_NONE` if none.
     /// @return actionType The action's bitmap type (0 if none).
     /// @return effectiveTime The action's effective timestamp (0 if none).
-    function prevOfType(uint256 cursor, uint256 mask, CompletionFilter filter)
+    function prevOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
         external
         view
-        returns (uint256 prevCursor, uint256 actionType, uint64 effectiveTime);
+        returns (uint256 prevActionIndex, uint256 actionType, uint64 effectiveTime);
 
     /// @notice Read the ABI-encoded parameters blob for a scheduled or
     /// completed corporate action, given a cursor returned from one of the
@@ -409,9 +409,9 @@ interface ICorporateActionsV1 {
     /// `prevOfType`) before calling this to ensure they know which decoder
     /// to apply.
     ///
-    /// Reverts if `cursor == NODE_NONE` or points outside the current
+    /// Reverts if `actionIndex == NODE_NONE` or points outside the current
     /// nodes array.
-    /// A cursor that points at a cancelled node returns whatever bytes
+    /// An action index pointing at a cancelled node returns whatever bytes
     /// were written at schedule time — cancelled nodes intentionally
     /// retain their `actionType` and `parameters` fields so correct
     /// consumers (who must filter cancelled nodes out via their
@@ -419,7 +419,7 @@ interface ICorporateActionsV1 {
     /// inspect them for debugging. See `LibCorporateAction.cancel` for
     /// the orphan-node invariant.
     ///
-    /// @param cursor The cursor returned by `nextOfType` / `prevOfType`.
+    /// @param actionIndex The action index returned by `nextOfType` / `prevOfType`.
     /// @return parameters The raw ABI-encoded parameters for the action.
-    function getActionParameters(uint256 cursor) external view returns (bytes memory parameters);
+    function getActionParameters(uint256 actionIndex) external view returns (bytes memory parameters);
 }

--- a/src/interface/ICorporateActionsV1.sol
+++ b/src/interface/ICorporateActionsV1.sol
@@ -72,7 +72,7 @@ uint256 constant VALID_ACTION_TYPES_MASK =
 /// indexers that sum `Transfer` events will diverge from `balanceOf` after a
 /// split. Supplement with:
 ///   - `CorporateActionScheduled` + `CorporateActionCancelled`: mirror
-///     these to reconstruct the linked list of `(actionIndex, actionType,
+///     these to reconstruct the linked list of `(actionId, actionType,
 ///     effectiveTime, parameters)`. A split is in effect once
 ///     `block.timestamp >= effectiveTime` for an unscheduled action — no
 ///     on-chain notification fires at that moment. Indexers compute
@@ -216,7 +216,7 @@ uint256 constant VALID_ACTION_TYPES_MASK =
 ///     `effectiveTime` ordering and `prev`/`next` pointers. The default
 ///     policy is "never migrate, always add a new version" — write any
 ///     migration code defensively if that policy ever changes.
-///   - **Type-level pause / disable.** `cancelCorporateAction(actionIndex)`
+///   - **Type-level pause / disable.** `cancelCorporateAction(actionId)`
 ///     unlinks one specific node. There is no "disable action type X
 ///     across the list" primitive; cancelling N pending nodes of type X
 ///     takes N transactions. If a type-level pause becomes operationally
@@ -239,46 +239,46 @@ uint256 constant VALID_ACTION_TYPES_MASK =
 interface ICorporateActionsV1 {
     /// @notice Emitted when a corporate action is successfully scheduled.
     /// @param sender The msg.sender that called `scheduleCorporateAction`.
-    /// @param actionIndex The array index assigned to the new action.
+    /// @param actionId The array index assigned to the new action.
     /// User-scheduled actions start at index 1; index 0 is the lazily-created
     /// bootstrap node and never appears in this event.
     /// @param actionType The bitmap action type (e.g. `ACTION_TYPE_STOCK_SPLIT_V1`).
     /// @param effectiveTime The timestamp at which the action becomes effective.
     event CorporateActionScheduled(
-        address indexed sender, uint256 indexed actionIndex, uint256 actionType, uint64 effectiveTime
+        address indexed sender, uint256 indexed actionId, uint256 actionType, uint64 effectiveTime
     );
 
     /// @notice Emitted when a previously scheduled action is cancelled before
     /// its `effectiveTime`.
     /// @param sender The msg.sender that called `cancelCorporateAction`.
-    /// @param actionIndex The action index that was cancelled.
-    event CorporateActionCancelled(address indexed sender, uint256 indexed actionIndex);
+    /// @param actionId The action id that was cancelled.
+    event CorporateActionCancelled(address indexed sender, uint256 indexed actionId);
 
     /// @notice Emitted whenever an account's migration cursor advances.
     /// `oldBalance` and `newBalance` may be equal when the rasterized
     /// value coincides with the pre-rebase value.
     /// @param account The account whose balance was migrated.
-    /// @param fromActionIndex The action index the account's cursor was at before this migration.
-    /// @param toActionIndex The action index the account's cursor is at after this migration.
+    /// @param fromActionId The action id the account's cursor was at before this migration.
+    /// @param toActionId The action id the account's cursor is at after this migration.
     /// @param oldBalance The stored balance before rasterization.
     /// @param newBalance The stored balance after rasterization.
     event AccountMigrated(
-        address indexed account, uint256 fromActionIndex, uint256 toActionIndex, uint256 oldBalance, uint256 newBalance
+        address indexed account, uint256 fromActionId, uint256 toActionId, uint256 oldBalance, uint256 newBalance
     );
 
     /// @notice Emitted whenever a `(account, id)` pair's receipt-side
     /// migration cursor advances.
     /// @param account The account whose receipt balance was migrated.
     /// @param id The ERC-1155 token ID.
-    /// @param fromActionIndex The action index the cursor was at before this migration.
-    /// @param toActionIndex The action index the cursor is at after this migration.
+    /// @param fromActionId The action id the cursor was at before this migration.
+    /// @param toActionId The action id the cursor is at after this migration.
     /// @param oldBalance The stored balance before rasterization.
     /// @param newBalance The stored balance after rasterization.
     event ReceiptAccountMigrated(
         address indexed account,
         uint256 indexed id,
-        uint256 fromActionIndex,
-        uint256 toActionIndex,
+        uint256 fromActionId,
+        uint256 toActionId,
         uint256 oldBalance,
         uint256 newBalance
     );
@@ -303,16 +303,16 @@ interface ICorporateActionsV1 {
     /// the future: `effectiveTime > block.timestamp`. Scheduling at the exact
     /// current timestamp reverts with `EffectiveTimeInPast`.
     /// @param parameters ABI-encoded parameters specific to the action type.
-    /// @return actionIndex Handle for the scheduled action.
+    /// @return actionId Handle for the scheduled action.
     function scheduleCorporateAction(bytes32 typeHash, uint64 effectiveTime, bytes calldata parameters)
         external
-        returns (uint256 actionIndex);
+        returns (uint256 actionId);
 
     /// @notice Cancel a scheduled action. Only valid while the action is
     /// strictly pending: `block.timestamp < effectiveTime`. At or after the
     /// exact `effectiveTime`, cancel reverts with `ActionAlreadyComplete`.
-    /// @param actionIndex The scheduled action handle to cancel.
-    function cancelCorporateAction(uint256 actionIndex) external;
+    /// @param actionId The scheduled action handle to cancel.
+    function cancelCorporateAction(uint256 actionId) external;
 
     /// @notice Count of all completed corporate actions. An action is complete
     /// when `block.timestamp >= effectiveTime` — i.e. at or after the exact
@@ -334,14 +334,14 @@ interface ICorporateActionsV1 {
     ///   passed (the typical choice for oracles reading historical state);
     /// - `PENDING` returns the most recent scheduled action whose effectiveTime
     ///   has not yet passed.
-    /// @return actionIndex Opaque handle for continued traversal via `prevOfType`.
+    /// @return actionId Opaque handle for continued traversal via `prevOfType`.
     /// `NODE_NONE` (`type(uint256).max`) if no matching action exists.
     /// @return actionType The action's bitmap type (0 if none).
     /// @return effectiveTime The action's effective timestamp (0 if none).
     function latestActionOfType(uint256 mask, CompletionFilter filter)
         external
         view
-        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime);
+        returns (uint256 actionId, uint256 actionType, uint64 effectiveTime);
 
     /// @notice Find the earliest action matching a type mask and completion
     /// filter. Entry point for walking the list forward from the head.
@@ -349,17 +349,17 @@ interface ICorporateActionsV1 {
     /// for the validity rules; `InvalidMask` reverts apply here too.
     /// @param filter Completion filter — see `latestActionOfType` for the
     /// semantics of `ALL` / `COMPLETED` / `PENDING`.
-    /// @return actionIndex Opaque handle for continued traversal via `nextOfType`.
+    /// @return actionId Opaque handle for continued traversal via `nextOfType`.
     /// `NODE_NONE` (`type(uint256).max`) if no matching action exists.
     /// @return actionType The action's bitmap type (0 if none).
     /// @return effectiveTime The action's effective timestamp (0 if none).
     function earliestActionOfType(uint256 mask, CompletionFilter filter)
         external
         view
-        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime);
+        returns (uint256 actionId, uint256 actionType, uint64 effectiveTime);
 
-    /// @notice Walk forward from an action index to the next matching action.
-    /// @param fromIndex The action index returned by a previous traversal call.
+    /// @notice Walk forward from an action id to the next matching action.
+    /// @param fromId The action id returned by a previous traversal call.
     /// Pass `NODE_NONE` to start from the head of the list (head-inclusive).
     /// If the action at this index has been cancelled since it was
     /// obtained, its `next` pointer was set to `NODE_NONE` by
@@ -369,17 +369,17 @@ interface ICorporateActionsV1 {
     /// @param mask Bitmap mask to filter action types — see `latestActionOfType`
     /// for the validity rules; `InvalidMask` reverts apply here too.
     /// @param filter Completion filter — see `latestActionOfType`.
-    /// @return nextActionIndex Opaque handle for the next match, or `NODE_NONE`
+    /// @return nextActionId Opaque handle for the next match, or `NODE_NONE`
     /// if none.
     /// @return actionType The action's bitmap type (0 if none).
     /// @return effectiveTime The action's effective timestamp (0 if none).
-    function nextOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
+    function nextOfType(uint256 fromId, uint256 mask, CompletionFilter filter)
         external
         view
-        returns (uint256 nextActionIndex, uint256 actionType, uint64 effectiveTime);
+        returns (uint256 nextActionId, uint256 actionType, uint64 effectiveTime);
 
-    /// @notice Walk backward from an action index to the previous matching action.
-    /// @param fromIndex The action index returned by a previous traversal call.
+    /// @notice Walk backward from an action id to the previous matching action.
+    /// @param fromId The action id returned by a previous traversal call.
     /// Pass `NODE_NONE` to start from the tail of the list (tail-inclusive).
     /// If the action at this index has been cancelled since it was
     /// obtained, its `prev` pointer was set to `NODE_NONE` and the walk
@@ -388,14 +388,14 @@ interface ICorporateActionsV1 {
     /// @param mask Bitmap mask to filter action types — see `latestActionOfType`
     /// for the validity rules; `InvalidMask` reverts apply here too.
     /// @param filter Completion filter — see `latestActionOfType`.
-    /// @return prevActionIndex Opaque handle for the previous match, or
+    /// @return prevActionId Opaque handle for the previous match, or
     /// `NODE_NONE` if none.
     /// @return actionType The action's bitmap type (0 if none).
     /// @return effectiveTime The action's effective timestamp (0 if none).
-    function prevOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
+    function prevOfType(uint256 fromId, uint256 mask, CompletionFilter filter)
         external
         view
-        returns (uint256 prevActionIndex, uint256 actionType, uint64 effectiveTime);
+        returns (uint256 prevActionId, uint256 actionType, uint64 effectiveTime);
 
     /// @notice Read the ABI-encoded parameters blob for a scheduled or
     /// completed corporate action, given a cursor returned from one of the
@@ -409,9 +409,9 @@ interface ICorporateActionsV1 {
     /// `prevOfType`) before calling this to ensure they know which decoder
     /// to apply.
     ///
-    /// Reverts if `actionIndex == NODE_NONE` or points outside the current
+    /// Reverts if `actionId == NODE_NONE` or points outside the current
     /// nodes array.
-    /// An action index pointing at a cancelled node returns whatever bytes
+    /// An action id pointing at a cancelled node returns whatever bytes
     /// were written at schedule time — cancelled nodes intentionally
     /// retain their `actionType` and `parameters` fields so correct
     /// consumers (who must filter cancelled nodes out via their
@@ -419,7 +419,7 @@ interface ICorporateActionsV1 {
     /// inspect them for debugging. See `LibCorporateAction.cancel` for
     /// the orphan-node invariant.
     ///
-    /// @param actionIndex The action index returned by `nextOfType` / `prevOfType`.
+    /// @param actionId The action id returned by `nextOfType` / `prevOfType`.
     /// @return parameters The raw ABI-encoded parameters for the action.
-    function getActionParameters(uint256 actionIndex) external view returns (bytes memory parameters);
+    function getActionParameters(uint256 actionId) external view returns (bytes memory parameters);
 }

--- a/src/interface/ICorporateActionsV1.sol
+++ b/src/interface/ICorporateActionsV1.sol
@@ -130,6 +130,27 @@ uint256 constant VALID_ACTION_TYPES_MASK =
 ///
 /// QUERYING CORPORATE ACTION STATE:
 ///
+/// **`actionId` vs `cursor` naming.** Both refer to the same `uint256`
+/// value at runtime — but the names mark two different roles:
+///
+/// - `actionId` is the **opaque handle** as it crosses the API boundary
+///   (params, returns, event fields). External consumers must not reason
+///   about ordering, sequencing, or arithmetic on these values; an action
+///   id is only meaningful when fed back into another API call. Cancelled
+///   actions leave gaps in the underlying numbering, the bootstrap
+///   occupies the lowest id, and future versions may further re-shape
+///   the space.
+/// - `cursor` is the conventional **local-variable name** for a walking
+///   pointer that holds the current action id during a traversal loop.
+///   The example below uses `cursor` for exactly this reason — it's a
+///   live position in a walk, not a stable identifier.
+///
+/// Storage variables that track per-account walk progress over time
+/// (`accountMigrationCursor`, `accountIdCursor`,
+/// `totalSupplyLatestCursor`) follow the cursor convention: they hold a
+/// position in the sequence, not an identifier callers should reason
+/// about.
+///
 /// The vault exposes stock split state through this interface:
 ///
 /// ```solidity

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -122,11 +122,11 @@ library LibCorporateAction {
 
     /// @notice Insert a node into the list maintaining time ordering.
     /// effectiveTime must be strictly in the future.
-    /// @return actionIndex The array index of the new node. Index 0 is the
+    /// @return actionId The array index of the new node. Index 0 is the
     /// bootstrap node, so user-scheduled actions have index >= 1.
     function schedule(uint256 actionType, uint64 effectiveTime, bytes memory parameters)
         internal
-        returns (uint256 actionIndex)
+        returns (uint256 actionId)
     {
         if (effectiveTime <= block.timestamp) {
             revert EffectiveTimeInPast(effectiveTime, block.timestamp);
@@ -136,11 +136,11 @@ library LibCorporateAction {
 
         _ensureBootstrap(s);
 
-        // Push new node — its array position is the actionIndex.
+        // Push new node — its array position is the actionId.
         s.nodes.push();
-        actionIndex = s.nodes.length - 1;
+        actionId = s.nodes.length - 1;
 
-        CorporateActionNode storage node = s.nodes[actionIndex];
+        CorporateActionNode storage node = s.nodes[actionId];
         node.actionType = actionType;
         node.effectiveTime = effectiveTime;
         node.parameters = parameters;
@@ -150,7 +150,7 @@ library LibCorporateAction {
         node.prev = NODE_NONE;
         node.next = NODE_NONE;
 
-        _insertOrdered(s, actionIndex, effectiveTime);
+        _insertOrdered(s, actionId, effectiveTime);
     }
 
     /// @dev Lazily create the index-0 init/bootstrap node on first `schedule`
@@ -266,7 +266,7 @@ library LibCorporateAction {
     /// (unlinked here).
     ///
     /// @dev `node.effectiveTime = 0` below is the double-cancel guard. A
-    /// second call to `cancel(actionIndex)` on an already-cancelled node
+    /// second call to `cancel(actionId)` on an already-cancelled node
     /// is caught by the `node.effectiveTime == 0` check at the top of
     /// this function. Without the zero-assignment, a double-cancel would:
     /// (1) pass the effectiveTime-in-past check because the original
@@ -276,16 +276,16 @@ library LibCorporateAction {
     /// Catastrophic, silent state corruption.
     /// `testCancelAlreadyCancelledReverts` pins the guard — do not remove
     /// the test or the zero assignment together.
-    function cancel(uint256 actionIndex) internal {
+    function cancel(uint256 actionId) internal {
         CorporateActionStorage storage s = getStorage();
-        if (actionIndex >= s.nodes.length) revert ActionDoesNotExist(actionIndex);
+        if (actionId >= s.nodes.length) revert ActionDoesNotExist(actionId);
 
-        CorporateActionNode storage node = s.nodes[actionIndex];
+        CorporateActionNode storage node = s.nodes[actionId];
 
-        if (node.effectiveTime == 0) revert ActionDoesNotExist(actionIndex);
+        if (node.effectiveTime == 0) revert ActionDoesNotExist(actionId);
         // Bootstrap (idx 0) has effectiveTime == block.timestamp at creation,
         // so this guard rejects `cancel(0)` without a special case.
-        if (node.effectiveTime <= block.timestamp) revert ActionAlreadyComplete(actionIndex);
+        if (node.effectiveTime <= block.timestamp) revert ActionAlreadyComplete(actionId);
 
         uint256 prevId = node.prev;
         uint256 nextId = node.next;

--- a/src/lib/LibCorporateActionNode.sol
+++ b/src/lib/LibCorporateActionNode.sol
@@ -8,7 +8,7 @@ import {InvalidMask} from "../error/ErrCorporateAction.sol";
 
 /// @dev Sentinel value for "no node" in `CorporateActionNode.prev`,
 /// `CorporateActionNode.next`, return values from `nextOfType` /
-/// `prevOfType`, and the `fromIndex` argument to those functions (where
+/// `prevOfType`, and the `fromId` argument to those functions (where
 /// it means "start from head/tail inclusive"). Index 0 is reserved for
 /// the bootstrap node, which is a real walkable node — value-level
 /// disambiguation via `type(uint256).max` keeps "no node" distinct from
@@ -65,20 +65,20 @@ enum CompletionFilter {
 /// Functions accept and return node indices rather than storage references,
 /// so callers always know the position of the node they are working with.
 library LibCorporateActionNode {
-    /// @notice Walk forward from `fromIndex`, returning the index of the next
+    /// @notice Walk forward from `fromId`, returning the index of the next
     /// node matching the type mask and completion filter.
     ///
-    /// @param fromIndex Start after this node (exclusive). Pass `NODE_NONE`
+    /// @param fromId Start after this node (exclusive). Pass `NODE_NONE`
     /// to start from the head of the list (head-inclusive).
     /// @param mask Bitmap mask to filter action types. Use type(uint256).max
     /// to match all types.
     /// @param filter Completion filter: ALL, COMPLETED, or PENDING.
     /// @return The index of the next matching node, or `NODE_NONE` if none.
-    function nextOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter) internal view returns (uint256) {
+    function nextOfType(uint256 fromId, uint256 mask, CompletionFilter filter) internal view returns (uint256) {
         if (mask & VALID_ACTION_TYPES_MASK == 0) revert InvalidMask();
         LibCorporateAction.CorporateActionStorage storage s = LibCorporateAction.getStorage();
         if (s.nodes.length == 0) return NODE_NONE;
-        uint256 current = fromIndex == NODE_NONE ? s.head : s.nodes[fromIndex].next;
+        uint256 current = fromId == NODE_NONE ? s.head : s.nodes[fromId].next;
 
         // Dispatch on `filter` once. The list is ordered by effectiveTime
         // and completion is monotonic across that order, so each branch
@@ -93,19 +93,19 @@ library LibCorporateActionNode {
         return walkForwardMatchingMask(s, current, mask);
     }
 
-    /// @notice Walk backward from `fromIndex`, returning the index of the
+    /// @notice Walk backward from `fromId`, returning the index of the
     /// previous node matching the type mask and completion filter.
     ///
-    /// @param fromIndex Start before this node (exclusive). Pass `NODE_NONE`
+    /// @param fromId Start before this node (exclusive). Pass `NODE_NONE`
     /// to start from the tail of the list (tail-inclusive).
     /// @param mask Bitmap mask to filter action types.
     /// @param filter Completion filter: ALL, COMPLETED, or PENDING.
     /// @return The index of the previous matching node, or `NODE_NONE` if none.
-    function prevOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter) internal view returns (uint256) {
+    function prevOfType(uint256 fromId, uint256 mask, CompletionFilter filter) internal view returns (uint256) {
         if (mask & VALID_ACTION_TYPES_MASK == 0) revert InvalidMask();
         LibCorporateAction.CorporateActionStorage storage s = LibCorporateAction.getStorage();
         if (s.nodes.length == 0) return NODE_NONE;
-        uint256 current = fromIndex == NODE_NONE ? s.tail : s.nodes[fromIndex].prev;
+        uint256 current = fromId == NODE_NONE ? s.tail : s.nodes[fromId].prev;
 
         // Mirror of `nextOfType`'s dispatch, walking backward from the tail.
         // The pending segment sits at the tail end and the completed segment
@@ -216,13 +216,13 @@ library LibCorporateActionNode {
         return current;
     }
 
-    /// @dev Resolve an action index to `(actionType, effectiveTime)`. Returns
-    /// `(0, 0)` when `actionIndex == NODE_NONE` without touching storage, so
+    /// @dev Resolve an action id to `(actionType, effectiveTime)`. Returns
+    /// `(0, 0)` when `actionId == NODE_NONE` without touching storage, so
     /// callers can thread "none found" results through without a branch of
     /// their own.
-    function resolve(uint256 actionIndex) private view returns (uint256 actionType, uint64 effectiveTime) {
-        if (actionIndex != NODE_NONE) {
-            CorporateActionNode storage node = LibCorporateAction.getStorage().nodes[actionIndex];
+    function resolve(uint256 actionId) private view returns (uint256 actionType, uint64 effectiveTime) {
+        if (actionId != NODE_NONE) {
+            CorporateActionNode storage node = LibCorporateAction.getStorage().nodes[actionId];
             actionType = node.actionType;
             effectiveTime = node.effectiveTime;
         }
@@ -232,39 +232,39 @@ library LibCorporateActionNode {
     function latestActionOfType(uint256 mask, CompletionFilter filter)
         internal
         view
-        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionId, uint256 actionType, uint64 effectiveTime)
     {
-        actionIndex = prevOfType(NODE_NONE, mask, filter);
-        (actionType, effectiveTime) = resolve(actionIndex);
+        actionId = prevOfType(NODE_NONE, mask, filter);
+        (actionType, effectiveTime) = resolve(actionId);
     }
 
     /// @notice Earliest action matching `mask` and `filter`, resolved with metadata.
     function earliestActionOfType(uint256 mask, CompletionFilter filter)
         internal
         view
-        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionId, uint256 actionType, uint64 effectiveTime)
     {
-        actionIndex = nextOfType(NODE_NONE, mask, filter);
-        (actionType, effectiveTime) = resolve(actionIndex);
+        actionId = nextOfType(NODE_NONE, mask, filter);
+        (actionType, effectiveTime) = resolve(actionId);
     }
 
-    /// @notice Next matching action after `fromIndex`, resolved with metadata.
-    function nextActionOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
+    /// @notice Next matching action after `fromId`, resolved with metadata.
+    function nextActionOfType(uint256 fromId, uint256 mask, CompletionFilter filter)
         internal
         view
-        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionId, uint256 actionType, uint64 effectiveTime)
     {
-        actionIndex = nextOfType(fromIndex, mask, filter);
-        (actionType, effectiveTime) = resolve(actionIndex);
+        actionId = nextOfType(fromId, mask, filter);
+        (actionType, effectiveTime) = resolve(actionId);
     }
 
-    /// @notice Previous matching action before `fromIndex`, resolved with metadata.
-    function prevActionOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
+    /// @notice Previous matching action before `fromId`, resolved with metadata.
+    function prevActionOfType(uint256 fromId, uint256 mask, CompletionFilter filter)
         internal
         view
-        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionId, uint256 actionType, uint64 effectiveTime)
     {
-        actionIndex = prevOfType(fromIndex, mask, filter);
-        (actionType, effectiveTime) = resolve(actionIndex);
+        actionId = prevOfType(fromId, mask, filter);
+        (actionType, effectiveTime) = resolve(actionId);
     }
 }

--- a/src/lib/LibCorporateActionNode.sol
+++ b/src/lib/LibCorporateActionNode.sol
@@ -216,13 +216,13 @@ library LibCorporateActionNode {
         return current;
     }
 
-    /// @dev Resolve a cursor to `(actionType, effectiveTime)`. Returns
-    /// `(0, 0)` when `cursor == NODE_NONE` without touching storage, so
+    /// @dev Resolve an action index to `(actionType, effectiveTime)`. Returns
+    /// `(0, 0)` when `actionIndex == NODE_NONE` without touching storage, so
     /// callers can thread "none found" results through without a branch of
     /// their own.
-    function resolve(uint256 cursor) private view returns (uint256 actionType, uint64 effectiveTime) {
-        if (cursor != NODE_NONE) {
-            CorporateActionNode storage node = LibCorporateAction.getStorage().nodes[cursor];
+    function resolve(uint256 actionIndex) private view returns (uint256 actionType, uint64 effectiveTime) {
+        if (actionIndex != NODE_NONE) {
+            CorporateActionNode storage node = LibCorporateAction.getStorage().nodes[actionIndex];
             actionType = node.actionType;
             effectiveTime = node.effectiveTime;
         }
@@ -232,39 +232,39 @@ library LibCorporateActionNode {
     function latestActionOfType(uint256 mask, CompletionFilter filter)
         internal
         view
-        returns (uint256 cursor, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
     {
-        cursor = prevOfType(NODE_NONE, mask, filter);
-        (actionType, effectiveTime) = resolve(cursor);
+        actionIndex = prevOfType(NODE_NONE, mask, filter);
+        (actionType, effectiveTime) = resolve(actionIndex);
     }
 
     /// @notice Earliest action matching `mask` and `filter`, resolved with metadata.
     function earliestActionOfType(uint256 mask, CompletionFilter filter)
         internal
         view
-        returns (uint256 cursor, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
     {
-        cursor = nextOfType(NODE_NONE, mask, filter);
-        (actionType, effectiveTime) = resolve(cursor);
+        actionIndex = nextOfType(NODE_NONE, mask, filter);
+        (actionType, effectiveTime) = resolve(actionIndex);
     }
 
-    /// @notice Next matching action after `fromCursor`, resolved with metadata.
-    function nextActionOfType(uint256 fromCursor, uint256 mask, CompletionFilter filter)
+    /// @notice Next matching action after `fromIndex`, resolved with metadata.
+    function nextActionOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
         internal
         view
-        returns (uint256 cursor, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
     {
-        cursor = nextOfType(fromCursor, mask, filter);
-        (actionType, effectiveTime) = resolve(cursor);
+        actionIndex = nextOfType(fromIndex, mask, filter);
+        (actionType, effectiveTime) = resolve(actionIndex);
     }
 
-    /// @notice Previous matching action before `fromCursor`, resolved with metadata.
-    function prevActionOfType(uint256 fromCursor, uint256 mask, CompletionFilter filter)
+    /// @notice Previous matching action before `fromIndex`, resolved with metadata.
+    function prevActionOfType(uint256 fromIndex, uint256 mask, CompletionFilter filter)
         internal
         view
-        returns (uint256 cursor, uint256 actionType, uint64 effectiveTime)
+        returns (uint256 actionIndex, uint256 actionType, uint64 effectiveTime)
     {
-        cursor = prevOfType(fromCursor, mask, filter);
-        (actionType, effectiveTime) = resolve(cursor);
+        actionIndex = prevOfType(fromIndex, mask, filter);
+        (actionType, effectiveTime) = resolve(actionIndex);
     }
 }


### PR DESCRIPTION
## Summary

Implements #128: rename `cursor` → `actionId` on the public API, treating the value as an opaque handle (ERC721/1155 `tokenId` precedent). Also corrects the existing pre-existing `actionIndex` usage on schedule/cancel — "index" implied sequential array behavior consumers might reason about; "id" makes the opacity contract explicit.

**Renames:**
- `nextOfType` / `prevOfType` first param: `cursor` → `fromId`
- `nextOfType` return: `nextCursor` → `nextActionId`
- `prevOfType` return: `prevCursor` → `prevActionId`
- `latestActionOfType` / `earliestActionOfType` return: `cursor` → `actionId`
- `getActionParameters` param: `cursor` → `actionId`
- `schedule` / `cancel` / `CorporateActionScheduled` / `CorporateActionCancelled`: `actionIndex` → `actionId` (pre-existing misnaming)
- `AccountMigrated` / `ReceiptAccountMigrated` event fields: `fromCursor` → `fromActionId`, `toCursor` → `toActionId`
- Errors `ActionAlreadyComplete` / `ActionDoesNotExist`: param `actionIndex` → `actionId`
- `LibCorporateActionNode` internal fns matching the interface shape

**Out of scope** (per #128 carve-out — legitimately called `cursor`):
- `accountMigrationCursor` / `accountIdCursor` / `totalSupplyLatestCursor` storage
- `LibRebase` / `LibReceiptRebase` `migratedBalance` internal params (cursor as local walk variable)
- Caller code locals (per the issue's "free to assign into a local called cursor" rule)

## Bytecode impact

Zero. Event sig keccaks use type strings, not param names. `bytecode_hash = "none"` + `cbor_metadata = false` keep param-name changes out of deployment bytecode. The pointer codehash suite (`testCodehash*` / `testCreationCode*` / `testRuntimeCode*`) passes without pointer regen.

## Test plan
- [x] full suite green (497/497 pass)
- [x] pointer codehash tests confirm no bytecode change
- [ ] static analysis (CI)
- [ ] legal (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)