### PR TITLE
test: pin V1 beacon addresses against in-repo constants (#115)

### DIFF
--- a/src/lib/LibProdDeployV1.sol
+++ b/src/lib/LibProdDeployV1.sol
@@ -21,6 +21,29 @@ library LibProdDeployV1 {
     /// https://basescan.org/address/0xef6f9d21ed2e2742bfd3dfcf67829e4855884fab
     address constant STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER = address(0xeF6f9D21ED2E2742bfd3dFcf67829e4855884faB);
 
+    /// @dev StoxReceipt UpgradeableBeacon deployed by the OARV beacon-set
+    /// deployer on Base. All prod receipt proxies point at this beacon's
+    /// ERC1967 slot. Resolved at runtime via
+    /// `OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER.I_RECEIPT_BEACON()`;
+    /// pinned here so a swapped deployer can't redirect the test chain.
+    /// https://basescan.org/address/0x86e93c39B095be0B0054C8488E26466Ee027D79a
+    address constant STOX_RECEIPT_BEACON_V1 = address(0x86e93c39B095be0B0054C8488E26466Ee027D79a);
+
+    /// @dev StoxReceiptVault (OffchainAssetReceiptVault) UpgradeableBeacon
+    /// deployed by the OARV beacon-set deployer on Base. Resolved at
+    /// runtime via
+    /// `OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER.I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON()`.
+    /// https://basescan.org/address/0xEa084c8F4331CDF3328E772781b59F8A24F28F1A
+    address constant STOX_RECEIPT_VAULT_BEACON_V1 = address(0xEa084c8F4331CDF3328E772781b59F8A24F28F1A);
+
+    /// @dev StoxWrappedTokenVault UpgradeableBeacon deployed by the wrapped
+    /// vault beacon-set deployer on Base. Not exposed via any deployer
+    /// getter; resolved at runtime by reading the ERC1967 beacon slot of
+    /// any wrapped vault proxy. Pinned here so a tampered proxy slot
+    /// can't redirect the impl-codehash chain.
+    /// https://basescan.org/address/0x4c2d2d3bf1232bf0d3fb7123007a9b8444637bc8
+    address constant STOX_WRAPPED_TOKEN_VAULT_BEACON_V1 = address(0x4c2d2d3Bf1232bf0d3FB7123007A9B8444637bC8);
+
     /// @dev The StoxWrappedTokenVault implementation deployed inside the
     /// StoxWrappedTokenVault beacon set on Base. Accessible via
     /// iStoxWrappedTokenVaultBeacon.implementation(). No proxy instances have

--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -207,6 +207,51 @@ contract LibProdTokensBaseTest is Test {
         );
     }
 
+    /// Pin the V1 beacon addresses against in-repo constants. The
+    /// per-token-set assertions in `checkTokenSet` resolve these
+    /// addresses at runtime — receipt and receipt-vault beacons via the
+    /// OARV deployer's getters, wrapped vault beacon via the ERC1967
+    /// slot of any wrapped proxy. Without explicit assertion the
+    /// downstream impl-codehash and beacon-owner checks proceed against
+    /// whatever address was returned by the getter or read from the
+    /// proxy slot. Pinning forces a swapped deployer or tampered slot
+    /// to fail loud at this layer rather than silently re-anchor every
+    /// downstream check on a different beacon.
+    function testProdReceiptBeaconAddress() external {
+        LibTestProd.createSelectForkBase(vm);
+        IOffchainAssetReceiptVaultBeaconSetDeployerV1 oarvDeployer = IOffchainAssetReceiptVaultBeaconSetDeployerV1(
+            LibProdDeployV1.OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER
+        );
+        assertEq(
+            address(oarvDeployer.I_RECEIPT_BEACON()),
+            LibProdDeployV1.STOX_RECEIPT_BEACON_V1,
+            "I_RECEIPT_BEACON resolved to unexpected address"
+        );
+    }
+
+    function testProdReceiptVaultBeaconAddress() external {
+        LibTestProd.createSelectForkBase(vm);
+        IOffchainAssetReceiptVaultBeaconSetDeployerV1 oarvDeployer = IOffchainAssetReceiptVaultBeaconSetDeployerV1(
+            LibProdDeployV1.OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER
+        );
+        assertEq(
+            address(oarvDeployer.I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON()),
+            LibProdDeployV1.STOX_RECEIPT_VAULT_BEACON_V1,
+            "I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON resolved to unexpected address"
+        );
+    }
+
+    function testProdWrappedTokenVaultBeaconAddress() external {
+        LibTestProd.createSelectForkBase(vm);
+        // All wrapped vault proxies share a single beacon. Read it from
+        // MSTR (any one is fine) and assert the in-repo constant.
+        assertEq(
+            beaconOf(LibProdTokensBase.MSTR_WRAPPED_TOKEN_VAULT),
+            LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_V1,
+            "wrapped vault beacon read from MSTR proxy slot drifted"
+        );
+    }
+
     function testMstrTokenSetOnBase() external {
         LibTestProd.createSelectForkBase(vm);
         checkTokenSet(

--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -52,16 +52,13 @@ contract LibProdTokensBaseTest is Test {
         // every deposit and withdraw on this token would revert.
         assertEq(IReceiptV3(receipt).manager(), receiptVault, "receipt manager != receipt vault");
 
-        // All prod tokens on Base are behind the V1 OARV deployer's beacons.
-        IOffchainAssetReceiptVaultBeaconSetDeployerV1 oarvDeployer = IOffchainAssetReceiptVaultBeaconSetDeployerV1(
-            LibProdDeployV1.OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER
-        );
-        address receiptBeacon = address(oarvDeployer.I_RECEIPT_BEACON());
-        address receiptVaultBeacon = address(oarvDeployer.I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON());
-        // The wrapped vault beacon is not exposed by any deployer getter,
-        // so read it from the proxy's slot. All wrapped proxies share the
-        // same beacon, pinned via the MSTR check below.
-        address wrappedVaultBeacon = beaconOf(LibProdTokensBase.MSTR_WRAPPED_TOKEN_VAULT);
+        // All prod tokens on Base are behind the V1 OARV deployer's
+        // beacons. The constants are the canonical source — the cross-check
+        // that they match runtime resolution lives in
+        // `testProdBeaconAddressesMatchConstants`.
+        address receiptBeacon = LibProdDeployV1.STOX_RECEIPT_BEACON_V1;
+        address receiptVaultBeacon = LibProdDeployV1.STOX_RECEIPT_VAULT_BEACON_V1;
+        address wrappedVaultBeacon = LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_V1;
 
         assertEq(beaconOf(receipt), receiptBeacon, "receipt beacon mismatch");
         assertEq(beaconOf(receiptVault), receiptVaultBeacon, "receipt vault beacon mismatch");
@@ -207,17 +204,13 @@ contract LibProdTokensBaseTest is Test {
         );
     }
 
-    /// Pin the V1 beacon addresses against in-repo constants. The
-    /// per-token-set assertions in `checkTokenSet` resolve these
-    /// addresses at runtime — receipt and receipt-vault beacons via the
-    /// OARV deployer's getters, wrapped vault beacon via the ERC1967
-    /// slot of any wrapped proxy. Without explicit assertion the
-    /// downstream impl-codehash and beacon-owner checks proceed against
-    /// whatever address was returned by the getter or read from the
-    /// proxy slot. Pinning forces a swapped deployer or tampered slot
-    /// to fail loud at this layer rather than silently re-anchor every
-    /// downstream check on a different beacon.
-    function testProdReceiptBeaconAddress() external {
+    /// Single pin test: the runtime-resolved V1 beacon addresses match
+    /// the in-repo constants. Once this passes, the rest of the prod
+    /// fork tests can use the `STOX_*_BEACON_V1` constants directly
+    /// without re-resolving from the deployer's getters or the proxy
+    /// slot — the constants are the canonical source, runtime resolution
+    /// is the cross-check.
+    function testProdBeaconAddressesMatchConstants() external {
         LibTestProd.createSelectForkBase(vm);
         IOffchainAssetReceiptVaultBeaconSetDeployerV1 oarvDeployer = IOffchainAssetReceiptVaultBeaconSetDeployerV1(
             LibProdDeployV1.OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER
@@ -227,24 +220,13 @@ contract LibProdTokensBaseTest is Test {
             LibProdDeployV1.STOX_RECEIPT_BEACON_V1,
             "I_RECEIPT_BEACON resolved to unexpected address"
         );
-    }
-
-    function testProdReceiptVaultBeaconAddress() external {
-        LibTestProd.createSelectForkBase(vm);
-        IOffchainAssetReceiptVaultBeaconSetDeployerV1 oarvDeployer = IOffchainAssetReceiptVaultBeaconSetDeployerV1(
-            LibProdDeployV1.OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER
-        );
         assertEq(
             address(oarvDeployer.I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON()),
             LibProdDeployV1.STOX_RECEIPT_VAULT_BEACON_V1,
             "I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON resolved to unexpected address"
         );
-    }
-
-    function testProdWrappedTokenVaultBeaconAddress() external {
-        LibTestProd.createSelectForkBase(vm);
         // All wrapped vault proxies share a single beacon. Read it from
-        // MSTR (any one is fine) and assert the in-repo constant.
+        // any wrapped proxy (MSTR is arbitrary) and assert the constant.
         assertEq(
             beaconOf(LibProdTokensBase.MSTR_WRAPPED_TOKEN_VAULT),
             LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_V1,


### PR DESCRIPTION
Closes #115. Closes #164.

Adds three V1 beacon address constants to `LibProdDeployV1` and pins them in the test suite via the cross-check pattern:

- `STOX_RECEIPT_BEACON_V1`
- `STOX_RECEIPT_VAULT_BEACON_V1`
- `STOX_WRAPPED_TOKEN_VAULT_BEACON_V1`

## Pattern

ONE pin test (`testProdBeaconAddressesMatchConstants`) asserts the runtime-resolved beacon addresses match the constants. Sources of resolution:

| Beacon | Resolved via |
|---|---|
| Receipt | `OARV.I_RECEIPT_BEACON()` |
| Receipt vault | `OARV.I_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON()` |
| Wrapped token vault | `beaconOf(MSTR_WRAPPED_TOKEN_VAULT)` (ERC1967 slot read) |

Once that pin passes, the constants are canonical. `checkTokenSet` now reads the constants directly instead of re-resolving from the deployer's getters and the proxy slot — every per-token-set test trusts the constants without re-running the cross-check.

This closes #164 (defense-in-depth) at the same time: a divergence between runtime and constant fails `testProdBeaconAddressesMatchConstants` loudly; a divergence at any individual proxy still fails the per-token-set `beaconOf(receipt) == receiptBeacon` assertion.

## Test plan
- [x] Single cross-check pin green on Base fork
- [x] All 17 LibProdTokensBaseTest tests green on fork
- [ ] static + legal + test (CI)