### PR TITLE
DO NOT MERGE — experiment: enable via_ir to measure size impact (#144)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@
 solc = "0.8.25"
 optimizer = true
 optimizer_runs = 100000
+via_ir = true
 
 evm_version = "cancun"
 


### PR DESCRIPTION
**DO NOT MERGE.** Experiment branch attached to #144 so the negative result has a PR-shaped record.

## TL;DR

`via_ir = true` makes `StoxReceiptVault` **larger**, not smaller. The contract that was already over EIP-170 (#90) gets +1,852 bytes more.

## Measurement

| Contract | Legacy (route 0) | IR (route 1) | Δ |
|---|---|---|---|
| StoxReceiptVault | 26,134 | **27,986** | **+1,852 (worse)** |
| TestStoxReceiptVault | 27,699 | 28,354 | +655 (worse) |
| StoxCorporateActionsFacet | 9,361 | 8,437 | -924 (better) |
| StoxWrappedTokenVault | 8,685 | 8,631 | -54 |
| StoxReceipt | 15,642 | 15,919 | +277 |

## Why

The IR pipeline aggressively monomorphises and inlines for runtime gas at high `optimizer_runs` (100k). Vault has deep inheritance + heavy inlining that the IR optimiser further inlines rather than collapses. With `optimizer_runs = 1` IR could plausibly invert (separate measurement; that's a different lever already listed in #90).

## Discard signal

#144 specified: "If size delta is <500 bytes, IR alone won't close the gap..." — actual delta is **+1,852 worse**, so even more conclusively a no-go on this lever.

## What to do instead

Per #90's remaining options:
- Move more logic to `StoxCorporateActionsFacet` (extract from vault).
- Lower `optimizer_runs` (deploy-size vs runtime-gas tradeoff).
- Lift OZ inheritance to library calls.

Closing this PR after merging is **not the plan**. It will be closed as a "tried, didn't work" experiment, and #144 is already closed with the same finding.
