### PR TITLE
docs: drop Directory Structure section from README (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,26 +96,6 @@ is delegatecalled by the vault. Key design choices:
 See `ICorporateActionsV1` NatSpec for the full external API and integrator
 guidance, and `docs/GLOSSARY.md` for domain terms.
 
-### Directory Structure
-
-- `src/concrete/` — StoxReceipt, StoxReceiptVault, StoxWrappedTokenVault,
-  StoxWrappedTokenVaultBeacon, StoxCorporateActionsFacet
-- `src/concrete/authorize/` — Authorizer implementations
-- `src/concrete/deploy/` — Deployer contracts (unified deployer, beacon set
-  deployers)
-- `src/interface/` — Versioned interfaces (`ICorporateActionsV1`,
-  `IStoxUnifiedDeployerV1`, `IStoxWrappedTokenVaultBeaconSetDeployerV1`)
-- `src/error/` — Shared error definitions (`ErrCorporateAction`, `ErrRebase`,
-  `ErrStockSplit`)
-- `src/lib/` — Libraries (corporate actions, rebase, storage access, production
-  addresses)
-- `src/generated/` — Zoltu deterministic deployment pointer files
-- `script/` — Forge deployment scripts
-- `test/` — Foundry tests (unit, fuzz, invariant, fork)
-- `docs/` — Domain glossary
-- `lib/` — Git submodule dependencies (rain.vats, rain.deploy,
-  rain.extrospection, rain.tofu.erc20-decimals)
-
 ## License
 
 LicenseRef-DCL-1.0 (DecentraLicense). REUSE-compliant.


### PR DESCRIPTION
Closes #97. Removes the 19-line directory listing — re-derivable from `ls`/GitHub tree, and historically drifts under change pressure (PR #27 landed with stale entries). Architecture diagram and corporate-actions overview kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)