### PR TITLE
test: pin no-CBOR-metadata on V1 beacons

### DIFF
--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -192,6 +192,21 @@ contract LibProdTokensBaseTest is Test {
         LibExtrospectBytecode.checkNoSolidityCBORMetadata(LibProdDeployV1.STOX_UNIFIED_DEPLOYER);
     }
 
+    function testProdReceiptBeaconHasNoCBOR() external {
+        LibTestProd.createSelectForkBase(vm);
+        LibExtrospectBytecode.checkNoSolidityCBORMetadata(LibProdDeployV1.STOX_RECEIPT_BEACON_V1);
+    }
+
+    function testProdReceiptVaultBeaconHasNoCBOR() external {
+        LibTestProd.createSelectForkBase(vm);
+        LibExtrospectBytecode.checkNoSolidityCBORMetadata(LibProdDeployV1.STOX_RECEIPT_VAULT_BEACON_V1);
+    }
+
+    function testProdWrappedTokenVaultBeaconHasNoCBOR() external {
+        LibTestProd.createSelectForkBase(vm);
+        LibExtrospectBytecode.checkNoSolidityCBORMetadata(LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_V1);
+    }
+
     /// Mutation pin: the no-CBOR tests above all return clean (no revert),
     /// which by itself doesn't prove `checkNoSolidityCBORMetadata` would
     /// catch a deployment that actually carried CBOR metadata. Construct


### PR DESCRIPTION
## Summary
- Extends checkNoSolidityCBORMetadata pins to the three V1 beacons.

Closes #162.

## Test plan
- [x] beacon no-CBOR fork tests pass on Base.