### PR TITLE
refactor: drop leading-underscore from first-party internal/private fns (#165)

### DIFF
--- a/src/concrete/StoxCorporateActionsFacet.sol
+++ b/src/concrete/StoxCorporateActionsFacet.sol
@@ -79,7 +79,7 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
         onlyDelegatecalled
         returns (uint256 actionId)
     {
-        _authorize(msg.sender, SCHEDULE_CORPORATE_ACTION, abi.encode(typeHash, effectiveTime, parameters));
+        authorizeAction(msg.sender, SCHEDULE_CORPORATE_ACTION, abi.encode(typeHash, effectiveTime, parameters));
         uint256 actionType = LibCorporateAction.resolveActionType(typeHash, parameters);
         actionId = LibCorporateAction.schedule(actionType, effectiveTime, parameters);
         emit CorporateActionScheduled(msg.sender, actionId, actionType, effectiveTime);
@@ -87,13 +87,13 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
 
     /// @inheritdoc ICorporateActionsV1
     // Same trust model as `scheduleCorporateAction`. The outer call's
-    // `actionId` is captured from calldata before `_authorize`, so a
+    // `actionId` is captured from calldata before `authorizeAction`, so a
     // re-entrant cancel during the authorizer callback can only act on
     // whatever index the (trusted) authorizer chooses to cancel — it
     // cannot redirect the outer call's target.
     // slither-disable-next-line reentrancy-events
     function cancelCorporateAction(uint256 actionId) external override onlyDelegatecalled {
-        _authorize(msg.sender, CANCEL_CORPORATE_ACTION, abi.encode(actionId));
+        authorizeAction(msg.sender, CANCEL_CORPORATE_ACTION, abi.encode(actionId));
         LibCorporateAction.cancel(actionId);
         emit CorporateActionCancelled(msg.sender, actionId);
     }
@@ -180,7 +180,7 @@ contract StoxCorporateActionsFacet is ICorporateActionsV1 {
     /// @param data ABI-encoded action context. For schedule:
     /// `abi.encode(bytes32 typeHash, uint64 effectiveTime, bytes parameters)`.
     /// For cancel: `abi.encode(uint256 actionId)`.
-    function _authorize(address user, bytes32 permission, bytes memory data) internal {
+    function authorizeAction(address user, bytes32 permission, bytes memory data) internal {
         IAuthorizeV1 auth = OffchainAssetReceiptVault(payable(address(this))).authorizer();
         auth.authorize(user, permission, data);
     }

--- a/src/concrete/StoxReceipt.sol
+++ b/src/concrete/StoxReceipt.sol
@@ -61,11 +61,11 @@ import {LibReceiptRebase} from "../lib/LibReceiptRebase.sol";
 /// `testZeroBalanceAdvancesCursor` regression in both `LibRebase.t.sol` and
 /// `LibReceiptRebase.t.sol`.
 contract StoxReceipt is Receipt {
-    /// @notice Emitted whenever `_migrateHolderId` advances a `(account, id)`
+    /// @notice Emitted whenever `migrateHolderId` advances a `(account, id)`
     /// pair's migration cursor. The cursor itself is storage state, so the
     /// event fires on every cursor advance regardless of whether
     /// `oldBalance == newBalance`. Fires from `_update` via
-    /// `_migrateHolderId`, before the mint / burn / transfer delta is
+    /// `migrateHolderId`, before the mint / burn / transfer delta is
     /// applied.
     /// @param account The holder whose `(account, id)` migration state changed.
     /// @param id The receipt id.
@@ -99,7 +99,7 @@ contract StoxReceipt is Receipt {
         override(ERC1155Upgradeable, IERC1155)
         returns (uint256)
     {
-        return _balanceOf(account, id, _vault());
+        return balanceOfFor(account, id, getVault());
     }
 
     /// @notice Batch-aware `balanceOf`. OZ's default `balanceOfBatch` reads
@@ -118,10 +118,10 @@ contract StoxReceipt is Receipt {
         if (accounts.length != ids.length) {
             revert ERC1155InvalidArrayLength(ids.length, accounts.length);
         }
-        ICorporateActionsV1 vault = _vault();
+        ICorporateActionsV1 vault = getVault();
         uint256[] memory batchBalances = new uint256[](accounts.length);
         for (uint256 i = 0; i < accounts.length; ++i) {
-            batchBalances[i] = _balanceOf(accounts[i], ids[i], vault);
+            batchBalances[i] = balanceOfFor(accounts[i], ids[i], vault);
         }
         return batchBalances;
     }
@@ -130,13 +130,13 @@ contract StoxReceipt is Receipt {
     /// vault as a parameter so callers inside a loop (`balanceOfBatch`)
     /// can fetch it once and pass it in, avoiding an external self-call
     /// per iteration.
-    function _balanceOf(address account, uint256 id, ICorporateActionsV1 vault) internal view returns (uint256) {
+    function balanceOfFor(address account, uint256 id, ICorporateActionsV1 vault) internal view returns (uint256) {
         uint256 stored = LibERC1155Storage.underlyingBalance(account, id);
         uint256 cursor = LibCorporateActionReceipt.getStorage().accountIdCursor[account][id];
         // The second return value is the new cursor — intentionally discarded
         // here because this is a pure read that must not mutate state;
         // cursor advancement happens on the next `_update` via
-        // `_migrateHolderId`.
+        // `migrateHolderId`.
         // slither-disable-next-line unused-return
         (uint256 effective,) = LibReceiptRebase.migratedBalance(stored, cursor, vault);
         return effective;
@@ -166,14 +166,14 @@ contract StoxReceipt is Receipt {
         // Snapshot the vault once so we don't pay the external self-call
         // per iteration. `manager()` is the external view on Receipt that
         // returns the configured vault address from Receipt7201Storage.
-        ICorporateActionsV1 vault = _vault();
+        ICorporateActionsV1 vault = getVault();
 
         // Migrate each (account, id) pair before the transfer executes.
-        // `_migrateHolderId` short-circuits on `address(0)` so mint (from ==
+        // `migrateHolderId` short-circuits on `address(0)` so mint (from ==
         // 0) and burn (to == 0) pass straight through to super._update.
         for (uint256 i = 0; i < ids.length; i++) {
-            _migrateHolderId(from, ids[i], vault);
-            _migrateHolderId(to, ids[i], vault);
+            migrateHolderId(from, ids[i], vault);
+            migrateHolderId(to, ids[i], vault);
         }
 
         // Now that both sides are rasterized to the current cursor, run
@@ -191,7 +191,7 @@ contract StoxReceipt is Receipt {
     ///
     /// `internal` so test harnesses derived from this contract can exercise
     /// the migration logic in isolation.
-    function _migrateHolderId(address account, uint256 id, ICorporateActionsV1 vault) internal {
+    function migrateHolderId(address account, uint256 id, ICorporateActionsV1 vault) internal {
         if (account == address(0)) return;
 
         LibCorporateActionReceipt.CorporateActionReceiptStorage storage s = LibCorporateActionReceipt.getStorage();
@@ -217,7 +217,7 @@ contract StoxReceipt is Receipt {
     /// `Receipt7201Storage` slot literal in this file — the cost is one
     /// CALL opcode per `_update`, which is amortized across every
     /// `(account, id)` pair the batch touches.
-    function _vault() internal view returns (ICorporateActionsV1) {
+    function getVault() internal view returns (ICorporateActionsV1) {
         return ICorporateActionsV1(this.manager());
     }
 }

--- a/src/concrete/StoxReceiptVault.sol
+++ b/src/concrete/StoxReceiptVault.sol
@@ -36,11 +36,11 @@ import {LibProdDeployV3} from "../lib/LibProdDeployV3.sol";
 /// inflating the recipient's balance. See `LibRebase.migratedBalance` and
 /// its zero-balance regression tests.
 contract StoxReceiptVault is OffchainAssetReceiptVault {
-    /// @notice Emitted whenever `_migrateAccount` advances an account's
+    /// @notice Emitted whenever `migrateAccount` advances an account's
     /// migration cursor. The cursor itself is storage state, so the event
     /// fires on every cursor advance regardless of whether
     /// `oldBalance == newBalance`. Fires from `_update` via
-    /// `_migrateAccount`, before the mint / burn / transfer delta is
+    /// `migrateAccount`, before the mint / burn / transfer delta is
     /// applied.
     /// @param account The account whose migration state changed.
     /// @param fromActionId The action id the account's cursor was at
@@ -76,7 +76,7 @@ contract StoxReceiptVault is OffchainAssetReceiptVault {
         // The second return value is the new cursor — intentionally discarded
         // here because `balanceOf` is a pure read that must not mutate state;
         // the cursor advancement happens on the next `_update` touch via
-        // `_migrateAccount`.
+        // `migrateAccount`.
         // slither-disable-next-line unused-return
         (uint256 balance,) = LibRebase.migratedBalance(stored, s.accountMigrationCursor[account]);
         return balance;
@@ -106,8 +106,8 @@ contract StoxReceiptVault is OffchainAssetReceiptVault {
     function _update(address from, address to, uint256 amount) internal virtual override {
         LibTotalSupply.fold();
 
-        _migrateAccount(from);
-        _migrateAccount(to);
+        migrateAccount(from);
+        migrateAccount(to);
 
         super._update(from, to, amount);
 
@@ -130,7 +130,7 @@ contract StoxReceiptVault is OffchainAssetReceiptVault {
     /// `internal` (rather than `private`) so test harnesses derived from this
     /// contract can exercise the migration logic in isolation. The function is
     /// only ever called from this contract's `_update` override.
-    function _migrateAccount(address account) internal {
+    function migrateAccount(address account) internal {
         if (account == address(0)) return;
 
         LibCorporateAction.CorporateActionStorage storage s = LibCorporateAction.getStorage();

--- a/src/lib/LibCorporateAction.sol
+++ b/src/lib/LibCorporateAction.sol
@@ -31,7 +31,7 @@ bytes32 constant SCHEDULE_CORPORATE_ACTION = keccak256("SCHEDULE_CORPORATE_ACTIO
 bytes32 constant CANCEL_CORPORATE_ACTION = keccak256("CANCEL_CORPORATE_ACTION");
 
 /// @dev External identifier for V1 vault initialisation. INIT is
-/// system-created via `_ensureBootstrap`; users cannot schedule it via
+/// system-created via `ensureBootstrap`; users cannot schedule it via
 /// `scheduleCorporateAction` (the dispatch in `resolveActionType` rejects
 /// the hash). The constant exists so every `ACTION_TYPE_*_V<N>` has a
 /// matching `*_V<N>_TYPE_HASH` per the action-type convention — indexers
@@ -56,7 +56,7 @@ bytes32 constant STABLES_DIVIDEND_V1_TYPE_HASH = keccak256("st0x.corporate-actio
 ///
 /// Nodes are stored in a dynamic array. Index 0, when the array is non-empty,
 /// is always the `ACTION_TYPE_INIT_V1` bootstrap node lazily created by
-/// `_ensureBootstrap` on the first `schedule` call. User-scheduled actions
+/// `ensureBootstrap` on the first `schedule` call. User-scheduled actions
 /// start at index 1. The null encoding for `prev`, `next`, and the "from
 /// head/tail inclusive" sentinel for `nextOfType`/`prevOfType` is
 /// `NODE_NONE` — value-level disambiguation, not positional, so a
@@ -76,7 +76,7 @@ library LibCorporateAction {
     /// the new field's offset.
     struct CorporateActionStorage {
         /// @param head Head of the list (earliest effectiveTime). After
-        /// `_ensureBootstrap` has fired this is always 0 (the bootstrap
+        /// `ensureBootstrap` has fired this is always 0 (the bootstrap
         /// node, which has the smallest effectiveTime by construction);
         /// before any schedule call `nodes.length == 0` and head/tail
         /// must not be read.
@@ -99,14 +99,14 @@ library LibCorporateAction {
         mapping(address => uint256) accountMigrationCursor;
         /// Per-cursor unmigrated supply. Maps cursor position (node index)
         /// to the sum of stored balances for accounts at that cursor level.
-        /// Index 0 is the bootstrap pot — captured by `_ensureBootstrap`
+        /// Index 0 is the bootstrap pot — captured by `ensureBootstrap`
         /// from OZ's `_totalSupply` at the moment the first action is
         /// scheduled. When an account migrates from cursor k to cursor k',
         /// storedBalance is subtracted from unmigrated[k] and the migrated
         /// balance is added to unmigrated[k'].
         mapping(uint256 => uint256) unmigrated;
         /// Index of the latest completed init-or-stock-split node seen by
-        /// `fold()`. `_ensureBootstrap` writes `NODE_NONE` here as
+        /// `fold()`. `ensureBootstrap` writes `NODE_NONE` here as
         /// the "no fold has run yet" sentinel so the first `fold()` call
         /// walks the head-inclusive range. Mint/burn amounts route to
         /// `unmigrated[totalSupplyLatestCursor]` after the first fold.
@@ -148,7 +148,7 @@ library LibCorporateAction {
 
         CorporateActionStorage storage s = getStorage();
 
-        _ensureBootstrap(s);
+        ensureBootstrap(s);
 
         // Push new node — its array position is the actionId.
         s.nodes.push();
@@ -164,7 +164,7 @@ library LibCorporateAction {
         node.prev = NODE_NONE;
         node.next = NODE_NONE;
 
-        _insertOrdered(s, actionId, effectiveTime);
+        insertOrdered(s, actionId, effectiveTime);
     }
 
     /// @dev Lazily create the index-0 init/bootstrap node on first `schedule`
@@ -187,7 +187,7 @@ library LibCorporateAction {
     /// - `unmigrated[0] = LibERC20Storage.underlyingTotalSupply()` captures
     ///   the pre-action total supply into pot 0. The pot invariant `I(0)`
     ///   holds at this moment because schedule() does not touch balances and
-    ///   no `_migrateAccount` has fired yet — so OZ's `_totalSupply == Σ
+    ///   no `migrateAccount` has fired yet — so OZ's `_totalSupply == Σ
     ///   _balances` equality is intact, and every account's
     ///   `accountMigrationCursor` is still 0 (= bootstrap).
     ///
@@ -195,7 +195,7 @@ library LibCorporateAction {
     /// creation time, so any `cancel(0)` call reverts immediately with
     /// `ActionAlreadyComplete` (the standard guard) — no special-casing
     /// needed in `cancel`.
-    function _ensureBootstrap(CorporateActionStorage storage s) internal {
+    function ensureBootstrap(CorporateActionStorage storage s) internal {
         if (s.nodes.length != 0) return;
 
         // Index 0 — bootstrap node.
@@ -239,10 +239,10 @@ library LibCorporateAction {
     /// @param newIndex The array index of the node being inserted.
     /// @param effectiveTime The node's effective time (cached from storage
     /// so the loop doesn't re-read it on every step).
-    function _insertOrdered(CorporateActionStorage storage s, uint256 newIndex, uint64 effectiveTime) private {
+    function insertOrdered(CorporateActionStorage storage s, uint256 newIndex, uint64 effectiveTime) private {
         CorporateActionNode storage node = s.nodes[newIndex];
 
-        // Walk backwards from tail to find correct position. `_ensureBootstrap`
+        // Walk backwards from tail to find correct position. `ensureBootstrap`
         // guarantees the list always contains at least the bootstrap node, so
         // the walk always terminates at the bootstrap (whose effectiveTime is
         // <= every user node's effectiveTime).

--- a/src/lib/LibTotalSupply.sol
+++ b/src/lib/LibTotalSupply.sol
@@ -71,8 +71,8 @@ import {LibRebaseMath} from "./LibRebaseMath.sol";
 /// ## Bootstrap as a real init node
 ///
 /// The pre-action snapshot of OZ's `_totalSupply` lives in `unmigrated[0]`,
-/// captured by `LibCorporateAction._ensureBootstrap` on the first
-/// `schedule()` call. `_ensureBootstrap` pushes the bootstrap init node at
+/// captured by `LibCorporateAction.ensureBootstrap` on the first
+/// `schedule()` call. `ensureBootstrap` pushes the bootstrap init node at
 /// index 0 (`actionType = ACTION_TYPE_INIT_V1`, `effectiveTime =
 /// block.timestamp`); user-scheduled splits start at index 1. Every
 /// holder's `accountMigrationCursor` defaults to 0 (Solidity mapping
@@ -84,11 +84,11 @@ import {LibRebaseMath} from "./LibRebaseMath.sol";
 /// `fold()` advances `totalSupplyLatestCursor` through the bootstrap
 /// (idx 0) and every completed split using `BALANCE_MIGRATION_TYPES_MASK`,
 /// so mint/burn deltas always route to the same pot every account's
-/// `_migrateAccount` lands them in.
+/// `migrateAccount` lands them in.
 ///
 /// ## Pot invariant
 ///
-/// At every `_update` boundary (post-`_ensureBootstrap`), for every cursor `k`:
+/// At every `_update` boundary (post-`ensureBootstrap`), for every cursor `k`:
 ///
 ///   `I(k): unmigrated[k] == Σ_{acc : cursor(acc) == k, acc != address(0)} underlyingBalance(acc)`
 ///
@@ -103,7 +103,7 @@ import {LibRebaseMath} from "./LibRebaseMath.sol";
 ///
 /// ### Proof of preservation
 ///
-/// **Base case** (immediately after `_ensureBootstrap` runs in the first
+/// **Base case** (immediately after `ensureBootstrap` runs in the first
 /// `schedule()`):
 /// - Every account has `cursor == 0` because no `_update` has fired yet.
 /// - `unmigrated[0] := underlyingTotalSupply() == Σ_acc underlyingBalance(acc)`
@@ -113,7 +113,7 @@ import {LibRebaseMath} from "./LibRebaseMath.sol";
 ///
 /// **Inductive step.** Assume `I(k)` holds for all `k` on entry to an
 /// `_update` call. Show it holds again on exit. The sequence is
-/// `fold → _migrateAccount(from) → _migrateAccount(to) → super._update →
+/// `fold → migrateAccount(from) → migrateAccount(to) → super._update →
 /// (onMint | onBurn if from/to == 0)`. The invariant can be temporarily
 /// violated in between these steps — we only claim it holds at entry
 /// and exit.
@@ -121,7 +121,7 @@ import {LibRebaseMath} from "./LibRebaseMath.sol";
 /// 1. `fold()` mutates only `totalSupplyLatestCursor`; no pot write and no
 ///    balance write. I(k) unchanged.
 ///
-/// 2. `_migrateAccount(account)` advancing the cursor from `c` to `c'`
+/// 2. `migrateAccount(account)` advancing the cursor from `c` to `c'`
 ///    with stored balance `b` rasterizing to `b'`:
 ///    - Writes `cursor(account) = c'` and `underlyingBalance(account) = b'`.
 ///    - Calls `onAccountMigrated`, which does `unmigrated[c] -= b;
@@ -223,7 +223,7 @@ library LibTotalSupply {
         // nodes (init or stock-split). Track the latest seen in a local and
         // write once at the end — each loop-body SSTORE would otherwise be
         // stomped by the next iteration.
-        // `_ensureBootstrap` initialises `totalSupplyLatestCursor` to
+        // `ensureBootstrap` initialises `totalSupplyLatestCursor` to
         // `NODE_NONE`, which `nextOfType` interprets as "from head
         // inclusive" so the first fold lands on the bootstrap.
         uint256 nodeIndex = LibCorporateActionNode.nextOfType(
@@ -259,7 +259,7 @@ library LibTotalSupply {
     /// @dev When `nodes.length == 0` (no `schedule` ever called) this is a
     /// no-op: there is no init node, no pot, and `effectiveTotalSupply`
     /// falls back to OZ's `_totalSupply` directly. Once the first
-    /// `schedule()` runs, `_ensureBootstrap` snapshots OZ's totalSupply
+    /// `schedule()` runs, `ensureBootstrap` snapshots OZ's totalSupply
     /// into `unmigrated[0]` and `fold()` will advance
     /// `totalSupplyLatestCursor` to the init node on the next `_update`,
     /// so all subsequent mints route into the post-init pot.

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -161,15 +161,15 @@ contract CorporateActionHarness {
         return LibCorporateAction.getStorage().totalSupplyLatestCursor;
     }
 
-    /// Direct call to `_ensureBootstrap` so tests can observe the
+    /// Direct call to `ensureBootstrap` so tests can observe the
     /// post-bootstrap pre-user-action state (`bootstrap.prev` /
     /// `bootstrap.next` both `NODE_NONE`). The production `schedule` call
-    /// fires `_ensureBootstrap` and then immediately splices in the user
+    /// fires `ensureBootstrap` and then immediately splices in the user
     /// action, mutating `bootstrap.next` away from `NODE_NONE` — so the
     /// only way to pin the in-between state is to invoke
-    /// `_ensureBootstrap` standalone.
+    /// `ensureBootstrap` standalone.
     function ensureBootstrap() external {
-        LibCorporateAction._ensureBootstrap(LibCorporateAction.getStorage());
+        LibCorporateAction.ensureBootstrap(LibCorporateAction.getStorage());
     }
 }
 
@@ -795,7 +795,7 @@ contract StoxCorporateActionsFacetTest is Test {
     /// Cancelling the only user-scheduled node leaves the list with just
     /// the bootstrap node — head and tail both collapse to the bootstrap.
     /// Bootstrap's `prev`/`next` storage fields are also pinned at
-    /// `NODE_NONE` (set by `_ensureBootstrap`, restored by `cancel`'s
+    /// `NODE_NONE` (set by `ensureBootstrap`, restored by `cancel`'s
     /// unlink path). A regression that left them at Solidity's default 0
     /// would create a forward self-loop (bootstrap.next = idx 0 = itself);
     /// surfaces here without needing a backward-walk-from-bootstrap test.
@@ -817,7 +817,7 @@ contract StoxCorporateActionsFacetTest is Test {
         corporateActionHarness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, uint64(block.timestamp), "");
     }
 
-    /// In a single `schedule` call, `_ensureBootstrap` runs BEFORE the
+    /// In a single `schedule` call, `ensureBootstrap` runs BEFORE the
     /// user node is pushed. Symptoms (bootstrap at idx 0, user at idx 1)
     /// are pinned by other tests, but the property "bootstrap precedes
     /// user node in array order" is the precondition. This pins it
@@ -841,7 +841,7 @@ contract StoxCorporateActionsFacetTest is Test {
     /// requires `effectiveTime > block.timestamp` for user actions. The
     /// strict-inequality between the user's `> block.timestamp` and
     /// bootstrap's `== block.timestamp` is the precondition that makes
-    /// `_insertOrdered`'s tail-walk always terminate at bootstrap (the
+    /// `insertOrdered`'s tail-walk always terminate at bootstrap (the
     /// tail walks back finding `effectiveTime <= newTime`, which is
     /// guaranteed at idx 0). If `schedule`'s guard ever weakened to
     /// `effectiveTime >= block.timestamp`, a user action could share
@@ -967,10 +967,10 @@ contract StoxCorporateActionsFacetTest is Test {
     /// at idx 0 (the bootstrap). Bootstrap can't be cancelled (its
     /// `effectiveTime == block.timestamp` triggers the
     /// `ActionAlreadyComplete` guard), and user actions all schedule
-    /// strictly into the future — so `_insertOrdered`'s tail-walk lands
+    /// strictly into the future — so `insertOrdered`'s tail-walk lands
     /// every user action AFTER bootstrap, never displacing it. This pin
     /// catches a regression where the head pointer drifted to a user
-    /// action (e.g., an `_insertOrdered` change that mistook an
+    /// action (e.g., an `insertOrdered` change that mistook an
     /// equal-time tie for a head insertion) or where bootstrap
     /// cancellation accidentally became reachable.
     function testFuzzHeadStaysAtBootstrapAcrossScheduleCancelMix(uint8 nodeCountSeed, uint8 cancelMaskSeed) external {
@@ -1298,9 +1298,9 @@ contract StoxCorporateActionsFacetTest is Test {
         assertEq(actionIndex, 1);
     }
 
-    /// `_ensureBootstrap` is silent — it must not emit `CorporateActionScheduled`
+    /// `ensureBootstrap` is silent — it must not emit `CorporateActionScheduled`
     /// for the bootstrap node, only the user action triggers an emit. A
-    /// regression that taught `_ensureBootstrap` to mirror `schedule`'s
+    /// regression that taught `ensureBootstrap` to mirror `schedule`'s
     /// emit would surface to off-chain indexers as a phantom action with
     /// idx 0 and `actionType = ACTION_TYPE_INIT_V1` they had never asked
     /// for, breaking any indexer that assumes one event per
@@ -1310,7 +1310,7 @@ contract StoxCorporateActionsFacetTest is Test {
         bytes memory parameters = LibStockSplit.encodeParametersV1(twoX);
 
         // Record every log emitted across the first scheduleCorporateAction
-        // call (which fires `_ensureBootstrap` plus the user action splice).
+        // call (which fires `ensureBootstrap` plus the user action splice).
         vm.recordLogs();
         vm.prank(ALICE);
         facetViaHarness.scheduleCorporateAction(STOCK_SPLIT_V1_TYPE_HASH, 1500, parameters);
@@ -1512,12 +1512,12 @@ contract StoxCorporateActionsFacetTest is Test {
     }
 
     /// getActionParameters at idx 0 (the bootstrap node) returns the empty
-    /// bytes blob `_ensureBootstrap` wrote. Bootstrap is a real walkable
+    /// bytes blob `ensureBootstrap` wrote. Bootstrap is a real walkable
     /// node under the 0-based scheme — a future "tighten cursor lower
     /// bound to 1" refactor would silently break receipt-side walks that
     /// happen to land here.
     function testGetActionParametersBootstrapReturnsEmpty() external {
-        // Schedule one user action so `_ensureBootstrap` fires and the
+        // Schedule one user action so `ensureBootstrap` fires and the
         // bootstrap node lands at idx 0.
         Float twoX = LibDecimalFloat.packLossless(2, 0);
         bytes memory params = LibStockSplit.encodeParametersV1(twoX);
@@ -1760,7 +1760,7 @@ contract StoxCorporateActionsFacetTest is Test {
 
     // -----------------------------------------------------------------------
     // Bootstrap (ACTION_TYPE_INIT_V1) coverage. The init node is created
-    // lazily by `_ensureBootstrap` on the first `schedule` call. These tests
+    // lazily by `ensureBootstrap` on the first `schedule` call. These tests
     // pin its identity, position, idempotency, and the immunity of the rest
     // of the system to the user trying to cancel or reschedule it.
 
@@ -1784,7 +1784,7 @@ contract StoxCorporateActionsFacetTest is Test {
         assertEq(bootstrap.next, userId, "bootstrap.next is the first user action");
     }
 
-    /// `_ensureBootstrap` writes `totalSupplyLatestCursor = NODE_NONE` as
+    /// `ensureBootstrap` writes `totalSupplyLatestCursor = NODE_NONE` as
     /// the "no fold has run yet" sentinel. The first `fold()` walks
     /// head-inclusive against this; `onMint` / `onBurn` use it as a
     /// guard that they should be no-ops when the array is empty (via
@@ -1793,13 +1793,13 @@ contract StoxCorporateActionsFacetTest is Test {
     /// value directly catches a regression that initialised the slot to
     /// 0 (which would silently mean "fold has landed on bootstrap" and
     /// route mint/burn into pot 0 from the very first schedule call).
-    /// Pin the post-`_ensureBootstrap` storage shape of `bootstrap.prev` /
+    /// Pin the post-`ensureBootstrap` storage shape of `bootstrap.prev` /
     /// `bootstrap.next`. After bootstrap fires, both must be `NODE_NONE` —
     /// the bootstrap is the only node in the list and has no neighbours.
-    /// The production `schedule` call fires `_ensureBootstrap` and then
+    /// The production `schedule` call fires `ensureBootstrap` and then
     /// immediately splices in the user action, mutating `bootstrap.next`
     /// away from `NODE_NONE`; without a standalone hook into
-    /// `_ensureBootstrap` (now `internal`) this in-between state is
+    /// `ensureBootstrap` (now `internal`) this in-between state is
     /// unreachable.
     ///
     /// Failure mode this catches: a regression that left
@@ -1813,12 +1813,12 @@ contract StoxCorporateActionsFacetTest is Test {
         corporateActionHarness.ensureBootstrap();
 
         CorporateActionNode memory bootstrap = corporateActionHarness.getNode(0);
-        assertEq(bootstrap.prev, NODE_NONE, "bootstrap.prev must be NODE_NONE post-_ensureBootstrap");
-        assertEq(bootstrap.next, NODE_NONE, "bootstrap.next must be NODE_NONE post-_ensureBootstrap");
+        assertEq(bootstrap.prev, NODE_NONE, "bootstrap.prev must be NODE_NONE post-ensureBootstrap");
+        assertEq(bootstrap.next, NODE_NONE, "bootstrap.next must be NODE_NONE post-ensureBootstrap");
     }
 
     function testEnsureBootstrapInitsTotalSupplyLatestCursorToNodeNone() external {
-        // Pre-schedule: storage default is 0. The post-_ensureBootstrap
+        // Pre-schedule: storage default is 0. The post-ensureBootstrap
         // value must be NODE_NONE, distinct from the default, so the
         // first `fold` knows it has not run yet.
         assertEq(corporateActionHarness.totalSupplyLatestCursor(), 0, "default storage is 0 pre-schedule");
@@ -1828,7 +1828,7 @@ contract StoxCorporateActionsFacetTest is Test {
         assertEq(
             corporateActionHarness.totalSupplyLatestCursor(),
             NODE_NONE,
-            "_ensureBootstrap writes NODE_NONE as the no-fold-yet sentinel"
+            "ensureBootstrap writes NODE_NONE as the no-fold-yet sentinel"
         );
     }
 
@@ -1890,7 +1890,7 @@ contract StoxCorporateActionsFacetTest is Test {
         );
     }
 
-    /// `_ensureBootstrap` snapshots `OZ.underlyingTotalSupply()` into
+    /// `ensureBootstrap` snapshots `OZ.underlyingTotalSupply()` into
     /// `unmigrated[0]` exactly once, on the first `schedule` call. A second
     /// schedule (with new mints in between) MUST NOT overwrite the snapshot
     /// — once the bootstrap has fired, additional supply is tracked via
@@ -1900,7 +1900,7 @@ contract StoxCorporateActionsFacetTest is Test {
     ///
     /// This test pokes OZ's `_totalSupply` directly between the two
     /// schedule calls to make a snapshot drift unambiguous: if
-    /// `_ensureBootstrap` re-fired, `unmigrated[0]` would change to the
+    /// `ensureBootstrap` re-fired, `unmigrated[0]` would change to the
     /// new value; if it correctly bailed out, the original snapshot
     /// stands.
     function testEnsureBootstrapSnapshotsOnlyOnFirstSchedule() external {
@@ -1919,7 +1919,7 @@ contract StoxCorporateActionsFacetTest is Test {
         // calls outside the corporate-action path would do).
         vm.store(address(corporateActionHarness), bytes32(uint256(ozBase) + 2), bytes32(uint256(5000)));
 
-        // Second schedule — `_ensureBootstrap` must short-circuit on
+        // Second schedule — `ensureBootstrap` must short-circuit on
         // `s.nodes.length != 0` and NOT re-snapshot. `unmigrated[0]` stays
         // pinned to the first value.
         corporateActionHarness.schedule(ACTION_TYPE_STOCK_SPLIT_V1, 2500, hex"");
@@ -1975,7 +1975,7 @@ contract StoxCorporateActionsFacetTest is Test {
     /// blob via the facet's external API. Under the 0-based scheme idx 0
     /// is a real walkable node, and the facet's bounds check
     /// (`actionId >= s.nodes.length`) admits cursor 0 once
-    /// `_ensureBootstrap` has fired. Storage-direct reads of
+    /// `ensureBootstrap` has fired. Storage-direct reads of
     /// `bootstrap.parameters.length == 0` already pin the storage shape;
     /// this pins the public-API contract — a regression that re-introduced
     /// a `cursor != 0` reject inside `getActionParameters` (matching the

--- a/test/src/concrete/StoxCorporateActionsInvariant.t.sol
+++ b/test/src/concrete/StoxCorporateActionsInvariant.t.sol
@@ -32,8 +32,8 @@ contract InvariantVault is StoxReceiptVault {
     function _update(address from, address to, uint256 amount) internal override {
         LibTotalSupply.fold();
 
-        _migrateAccount(from);
-        _migrateAccount(to);
+        migrateAccount(from);
+        migrateAccount(to);
 
         ERC20Upgradeable._update(from, to, amount);
 
@@ -358,7 +358,7 @@ contract StoxCorporateActionsHandler is Test {
         assertEq(
             VAULT.migrationCursor(a),
             VAULT.totalSupplyLatestCursor(),
-            "invariant 4: cursor(actor) == totalSupplyLatestCursor after _migrateAccount"
+            "invariant 4: cursor(actor) == totalSupplyLatestCursor after migrateAccount"
         );
     }
 
@@ -386,7 +386,7 @@ contract StoxCorporateActionsHandler is Test {
         assertEq(
             RECEIPT.holderIdCursor(a, id),
             VAULT.totalSupplyLatestCursor(),
-            "receipt invariant: holderIdCursor == totalSupplyLatestCursor after _migrateHolderId"
+            "receipt invariant: holderIdCursor == totalSupplyLatestCursor after migrateHolderId"
         );
     }
 
@@ -564,7 +564,7 @@ contract StoxCorporateActionsInvariantTest is Test {
     }
 
     /// Invariant 4 is a POST-CALL property, not a resting invariant:
-    /// after `_migrateAccount(account)` returns inside `_update`, that
+    /// after `migrateAccount(account)` returns inside `_update`, that
     /// specific account's cursor equals `totalSupplyLatestCursor`. It does
     /// NOT hold for every actor at every moment — an actor touched before
     /// a later split completes legitimately sits at the older cursor until
@@ -612,7 +612,7 @@ contract StoxCorporateActionsInvariantTest is Test {
     }
 
     /// Invariant 6: `totalSupplyLatestCursor` is either `NODE_NONE` (the
-    /// `_ensureBootstrap`-set sentinel meaning "no fold has run yet") or
+    /// `ensureBootstrap`-set sentinel meaning "no fold has run yet") or
     /// points at a node whose effective time is in the past. It must also
     /// not exceed the nodes array bounds.
     function invariantTotalSupplyLatestSplitValid() external view {

--- a/test/src/concrete/StoxReceipt.t.sol
+++ b/test/src/concrete/StoxReceipt.t.sol
@@ -40,7 +40,7 @@ contract StoxReceiptTest is Test {
 /// contract implementing both.
 ///
 /// `IReceiptManagerV2` also requires `symbol()`, `decimals()` etc. via the
-/// Receipt's `_vaultShareSymbol` helper. In tests we only call `balanceOf`
+/// Receipt's `getVaultShareSymbol` helper. In tests we only call `balanceOf`
 /// and `_update` paths that don't hit `uri()`, so the stub implementations
 /// below are minimal.
 contract MockVault is ICorporateActionsV1, IReceiptManagerV2 {
@@ -128,7 +128,7 @@ contract MockVault is ICorporateActionsV1, IReceiptManagerV2 {
         revert("mock");
     }
 
-    /// Expose minimal IERC20Metadata surface that `Receipt._vaultShareSymbol`
+    /// Expose minimal IERC20Metadata surface that `Receipt.getVaultShareSymbol`
     /// calls via `IERC20Metadata(address(manager)).symbol()`. Not actually
     /// used in our tests (we never hit `uri()`), but the `_update` path may
     /// touch it if anything inspects name/symbol. Stubbed for safety.
@@ -174,7 +174,7 @@ contract TestStoxReceipt is StoxReceipt {
     /// Expose internal migration so tests can exercise the zero-address
     /// short-circuit directly.
     function publicMigrateHolderId(address account, uint256 id) external {
-        _migrateHolderId(account, id, ICorporateActionsV1(this.manager()));
+        migrateHolderId(account, id, ICorporateActionsV1(this.manager()));
     }
 }
 
@@ -440,7 +440,7 @@ contract StoxReceiptRebaseIntegrationTest is Test {
         assertEq(receipt.rawStoredBalance(ALICE, ID_A), 50);
     }
 
-    /// `_migrateHolderId(address(0), ...)` short-circuits. After a
+    /// `migrateHolderId(address(0), ...)` short-circuits. After a
     /// completed split, calling it for address(0) must leave address(0)'s
     /// cursor and balance at their zero-initialized values (no state
     /// pollution on the zero address).
@@ -745,7 +745,7 @@ contract StoxReceiptRebaseIntegrationTest is Test {
     // Issue #81: receipt-side always-emit semantics.
     //
     // Mirrors the share-side test matrix on `StoxReceiptVault.t.sol`.
-    // `_migrateHolderId` must emit `ReceiptAccountMigrated` on every
+    // `migrateHolderId` must emit `ReceiptAccountMigrated` on every
     // cursor advance, regardless of whether the rasterized balance equals
     // the pre-rebase balance. Four phenomena drive a balance-equal
     // cursor advance: zero balance, single-step truncation collision,
@@ -823,7 +823,7 @@ contract StoxReceiptRebaseIntegrationTest is Test {
     /// Already-migrated complement: a `(holder, id)` pair at the latest
     /// cursor that gets touched again with no new completed splits in
     /// between must NOT re-emit `ReceiptAccountMigrated`. Pins the
-    /// `newCursor == currentCursor` early return in `_migrateHolderId`.
+    /// `newCursor == currentCursor` early return in `migrateHolderId`.
     function testReceiptAccountMigratedDoesNotReEmitWhenAlreadyAtLatest() external {
         _mint(ALICE, ID_A, 100);
         _splitParams(2);
@@ -850,7 +850,7 @@ contract StoxReceiptRebaseIntegrationTest is Test {
 
     /// Event ordering pin: `ReceiptAccountMigrated` must fire BEFORE the
     /// corresponding ERC-1155 `TransferSingle` event in the same `_update`
-    /// call, because `_migrateHolderId` runs before the receipt's base
+    /// call, because `migrateHolderId` runs before the receipt's base
     /// `_update`. Indexers rely on this ordering to compute pre-transfer
     /// rasterized balances from the migration log.
     function testReceiptAccountMigratedOrderedBeforeTransferSingle() external {

--- a/test/src/concrete/StoxReceiptVault.t.sol
+++ b/test/src/concrete/StoxReceiptVault.t.sol
@@ -26,7 +26,7 @@ import {LibTotalSupply} from "../../../src/lib/LibTotalSupply.sol";
 /// standing up the full rain.vats auth/freeze infrastructure (admin grants,
 /// authorizer wiring, certify state, etc).
 ///
-/// The test class re-overrides `_update` to call `_migrateAccount` for both
+/// The test class re-overrides `_update` to call `migrateAccount` for both
 /// sides and then call `ERC20Upgradeable._update` directly, skipping the
 /// `OffchainAssetReceiptVault._update` middle layer. The migration semantics
 /// being tested live entirely in `StoxReceiptVault` and the libraries it calls,
@@ -37,8 +37,8 @@ contract TestStoxReceiptVault is StoxReceiptVault {
         // bypassing the OffchainAssetReceiptVault authorizer/freeze layer.
         LibTotalSupply.fold();
 
-        _migrateAccount(from);
-        _migrateAccount(to);
+        migrateAccount(from);
+        migrateAccount(to);
 
         ERC20Upgradeable._update(from, to, amount);
 
@@ -209,16 +209,16 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
         assertEq(vault.migrationCursor(fresh), 0, "fresh account cursor defaults to 0 (= bootstrap)");
     }
 
-    /// `_migrateAccount` is a complete no-op when no completed splits
+    /// `migrateAccount` is a complete no-op when no completed splits
     /// exist past the holder's cursor. Fresh holder (cursor 0 = bootstrap),
     /// only bootstrap fired, no user splits completed: a touch must not
     /// emit `AccountMigrated` and must not write to `accountMigrationCursor`
     /// (it stays at the default 0). The cursor-advance early-return inside
-    /// `_migrateAccount` (`if (newCursor == currentCursor) return;`) is what
+    /// `migrateAccount` (`if (newCursor == currentCursor) return;`) is what
     /// suppresses both. A regression that emitted unconditionally or that
     /// wrote the cursor before the early-return would surface here.
     function testMigrateAccountNoOpWhenAtLatest() external {
-        // Schedule a future user split so `_ensureBootstrap` fires.
+        // Schedule a future user split so `ensureBootstrap` fires.
         // The split is pending; only bootstrap is completed.
         vault.publicSchedule(ACTION_TYPE_STOCK_SPLIT_V1, 5000, _splitParams(2));
 
@@ -464,7 +464,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
     /// Already-migrated complement of #81's always-emit semantics: an
     /// account at the latest cursor that gets touched again (no new
     /// completed splits in between) must NOT re-emit `AccountMigrated`.
-    /// The `newCursor == currentCursor` early return in `_migrateAccount`
+    /// The `newCursor == currentCursor` early return in `migrateAccount`
     /// suppresses the spurious event. Pins that "every cursor advance
     /// emits" reads as "iff cursor advances".
     function testAccountMigratedDoesNotReEmitWhenAlreadyAtLatest() external {
@@ -494,7 +494,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
 
     /// Event ordering pin: `AccountMigrated` must fire BEFORE the
     /// corresponding ERC-20 `Transfer` event in the same `_update` call,
-    /// because `_migrateAccount` runs before `super._update`. Indexers
+    /// because `migrateAccount` runs before `super._update`. Indexers
     /// rely on this ordering to compute pre-transfer rasterized balances
     /// from the migration log before applying the transfer delta.
     function testAccountMigratedOrderedBeforeTransfer() external {
@@ -707,7 +707,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
         assertEq(vault.totalSupply(), 150, "totalSupply reflects burn via OZ");
         assertEq(vault.unmigrated(0), 0, "pot 0 still untouched");
 
-        // Schedule a split with a future effective time. `_ensureBootstrap`
+        // Schedule a split with a future effective time. `ensureBootstrap`
         // fires here: pushes the bootstrap node at idx 0 with `effectiveTime
         // = block.timestamp` (immediately completed), captures `unmigrated[0]
         // = OZ.totalSupply` (= 150 after the prior mint/burn), and writes
@@ -715,7 +715,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
         // sentinel. The user split lands at idx 1 and is pending until warp.
         vault.publicSchedule(ACTION_TYPE_STOCK_SPLIT_V1, 5000, _splitParams(2));
         // `totalSupplyLatestCursor` only moves inside `fold` (called from
-        // `_update`), so it stays at the `NODE_NONE` sentinel `_ensureBootstrap`
+        // `_update`), so it stays at the `NODE_NONE` sentinel `ensureBootstrap`
         // wrote until the next _update.
         assertEq(vault.totalSupplyLatestCursor(), NODE_NONE, "schedule alone does not advance latest cursor");
         assertEq(vault.unmigrated(0), 150, "ensureBootstrap snapshotted OZ total supply into pot 0");
@@ -724,7 +724,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
         // is at idx 0 and completed at schedule time, so `fold()` advances
         // `totalSupplyLatestCursor` to the bootstrap (idx 0). BOB's cursor
         // default is already 0 (= bootstrap), and there are no completed
-        // splits past it, so `_migrateAccount` is a no-op for him. Then
+        // splits past it, so `migrateAccount` is a no-op for him. Then
         // super._update mints 100 into _balances[BOB], and onMint adds
         // 100 to `unmigrated[0]` (the latest pot).
         vault.publicUpdate(address(0), BOB, 100);
@@ -819,7 +819,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
     // -----------------------------------------------------------------------
     // Cursor / totalSupplyLatestCursor invariant.
     //
-    // After `_migrateAccount(account)` returns inside `_update` (which runs
+    // After `migrateAccount(account)` returns inside `_update` (which runs
     // after `fold()`), `accountMigrationCursor[account]` equals
     // `s.totalSupplyLatestCursor`. `LibTotalSupply.onBurn` subtracts the
     // burn amount from `unmigrated[totalSupplyLatestCursor]`. If the
@@ -856,7 +856,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
 
         // Now burn some from Bob. Inside `_update`, fold() advances
         // totalSupplyLatestCursor to 2 (the second split), then
-        // _migrateAccount(BOB) walks Bob's cursor from 1 to 2, rasterizing
+        // migrateAccount(BOB) walks Bob's cursor from 1 to 2, rasterizing
         // the balance to 6000. Then onBurn(500) subtracts 500 from
         // unmigrated[2]. If the cursor invariant held, this succeeds; if
         // it didn't, onBurn would underflow.
@@ -955,7 +955,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
         assertEq(
             vault.migrationCursor(account),
             vault.totalSupplyLatestCursor(),
-            "migrationCursor must equal totalSupplyLatestCursor after _migrateAccount"
+            "migrationCursor must equal totalSupplyLatestCursor after migrateAccount"
         );
     }
 
@@ -973,11 +973,11 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
     /// they'll diverge and the pot accounting will break silently. This test
     /// fails fast in that scenario:
     ///
-    ///   - If `_migrateAccount` starts walking the new type without
+    ///   - If `migrateAccount` starts walking the new type without
     ///     `LibTotalSupply.fold()` doing the same, the first assertion here
     ///     fails because `migrationCursor` advances past the synthetic node
     ///     but `totalSupplyLatestCursor` does not.
-    ///   - If `fold()` starts walking the new type without `_migrateAccount`
+    ///   - If `fold()` starts walking the new type without `migrateAccount`
     ///     doing the same, the inverse failure mode triggers.
     ///
     /// When that happens, DO NOT just update the assertions — the failure is
@@ -993,14 +993,14 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
         // lands at idx 2.
         vault.publicSchedule(ACTION_TYPE_STABLES_DIVIDEND_V1, 1500, abi.encode(uint256(0)));
 
-        // Give Bob a pre-existing balance so _migrateAccount has something
+        // Give Bob a pre-existing balance so migrateAccount has something
         // to rasterize if it ever starts walking the dividend node.
         vault.publicUpdate(address(0), BOB, 1000);
 
         // Warp past the dividend's effective time so it counts as completed.
         vm.warp(2000);
 
-        // Touch Bob to drive fold() + _migrateAccount.
+        // Touch Bob to drive fold() + migrateAccount.
         vault.publicUpdate(BOB, BOB, 0);
 
         // Bootstrap (idx 0, type INIT) is the default cursor and IS in the
@@ -1043,7 +1043,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
 
         // Critically: no `_update` between the warp and the read, so
         // `fold()` hasn't run; `totalSupplyLatestCursor` is still the
-        // `NODE_NONE` sentinel `_ensureBootstrap` set even though it
+        // `NODE_NONE` sentinel `ensureBootstrap` set even though it
         // populated `unmigrated[0]` from the schedule. The view's walk
         // reads `unmigrated[0]` directly.
         assertEq(vault.totalSupplyLatestCursor(), NODE_NONE, "no _update yet => latestCursor unchanged");
@@ -1052,7 +1052,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
 
     /// `effectiveTotalSupply()` called between split completion and the first
     /// post-split `_update` reads `unmigrated[0]` (snapshotted by
-    /// `_ensureBootstrap` at schedule time) and walks every completed
+    /// `ensureBootstrap` at schedule time) and walks every completed
     /// multiplier. No state mutation in the view path.
     ///
     /// INTENT: pin the behaviour of the view during the post-schedule,
@@ -1065,7 +1065,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
         assertEq(vault.totalSupplyLatestCursor(), 0, "no split tracked yet (default storage)");
 
         // Schedule a 2x split and warp past its effective time. Schedule
-        // runs `_ensureBootstrap`, which snapshots `unmigrated[0] = 100`
+        // runs `ensureBootstrap`, which snapshots `unmigrated[0] = 100`
         // and sets `totalSupplyLatestCursor = NODE_NONE` as the "no fold
         // has run yet" sentinel. Critically, do NOT call any `_update`
         // after warping — so `fold()` hasn't run.
@@ -1144,7 +1144,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
     /// simultaneously to pin the migrate+burn interaction in one test.
     ///
     /// INTENT: a future regression that, for example, decoupled
-    /// `onBurn` from `_migrateAccount`'s ordering would leave one of
+    /// `onBurn` from `migrateAccount`'s ordering would leave one of
     /// the pots or the stored balance inconsistent with the others.
     /// Asserting all four quantities at once makes such a regression
     /// visible in a single test failure rather than having to correlate
@@ -1236,7 +1236,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
         vault.publicSchedule(ACTION_TYPE_STOCK_SPLIT_V1, 1500, _splitParams(2));
         vm.warp(2000);
 
-        // Alice touches: `_ensureBootstrap` already snapshotted
+        // Alice touches: `ensureBootstrap` already snapshotted
         // `unmigrated[0] = 150` at schedule time; the user split is at
         // idx 1 (bootstrap is at idx 0). Alice migrates 50 → 100, shifting
         // 50 out of pot 0 and 100 into pot 1.
@@ -1464,7 +1464,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
     /// split chain, repeated touches with no new splits must not change
     /// cursor, stored balance, or view balance, and must not re-emit
     /// `AccountMigrated`. Guards the `newCursor == currentCursor` early
-    /// return in `_migrateAccount`.
+    /// return in `migrateAccount`.
     function testFuzzMigrationIdempotentAcrossRepeatedTouches(
         uint32 initialBalance,
         uint8 numSplits,
@@ -1633,7 +1633,7 @@ contract StoxReceiptVaultMigrationIntegrationTest is Test {
     uint256 internal constant OP_COUNT = 4;
 
     /// Three deterministic regression tests below pin the invariants that
-    /// `StoxReceiptVault._migrateAccount`'s `if (account == address(0)) return;`
+    /// `StoxReceiptVault.migrateAccount`'s `if (account == address(0)) return;`
     /// short-circuit preserves. The skip is sound only because OZ
     /// `ERC20Upgradeable` routes mints/burns through `_totalSupply`, never
     /// through `_balances[address(0)]` — if a future refactor (or a new facet)

--- a/test/src/concrete/StoxReceiptVaultFallbackRouting.t.sol
+++ b/test/src/concrete/StoxReceiptVaultFallbackRouting.t.sol
@@ -144,7 +144,7 @@ contract StoxReceiptVaultFallbackRoutingTest is Test {
     /// Pins that the fallback delegatecall path returns idx 0 for this,
     /// not silently rewriting it through some sentinel translation layer.
     function testNextOfTypeHeadInclusiveReturnsBootstrap() external {
-        // Schedule a user action so `_ensureBootstrap` fires; bootstrap
+        // Schedule a user action so `ensureBootstrap` fires; bootstrap
         // is at idx 0, user action at idx 1.
         bytes memory params = abi.encode(LibDecimalFloat.packLossless(2, 0));
         vm.prank(ALICE);

--- a/test/src/lib/LibTotalSupply.t.sol
+++ b/test/src/lib/LibTotalSupply.t.sol
@@ -506,7 +506,7 @@ contract LibTotalSupplyTest is Test {
     /// `onBurn` reverts via Solidity 0.8 underflow panic when the burn
     /// amount exceeds the current pot at `totalSupplyLatestCursor`. Under
     /// normal vault operation this state is unreachable (every burn is
-    /// preceded by `_migrateAccount(burner)`, which moves the burner's
+    /// preceded by `migrateAccount(burner)`, which moves the burner's
     /// balance into the latest pot first), but wrapping the subtraction
     /// in an `unchecked` block would silently skip the check and let a
     /// refactor corrupt the pot.


### PR DESCRIPTION
Closes #165.

Renames seven internal/private functions defined here (not inherited from a third-party base) to drop the OZ-style leading underscore:

| Old | New |
|---|---|
| `LibCorporateAction._ensureBootstrap` | `ensureBootstrap` |
| `LibCorporateAction._insertOrdered` | `insertOrdered` |
| `StoxReceipt._balanceOf` | `balanceOfFor` |
| `StoxReceipt._migrateHolderId` | `migrateHolderId` |
| `StoxReceipt._vault` | `getVault` |
| `StoxReceiptVault._migrateAccount` | `migrateAccount` |
| `StoxCorporateActionsFacet._authorize` | `authorizeAction` |

`balanceOfFor` / `getVault` / `authorizeAction` get descriptive suffixes to avoid collision with the OZ public `balanceOf` overload, the ICloneable `vault()` concept, and the `IAuthorizeV1.authorize` external call. The rest just lose the leading underscore.

Visibility is on the function declaration; the underscore conveyed nothing the signature didn't already say. OZ-inherited overrides (`_update`, `_msgSender`, etc.) keep their inherited names per the issue's out-of-scope list.

## Test plan
- [x] 533/533 tests pass locally
- [ ] static + legal + test (CI)
