### PR TITLE
test: pin no-metamorphic-risk on prod V1 implementations (#112)

### DIFF
--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -18,6 +18,7 @@ import {
     ERC1967_BEACON_SLOT,
     LibExtrospectERC1967BeaconProxy
 } from "rain.extrospection/lib/LibExtrospectERC1967BeaconProxy.sol";
+import {LibExtrospectMetamorphic} from "rain.extrospection/lib/LibExtrospectMetamorphic.sol";
 
 /// @title LibProdTokensBaseTest
 /// @notice Fork tests verifying production token instances on Base.
@@ -143,6 +144,62 @@ contract LibProdTokensBaseTest is Test {
             IERC4626(wrappedTokenVault).totalAssets(),
             IERC20Metadata(receiptVault).totalSupply(),
             "wrapped vault totalAssets > receipt vault totalSupply"
+        );
+    }
+
+    /// Pin the metamorphic-risk surface of the prod V1 implementations.
+    /// `LibExtrospectMetamorphic.scanMetamorphicRisk` returns a bitmap of
+    /// reachable opcodes from the metamorphic set (SELFDESTRUCT,
+    /// DELEGATECALL, CALLCODE, CREATE, CREATE2 — bits 0xFF, 0xF4, 0xF2,
+    /// 0xF0, 0xF5 in the all-opcodes bitmap). The codehash pin in
+    /// `checkTokenSet` answers "what bytecode is at this address now";
+    /// this test answers "what redeployment surface does that bytecode
+    /// expose".
+    ///
+    /// Empirically, all three V1 implementations have only DELEGATECALL
+    /// reachable (bit 244 = `1 << 244`). DELEGATECALL is expected because
+    /// the implementations are OZ Upgradeable beacon-proxy targets and
+    /// the upgrade / call machinery embedded in the implementation
+    /// contains delegatecall sites. The pin captures the currently-known
+    /// shape — any change (a new metamorphic op appearing, or
+    /// DELEGATECALL going away) trips the test and forces an explicit
+    /// re-evaluation.
+    ///
+    /// Linear bytecode scan is gas-intensive — `rain.extrospection`
+    /// algorithms are intended for offchain / fork-test use, which this
+    /// test is.
+    /// Bitmap pin for `STOX_RECEIPT_VAULT_IMPLEMENTATION`: only DELEGATECALL
+    /// (opcode 0xF4, bit 244) is reachable. The receipt vault implementation
+    /// contains delegatecall sites from the OZ Upgradeable inheritance chain
+    /// (and/or ERC2771 forwarder machinery). Receipt and wrapped-vault
+    /// implementations are clean (0 — no metamorphic ops reachable). Any
+    /// drift in either direction trips the corresponding assertion.
+    uint256 constant METAMORPHIC_RISK_DELEGATECALL_ONLY = 1 << 244;
+
+    function testProdReceiptImplementationMetamorphicRiskPinned() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            LibExtrospectMetamorphic.scanMetamorphicRisk(LibProdDeployV1.STOX_RECEIPT_IMPLEMENTATION.code),
+            0,
+            "STOX_RECEIPT_IMPLEMENTATION metamorphic surface drifted"
+        );
+    }
+
+    function testProdReceiptVaultImplementationMetamorphicRiskPinned() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            LibExtrospectMetamorphic.scanMetamorphicRisk(LibProdDeployV1.STOX_RECEIPT_VAULT_IMPLEMENTATION.code),
+            METAMORPHIC_RISK_DELEGATECALL_ONLY,
+            "STOX_RECEIPT_VAULT_IMPLEMENTATION metamorphic surface drifted"
+        );
+    }
+
+    function testProdWrappedTokenVaultImplementationMetamorphicRiskPinned() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            LibExtrospectMetamorphic.scanMetamorphicRisk(LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_IMPLEMENTATION.code),
+            0,
+            "STOX_WRAPPED_TOKEN_VAULT_IMPLEMENTATION metamorphic surface drifted"
         );
     }
 

--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -19,6 +19,7 @@ import {
     LibExtrospectERC1967BeaconProxy
 } from "rain.extrospection/lib/LibExtrospectERC1967BeaconProxy.sol";
 import {LibExtrospectMetamorphic} from "rain.extrospection/lib/LibExtrospectMetamorphic.sol";
+import {EVM_OP_DELEGATECALL} from "rain.extrospection/lib/EVMOpcodes.sol";
 
 /// @title LibProdTokensBaseTest
 /// @notice Fork tests verifying production token instances on Base.
@@ -169,12 +170,15 @@ contract LibProdTokensBaseTest is Test {
     /// algorithms are intended for offchain / fork-test use, which this
     /// test is.
     /// Bitmap pin for `STOX_RECEIPT_VAULT_IMPLEMENTATION`: only DELEGATECALL
-    /// (opcode 0xF4, bit 244) is reachable. The receipt vault implementation
-    /// contains delegatecall sites from the OZ Upgradeable inheritance chain
-    /// (and/or ERC2771 forwarder machinery). Receipt and wrapped-vault
-    /// implementations are clean (0 — no metamorphic ops reachable). Any
-    /// drift in either direction trips the corresponding assertion.
-    uint256 constant METAMORPHIC_RISK_DELEGATECALL_ONLY = 1 << 244;
+    /// is reachable. The receipt vault implementation contains delegatecall
+    /// sites from the OZ Upgradeable inheritance chain (and/or ERC2771
+    /// forwarder machinery). Receipt and wrapped-vault implementations are
+    /// clean (0 — no metamorphic ops reachable). Any drift in either
+    /// direction trips the corresponding assertion. Bit position derived
+    /// from the upstream `EVM_OP_DELEGATECALL` constant rather than a
+    /// literal so the bitmap stays correct if rain.extrospection ever
+    /// re-derives opcode numbering.
+    uint256 constant METAMORPHIC_RISK_DELEGATECALL_ONLY = 1 << EVM_OP_DELEGATECALL;
 
     function testProdReceiptImplementationMetamorphicRiskPinned() external {
         LibTestProd.createSelectForkBase(vm);


### PR DESCRIPTION
Closes #112.

Three fork-test pins on the metamorphic-risk surface of every prod V1 implementation on Base. Uses `rain.extrospection.LibExtrospectMetamorphic.scanMetamorphicRisk` to scan reachable opcodes from the metamorphic set (SELFDESTRUCT, DELEGATECALL, CALLCODE, CREATE, CREATE2 — the ops that could let a contract die and be redeployed with different code at the same address).

The codehash pin in `checkTokenSet` answers *"what bytecode is at this address now"*. This pins *"what redeployment surface does that bytecode expose"*. Together they catch both bytecode swap (codehash) and a swap to bytecode with different metamorphic characteristics (this).

## Empirical findings from V1 deployment on Base

| Implementation | Bitmap | Interpretation |
|---|---|---|
| `STOX_RECEIPT_IMPLEMENTATION` | `0` | No metamorphic ops reachable. |
| `STOX_RECEIPT_VAULT_IMPLEMENTATION` | `1 << 244` | **DELEGATECALL only.** Expected from OZ Upgradeable / forwarder machinery. |
| `STOX_WRAPPED_TOKEN_VAULT_IMPLEMENTATION` | `0` | No metamorphic ops reachable. |

Each pin asserts the actual scanned bitmap equals the documented expected value. Drift in either direction (a new metamorphic op appearing, or DELEGATECALL going away from receipt-vault impl) trips the corresponding test and forces explicit re-evaluation.

## Test plan
- [x] all three pins green against Base fork (RPC_URL_BASE_FORK)
- [ ] static + legal + test (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
