### PR TITLE
test: pin bootstrap state via facet API (#131, #134)

### DIFF
--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -1935,4 +1935,53 @@ contract StoxCorporateActionsFacetTest is Test {
         vm.warp(2000);
         assertEq(corporateActionHarness.countCompleted(), 1, "only the user action counts as completed");
     }
+
+    /// `getActionParameters(0)` returns the bootstrap's empty `parameters`
+    /// blob via the facet's external API. Under the 0-based scheme idx 0
+    /// is a real walkable node, and the facet's bounds check
+    /// (`actionId >= s.nodes.length`) admits cursor 0 once
+    /// `_ensureBootstrap` has fired. Storage-direct reads of
+    /// `bootstrap.parameters.length == 0` already pin the storage shape;
+    /// this pins the public-API contract — a regression that re-introduced
+    /// a `cursor != 0` reject inside `getActionParameters` (matching the
+    /// pre-bootstrap 1-based scheme) would silently break receipt-side
+    /// walks that read parameters at cursor 0 and would not surface in any
+    /// existing test.
+    function testGetActionParametersReturnsEmptyBytesForBootstrap() external {
+        // Schedule a user action via the delegatecall path so bootstrap
+        // exists in the same storage namespace the facet reads from.
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory params = LibStockSplit.encodeParametersV1(twoX);
+        vm.prank(ALICE);
+        facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_V1_TYPE_HASH, 1500, params);
+
+        bytes memory bootstrapParams = facetViaHarness.getActionParameters(0);
+        assertEq(bootstrapParams.length, 0, "bootstrap parameters must be empty bytes via facet API");
+    }
+
+    /// Cross-contract pin: `vault.nextOfType(NODE_NONE, INIT, ALL)`
+    /// returns the bootstrap (idx 0) through the facet's external function
+    /// over a delegatecall fallback, not just through the in-process
+    /// `LibCorporateActionNode.nextOfType` library call exercised by
+    /// `testBootstrapIsVisibleViaInitMaskInvisibleViaSplitMask`. The
+    /// receipt contract relies on this exact path:
+    /// `ICorporateActionsV1(address(vault)).nextOfType(...)` reads the
+    /// vault's bootstrap idx during head-inclusive receipt-side walks. A
+    /// regression in the fallback router (e.g., a cursor-rewriting layer
+    /// added between caller and facet) would silently break that walk
+    /// without breaking the library-direct test.
+    function testFacetNextOfTypeReturnsBootstrapForInitMaskFromNodeNone() external {
+        // Schedule a user action via the delegatecall path so bootstrap
+        // exists in the harness's storage namespace.
+        Float twoX = LibDecimalFloat.packLossless(2, 0);
+        bytes memory params = LibStockSplit.encodeParametersV1(twoX);
+        vm.prank(ALICE);
+        facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_V1_TYPE_HASH, 1500, params);
+
+        (uint256 actionId, uint256 actionType, uint64 effectiveTime) =
+            facetViaHarness.nextOfType(NODE_NONE, ACTION_TYPE_INIT_V1, CompletionFilter.ALL);
+        assertEq(actionId, 0, "INIT mask from NODE_NONE returns bootstrap idx 0 via facet");
+        assertEq(actionType, ACTION_TYPE_INIT_V1, "bootstrap actionType is INIT_V1");
+        assertEq(uint256(effectiveTime), block.timestamp, "bootstrap effectiveTime is block.timestamp at schedule");
+    }
 }


### PR DESCRIPTION
Closes #131. Closes #134.

Two pin tests for bootstrap state observable via the **facet's external API** under the cross-contract delegatecall path. Existing tests cover the storage-direct shape (`testBootstrapNodePropertiesAfterFirstSchedule`, `testBootstrapIsVisibleViaInitMaskInvisibleViaSplitMask`); these pin the public-API contract that receipts and offchain consumers actually consume.

## What's pinned

| Test | Asserts |
|---|---|
| `testGetActionParametersReturnsEmptyBytesForBootstrap` | `facetViaHarness.getActionParameters(0)` returns empty bytes after `_ensureBootstrap` fires |
| `testFacetNextOfTypeReturnsBootstrapForInitMaskFromNodeNone` | `facetViaHarness.nextOfType(NODE_NONE, ACTION_TYPE_INIT_V1, ALL)` returns idx 0 over the delegatecall fallback |

Both schedule a real action via `facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_V1_TYPE_HASH, ...)` so bootstrap exists in the harness's storage namespace, then read through the same delegatecall path.

## Mutation verification

- `getActionParameters(actionId)` mutated to add `if (actionId == 0) revert ActionDoesNotExist(0);` after the bounds check → the new test fails with `ActionDoesNotExist(0)`. Reverted.
- `nextOfType` mutated so the `fromId == NODE_NONE` branch reads `s.nodes[s.head].next` instead of `s.head` (skipping the head) → the new test fails with `actionId == NODE_NONE`. Reverted.

## Sibling issues handled separately

- **#133** is already pinned — `testEnsureBootstrapInitsTotalSupplyLatestCursorToNodeNone` reads `s.totalSupplyLatestCursor` storage-direct after first schedule. Closing the issue.
- **#135** is already pinned on both sides — `testMigrationCursorDefaultsToBootstrapForFreshAccount` (share-side) and `testReceiptCursorDefaultsToBootstrapForFreshPair` (receipt-side `(holder, id)`). Closing the issue.
- **#132** observation requires calling `_ensureBootstrap` without the user-action splice that follows it inside `schedule()`. The function is `private` and only fires inside `schedule`. Leaving open with a comment.

## Test plan
- [x] Both new tests pass.
- [x] Both mutations confirmed to falsify the corresponding test.
- [ ] Full suite + static + legal (CI).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for corporate action facet's parameter retrieval and node traversal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->