### PR TITLE
test: pin prod V1 deployer bytecode (#114)

### DIFF
--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -207,6 +207,58 @@ contract LibProdTokensBaseTest is Test {
         );
     }
 
+    /// Pin the deployed runtime bytecode of each prod V1 deployer against
+    /// its `LibProdDeployV1.PROD_*_BASE_CODEHASH_V1` constant. The
+    /// per-token-set assertions in `checkTokenSet` trust the OARV
+    /// deployer's `I_RECEIPT_BEACON()` / `I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON()`
+    /// getters; if the deployer at the constant address were swapped for a
+    /// contract with different bytecode, those getters could return
+    /// arbitrary addresses and every downstream beacon / impl check would
+    /// proceed against whatever the swapped deployer reported. Pinning the
+    /// runtime keccak forces a swap to fail loud.
+    ///
+    /// The metamorphic-risk pins above answer "could this deployer's code
+    /// change post-deploy"; this answers "is the code at the address what
+    /// we expect today". Both are needed.
+    function testProdOffchainAssetReceiptVaultBeaconSetDeployerCodehash() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            keccak256(LibProdDeployV1.OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER.code),
+            LibProdDeployV1.PROD_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_BASE_CODEHASH_V1,
+            "OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER codehash drifted"
+        );
+    }
+
+    function testProdWrappedTokenVaultBeaconSetDeployerCodehash() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            keccak256(LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER.code),
+            LibProdDeployV1.PROD_STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER_BASE_CODEHASH_V1,
+            "STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER codehash drifted"
+        );
+    }
+
+    function testProdUnifiedDeployerCodehash() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            keccak256(LibProdDeployV1.STOX_UNIFIED_DEPLOYER.code),
+            LibProdDeployV1.PROD_STOX_UNIFIED_DEPLOYER_BASE_CODEHASH_V1,
+            "STOX_UNIFIED_DEPLOYER codehash drifted"
+        );
+
+        // Mutation pin: confirm the assertion would actually catch a swap
+        // by overwriting the deployer's bytecode and verifying the
+        // codehash check would now fail. Without this, a constant equal
+        // to keccak256("") (or any sentinel hash) would silently always
+        // match because of mismatched expectations.
+        vm.etch(LibProdDeployV1.STOX_UNIFIED_DEPLOYER, hex"00");
+        assertNotEq(
+            keccak256(LibProdDeployV1.STOX_UNIFIED_DEPLOYER.code),
+            LibProdDeployV1.PROD_STOX_UNIFIED_DEPLOYER_BASE_CODEHASH_V1,
+            "swapped bytecode must not match the pinned codehash"
+        );
+    }
+
     function testMstrTokenSetOnBase() external {
         LibTestProd.createSelectForkBase(vm);
         checkTokenSet(


### PR DESCRIPTION
Closes #114.

Three pin tests asserting the prod V1 deployers' runtime keccak matches their existing `LibProdDeployV1.PROD_*_BASE_CODEHASH_V1` constants:

| Deployer | Pin |
|---|---|
| `OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER` | `PROD_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_BASE_CODEHASH_V1` |
| `STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER` | `PROD_STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER_BASE_CODEHASH_V1` |
| `STOX_UNIFIED_DEPLOYER` | `PROD_STOX_UNIFIED_DEPLOYER_BASE_CODEHASH_V1` |

`checkTokenSet` calls `oarvDeployer.I_RECEIPT_BEACON()` and `I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON()` and trusts the addresses returned. Pinning the deployer's bytecode against the in-repo constant catches the case where the deployer at the constant address has been swapped — the downstream beacon / impl checks would otherwise proceed against whatever the swapped deployer returned.

## Mutation verification

`testProdUnifiedDeployerCodehash` includes an inline `vm.etch` mutation: overwrite the deployer's bytecode with `hex"00"`, then `assertNotEq` confirms the keccak diverges from the pinned constant. Without this, a constant equal to `keccak256("")` (or any sentinel) would silently always match.

## Test plan
- [x] Three pins green on Base fork
- [x] Mutation pin (`vm.etch` + `assertNotEq`) confirms the keccak check would catch a swap
- [ ] static + legal + test (CI)
