### PR TITLE
test: pin metamorphic-risk on V1 beacons (#163)

### DIFF
--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -331,6 +331,36 @@ contract LibProdTokensBaseTest is Test {
         );
     }
 
+    /// Same pattern extended to the three V1 beacons. UpgradeableBeacon
+    /// doesn't contain reachable DELEGATECALL on its own (the upgrade
+    /// flow is a storage write); expected bitmap is 0 per beacon.
+    function testProdReceiptBeaconMetamorphicRiskPinned() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            LibExtrospectMetamorphic.scanMetamorphicRisk(LibProdDeployV1.STOX_RECEIPT_BEACON_V1.code),
+            0,
+            "STOX_RECEIPT_BEACON_V1 metamorphic surface drifted"
+        );
+    }
+
+    function testProdReceiptVaultBeaconMetamorphicRiskPinned() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            LibExtrospectMetamorphic.scanMetamorphicRisk(LibProdDeployV1.STOX_RECEIPT_VAULT_BEACON_V1.code),
+            0,
+            "STOX_RECEIPT_VAULT_BEACON_V1 metamorphic surface drifted"
+        );
+    }
+
+    function testProdWrappedTokenVaultBeaconMetamorphicRiskPinned() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            LibExtrospectMetamorphic.scanMetamorphicRisk(LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_V1.code),
+            0,
+            "STOX_WRAPPED_TOKEN_VAULT_BEACON_V1 metamorphic surface drifted"
+        );
+    }
+
     /// Pin the deployed runtime bytecode of each prod V1 deployer against
     /// its `LibProdDeployV1.PROD_*_BASE_CODEHASH_V1` constant. The
     /// per-token-set assertions in `checkTokenSet` trust the OARV


### PR DESCRIPTION
Closes #163.

Three pin tests asserting `scanMetamorphicRisk` against each V1 beacon's runtime code matches `0`:
- `STOX_RECEIPT_BEACON_V1`
- `STOX_RECEIPT_VAULT_BEACON_V1`
- `STOX_WRAPPED_TOKEN_VAULT_BEACON_V1`

`UpgradeableBeacon` doesn't contain reachable DELEGATECALL on its own (the upgrade flow is a storage write); empirically all three pin to 0. Drift forces re-evaluation.

## Test plan
- [x] All 3 pins green on Base fork
- [ ] static + legal + test (CI)
