### PR TITLE
docs: fix stale cursor doc in NatSpec (#128)

### DIFF
--- a/src/interface/ICorporateActionsV1.sol
+++ b/src/interface/ICorporateActionsV1.sol
@@ -419,14 +419,14 @@ interface ICorporateActionsV1 {
         returns (uint256 prevActionId, uint256 actionType, uint64 effectiveTime);
 
     /// @notice Read the ABI-encoded parameters blob for a scheduled or
-    /// completed corporate action, given a cursor returned from one of the
-    /// traversal getters.
+    /// completed corporate action, given an `actionId` returned from one
+    /// of the traversal getters.
     ///
     /// @dev Intended for cross-contract consumers that need to apply the
     /// action (e.g. the receipt contract reading a stock split multiplier
     /// during its own rebase walk). For stock splits, the returned bytes
     /// decode to a single `Float` via `LibStockSplit.decodeParametersV1`.
-    /// Consumers should mask the cursor's `actionType` (via `nextOfType` /
+    /// Consumers should mask the action's `actionType` (via `nextOfType` /
     /// `prevOfType`) before calling this to ensure they know which decoder
     /// to apply.
     ///

--- a/src/lib/LibCorporateActionReceipt.sol
+++ b/src/lib/LibCorporateActionReceipt.sol
@@ -52,10 +52,13 @@ library LibCorporateActionReceipt {
     /// (`testReceiptStorageLayoutPin`) must be extended in every later PR
     /// that appends a new field.
     struct CorporateActionReceiptStorage {
-        /// Per-(holder, id) migration cursor — the 1-based index of the
-        /// last stock split node this `(holder, id)` pair was migrated
-        /// through, as seen on the vault's corporate-action linked list.
-        /// 0 = never migrated.
+        /// Per-(holder, id) migration cursor — the action id of the last
+        /// migration node this `(holder, id)` pair was migrated through,
+        /// as seen on the vault's corporate-action linked list. The
+        /// default 0 corresponds to the vault's bootstrap node (idx 0,
+        /// identity for splits), so a fresh `(holder, id)` pair's default
+        /// cursor of 0 is semantically equivalent to "no real migration
+        /// applied yet".
         mapping(address holder => mapping(uint256 id => uint256 cursor)) accountIdCursor;
     }
 


### PR DESCRIPTION
## Summary

Doc-only fixups found while auditing remaining cursor uses after #139 / #140.

**Fixes:**
- \`ICorporateActionsV1.getActionParameters\` NatSpec described the input as "a cursor returned from one of the traversal getters" — but the API return is data crossing the boundary, so it's an \`actionId\` per the rename convention. Same fix on the "mask the cursor's actionType" line below.
- \`LibCorporateActionReceipt.accountIdCursor\` comment claimed "1-based index" with "0 = never migrated". Stale post-PR-124: indexing is 0-based and \`cursor == 0\` is the bootstrap node (identity for splits), semantically "no real migration applied yet".

No code changes, no bytecode impact.

After this lands, #128 can close — every remaining \`cursor\` reference in src/ is either a storage variable holding state-machine progress over time, a local variable during a walk, or descriptive prose about the cursor concept. All legitimate per the convention documented in the interface NatSpec.

## Test plan
- [ ] static analysis (CI)
- [ ] legal (CI)
- [x] no test changes — doc only

🤖 Generated with [Claude Code](https://claude.com/claude-code)