### PR TITLE
test: pin V1 beacon runtime codehashes

### DIFF
--- a/src/lib/LibProdDeployV1.sol
+++ b/src/lib/LibProdDeployV1.sol
@@ -44,6 +44,18 @@ library LibProdDeployV1 {
     /// https://basescan.org/address/0x4c2d2d3bf1232bf0d3fb7123007a9b8444637bc8
     address constant STOX_WRAPPED_TOKEN_VAULT_BEACON_V1 = address(0x4c2d2d3Bf1232bf0d3FB7123007A9B8444637bC8);
 
+    /// @dev Runtime codehash shared by all three V1 beacon contracts on Base
+    /// (`STOX_RECEIPT_BEACON_V1`, `STOX_RECEIPT_VAULT_BEACON_V1`,
+    /// `STOX_WRAPPED_TOKEN_VAULT_BEACON_V1`). All three are
+    /// `UpgradeableBeacon` instances — their implementation and owner live
+    /// in storage, not in code, so the runtime bytecode is identical across
+    /// every beacon constructed from the same `UpgradeableBeacon` source.
+    /// Pinning this codehash guards against a tampered beacon contract
+    /// proxying through `implementation()`/`owner()` selectors that would
+    /// otherwise pass the existing impl-codehash and owner checks.
+    bytes32 constant PROD_BEACON_BASE_RUNTIME_CODEHASH_V1 =
+        0x8e95867e52db417944afd90f3b6c3c980962831e8a944e7f6958ba8f8cc10630;
+
     /// @dev The StoxWrappedTokenVault implementation deployed inside the
     /// StoxWrappedTokenVault beacon set on Base. Accessible via
     /// iStoxWrappedTokenVaultBeacon.implementation(). No proxy instances have

--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -207,6 +207,31 @@ contract LibProdTokensBaseTest is Test {
         LibExtrospectBytecode.checkNoSolidityCBORMetadata(LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_V1);
     }
 
+    /// All three V1 beacons are `UpgradeableBeacon` instances — implementation
+    /// and owner live in storage, runtime bytecode is identical. Pinning the
+    /// shared codehash detects a beacon address swapped to a contract that
+    /// merely mimics the `implementation()` / `owner()` selectors used by the
+    /// other checks, which would otherwise pass through unnoticed.
+    function testProdReceiptBeaconRuntimeCodehash() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(LibProdDeployV1.STOX_RECEIPT_BEACON_V1.codehash, LibProdDeployV1.PROD_BEACON_BASE_RUNTIME_CODEHASH_V1);
+    }
+
+    function testProdReceiptVaultBeaconRuntimeCodehash() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            LibProdDeployV1.STOX_RECEIPT_VAULT_BEACON_V1.codehash, LibProdDeployV1.PROD_BEACON_BASE_RUNTIME_CODEHASH_V1
+        );
+    }
+
+    function testProdWrappedTokenVaultBeaconRuntimeCodehash() external {
+        LibTestProd.createSelectForkBase(vm);
+        assertEq(
+            LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_V1.codehash,
+            LibProdDeployV1.PROD_BEACON_BASE_RUNTIME_CODEHASH_V1
+        );
+    }
+
     /// Mutation pin: the no-CBOR tests above all return clean (no revert),
     /// which by itself doesn't prove `checkNoSolidityCBORMetadata` would
     /// catch a deployment that actually carried CBOR metadata. Construct


### PR DESCRIPTION
## Summary
- Adds PROD_BEACON_BASE_RUNTIME_CODEHASH_V1 to LibProdDeployV1.
- All three V1 beacons share the codehash because they are all UpgradeableBeacon instances (impl/owner live in storage, not code).
- Three pin tests assert each beacon address's runtime codehash matches the constant.

Closes #113.

## Test plan
- [x] testProd*BeaconRuntimeCodehash on Base fork: 3 passed.