### PR TITLE
chore: bump rain-vats dep 0.1.1 -> 0.1.2

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -42,7 +42,7 @@ forge-std = "1.16.1"
 "rain-sol-codegen" = "0.1.0"
 "rain-solmem" = "0.1.3"
 "rain-tofu-erc20-decimals" = "0.1.1"
-"rain-vats" = "0.1.1"
+"rain-vats" = "0.1.2"
 "rain-verify-interface" = "0.1.0"
 
 [soldeer]

--- a/remappings.txt
+++ b/remappings.txt
@@ -9,6 +9,5 @@ rain-math-float-0.1.1/=dependencies/rain-math-float-0.1.1/
 rain-sol-codegen-0.1.0/=dependencies/rain-sol-codegen-0.1.0/
 rain-solmem-0.1.3/=dependencies/rain-solmem-0.1.3/
 rain-tofu-erc20-decimals-0.1.1/=dependencies/rain-tofu-erc20-decimals-0.1.1/
-rain-vats-0.1.0/=dependencies/rain-vats-0.1.0/
-rain-vats-0.1.1/=dependencies/rain-vats-0.1.1/
+rain-vats-0.1.2/=dependencies/rain-vats-0.1.2/
 rain-verify-interface-0.1.0/=dependencies/rain-verify-interface-0.1.0/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -77,10 +77,10 @@ integrity = "9e1fccf893dd0d90aeb445c78f9eee3904bc50287ff1da30b954508f18412cd2"
 
 [[dependencies]]
 name = "rain-vats"
-version = "0.1.1"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-vats/0_1_1_14-05-2026_13:57:41_rain.zip"
-checksum = "2ab3bed33090bdee4729a2daa754bc590532bab031bf3d8fab972aff66c47d7d"
-integrity = "5b70da80f901d020db0cfe49738982fde0b561132d65996495da390b543e37fd"
+version = "0.1.2"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-vats/0_1_2_14-05-2026_20:31:45_rain.zip"
+checksum = "1aaa977a9de37eba9067caf64675413359eed50b71dc5b11d8f22bb1d93e7cee"
+integrity = "e7824596422efb62693e6cd417392439a2ed6906ba1996f5304ff3f599f6a4eb"
 
 [[dependencies]]
 name = "rain-verify-interface"

--- a/src/concrete/StoxCorporateActionsFacet.sol
+++ b/src/concrete/StoxCorporateActionsFacet.sol
@@ -11,8 +11,8 @@ import {
     LibCorporateActionNode,
     NODE_NONE
 } from "../lib/LibCorporateActionNode.sol";
-import {IAuthorizeV1} from "rain-vats-0.1.1/src/interface/IAuthorizeV1.sol";
-import {OffchainAssetReceiptVault} from "rain-vats-0.1.1/src/concrete/vault/OffchainAssetReceiptVault.sol";
+import {IAuthorizeV1} from "rain-vats-0.1.2/src/interface/IAuthorizeV1.sol";
+import {OffchainAssetReceiptVault} from "rain-vats-0.1.2/src/concrete/vault/OffchainAssetReceiptVault.sol";
 
 /// @title StoxCorporateActionsFacet
 /// @notice Diamond facet implementing the corporate action linked list.

--- a/src/concrete/StoxReceipt.sol
+++ b/src/concrete/StoxReceipt.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Receipt} from "rain-vats-0.1.1/src/concrete/receipt/Receipt.sol";
+import {Receipt} from "rain-vats-0.1.2/src/concrete/receipt/Receipt.sol";
 import {ERC1155Upgradeable} from "@openzeppelin-contracts-upgradeable-5.6.1/token/ERC1155/ERC1155Upgradeable.sol";
 import {IERC1155} from "@openzeppelin-contracts-5.6.1/token/ERC1155/IERC1155.sol";
 import {ICorporateActionsV1} from "../interface/ICorporateActionsV1.sol";

--- a/src/concrete/StoxReceiptVault.sol
+++ b/src/concrete/StoxReceiptVault.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {OffchainAssetReceiptVault} from "rain-vats-0.1.1/src/concrete/vault/OffchainAssetReceiptVault.sol";
+import {OffchainAssetReceiptVault} from "rain-vats-0.1.2/src/concrete/vault/OffchainAssetReceiptVault.sol";
 import {LibCorporateAction} from "../lib/LibCorporateAction.sol";
 import {LibRebase} from "../lib/LibRebase.sol";
 import {LibTotalSupply} from "../lib/LibTotalSupply.sol";

--- a/src/concrete/authorize/StoxOffchainAssetReceiptVaultAuthorizerV1.sol
+++ b/src/concrete/authorize/StoxOffchainAssetReceiptVaultAuthorizerV1.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {
     OffchainAssetReceiptVaultAuthorizerV1,
     OffchainAssetReceiptVaultAuthorizerV1Config
-} from "rain-vats-0.1.1/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
+} from "rain-vats-0.1.2/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
 import {ICLONEABLE_V2_SUCCESS} from "rain-factory-0.1.0/src/interface/ICloneableV2.sol";
 import {SCHEDULE_CORPORATE_ACTION, CANCEL_CORPORATE_ACTION} from "../../lib/LibCorporateAction.sol";
 

--- a/src/concrete/authorize/StoxOffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol
+++ b/src/concrete/authorize/StoxOffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {
     OffchainAssetReceiptVaultPaymentMintAuthorizerV1
-} from "rain-vats-0.1.1/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol";
+} from "rain-vats-0.1.2/src/concrete/authorize/OffchainAssetReceiptVaultPaymentMintAuthorizerV1.sol";
 
 /// @title StoxOffchainAssetReceiptVaultPaymentMintAuthorizerV1
 /// @notice An OffchainAssetReceiptVaultPaymentMintAuthorizerV1 specialized for

--- a/src/concrete/deploy/StoxOffchainAssetReceiptVaultBeaconSetDeployer.sol
+++ b/src/concrete/deploy/StoxOffchainAssetReceiptVaultBeaconSetDeployer.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {
     OffchainAssetReceiptVaultBeaconSetDeployer,
     OffchainAssetReceiptVaultBeaconSetDeployerConfig
-} from "rain-vats-0.1.1/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+} from "rain-vats-0.1.2/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
 import {LibProdDeployV3} from "../../lib/LibProdDeployV3.sol";
 
 /// @title StoxOffchainAssetReceiptVaultBeaconSetDeployer

--- a/src/concrete/deploy/StoxUnifiedDeployer.sol
+++ b/src/concrete/deploy/StoxUnifiedDeployer.sol
@@ -6,7 +6,7 @@ import {
     OffchainAssetReceiptVaultBeaconSetDeployer,
     OffchainAssetReceiptVaultConfigV2,
     OffchainAssetReceiptVault
-} from "rain-vats-0.1.1/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+} from "rain-vats-0.1.2/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {StoxWrappedTokenVaultBeaconSetDeployer} from "./StoxWrappedTokenVaultBeaconSetDeployer.sol";
 import {LibProdDeployV3} from "../../lib/LibProdDeployV3.sol";

--- a/src/interface/IStoxUnifiedDeployerV1.sol
+++ b/src/interface/IStoxUnifiedDeployerV1.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.25;
 
-import {OffchainAssetReceiptVaultConfigV2} from "rain-vats-0.1.1/src/concrete/vault/OffchainAssetReceiptVault.sol";
+import {OffchainAssetReceiptVaultConfigV2} from "rain-vats-0.1.2/src/concrete/vault/OffchainAssetReceiptVault.sol";
 
 /// @title IStoxUnifiedDeployerV1
 /// @notice V1 interface for the StoxUnifiedDeployer.

--- a/test/src/concrete/StoxCorporateActionsFacet.authorizerIntegration.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.authorizerIntegration.t.sol
@@ -8,13 +8,13 @@ import {
     OffchainAssetReceiptVaultAuthorizerV1Config,
     CERTIFY,
     CERTIFY_ADMIN
-} from "rain-vats-0.1.1/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
+} from "rain-vats-0.1.2/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
 import {
     StoxOffchainAssetReceiptVaultAuthorizerV1,
     SCHEDULE_CORPORATE_ACTION_ADMIN,
     CANCEL_CORPORATE_ACTION_ADMIN
 } from "../../../src/concrete/authorize/StoxOffchainAssetReceiptVaultAuthorizerV1.sol";
-import {Unauthorized} from "rain-vats-0.1.1/src/interface/IAuthorizeV1.sol";
+import {Unauthorized} from "rain-vats-0.1.2/src/interface/IAuthorizeV1.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 import {CloneFactory} from "rain-factory-0.1.0/src/concrete/CloneFactory.sol";
 

--- a/test/src/concrete/StoxCorporateActionsFacet.t.sol
+++ b/test/src/concrete/StoxCorporateActionsFacet.t.sol
@@ -25,7 +25,7 @@ import {
     ActionDoesNotExist,
     InvalidMask
 } from "../../../src/error/ErrCorporateAction.sol";
-import {IAuthorizeV1, Unauthorized} from "rain-vats-0.1.1/src/interface/IAuthorizeV1.sol";
+import {IAuthorizeV1, Unauthorized} from "rain-vats-0.1.2/src/interface/IAuthorizeV1.sol";
 import {Float, LibDecimalFloat} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
 import {
     CorporateActionNode,

--- a/test/src/concrete/StoxReceipt.t.sol
+++ b/test/src/concrete/StoxReceipt.t.sol
@@ -17,7 +17,7 @@ import {
     CORPORATE_ACTION_RECEIPT_STORAGE_LOCATION
 } from "../../../src/lib/LibCorporateActionReceipt.sol";
 import {LibERC1155Storage} from "../../../src/lib/LibERC1155Storage.sol";
-import {IReceiptManagerV2} from "rain-vats-0.1.1/src/interface/IReceiptManagerV2.sol";
+import {IReceiptManagerV2} from "rain-vats-0.1.2/src/interface/IReceiptManagerV2.sol";
 import {IERC1155Errors} from "@openzeppelin-contracts-5.6.1/interfaces/draft-IERC6093.sol";
 
 contract StoxReceiptTest is Test {

--- a/test/src/concrete/StoxReceiptVaultFallbackRouting.t.sol
+++ b/test/src/concrete/StoxReceiptVaultFallbackRouting.t.sol
@@ -13,7 +13,7 @@ import {
 import {LibProdDeployV3} from "../../../src/lib/LibProdDeployV3.sol";
 import {STOCK_SPLIT_V1_TYPE_HASH, UnknownActionType} from "../../../src/lib/LibCorporateAction.sol";
 import {CompletionFilter, NODE_NONE} from "../../../src/lib/LibCorporateActionNode.sol";
-import {IAuthorizeV1, Unauthorized} from "rain-vats-0.1.1/src/interface/IAuthorizeV1.sol";
+import {IAuthorizeV1, Unauthorized} from "rain-vats-0.1.2/src/interface/IAuthorizeV1.sol";
 import {Float, LibDecimalFloat} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
 import {LibTestTofu} from "../../lib/LibTestTofu.sol";
 

--- a/test/src/concrete/authorize/StoxOffchainAssetReceiptVaultAuthorizerV1.initializeGuard.t.sol
+++ b/test/src/concrete/authorize/StoxOffchainAssetReceiptVaultAuthorizerV1.initializeGuard.t.sol
@@ -7,7 +7,7 @@ import {Clones} from "@openzeppelin-contracts-5.6.1/proxy/Clones.sol";
 import {SCHEDULE_CORPORATE_ACTION, CANCEL_CORPORATE_ACTION} from "../../../../src/lib/LibCorporateAction.sol";
 import {
     OffchainAssetReceiptVaultAuthorizerV1Config
-} from "rain-vats-0.1.1/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
+} from "rain-vats-0.1.2/src/concrete/authorize/OffchainAssetReceiptVaultAuthorizerV1.sol";
 import {
     StoxOffchainAssetReceiptVaultAuthorizerV1,
     SCHEDULE_CORPORATE_ACTION_ADMIN,

--- a/test/src/concrete/deploy/StoxProdV2.t.sol
+++ b/test/src/concrete/deploy/StoxProdV2.t.sol
@@ -10,7 +10,7 @@ import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
 import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
 import {
     IOffchainAssetReceiptVaultBeaconSetDeployerV1
-} from "rain-vats-0.1.1/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
+} from "rain-vats-0.1.2/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
 
 /// @title StoxProdV2Test
 /// @notice Fork tests verifying all V2 Zoltu deployments exist on all

--- a/test/src/concrete/deploy/StoxUnifiedDeployer.newTokenAndWrapperVault.t.sol
+++ b/test/src/concrete/deploy/StoxUnifiedDeployer.newTokenAndWrapperVault.t.sol
@@ -5,8 +5,8 @@ pragma solidity =0.8.25;
 import {Test, Vm} from "forge-std-1.16.1/src/Test.sol";
 import {
     OffchainAssetReceiptVaultConfigV2
-} from "rain-vats-0.1.1/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
-import {ReceiptVaultConfigV2} from "rain-vats-0.1.1/src/abstract/ReceiptVault.sol";
+} from "rain-vats-0.1.2/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+import {ReceiptVaultConfigV2} from "rain-vats-0.1.2/src/abstract/ReceiptVault.sol";
 import {StoxUnifiedDeployer} from "../../../../src/concrete/deploy/StoxUnifiedDeployer.sol";
 import {StoxWrappedTokenVault} from "../../../../src/concrete/StoxWrappedTokenVault.sol";
 import {LibProdDeployV3} from "../../../../src/lib/LibProdDeployV3.sol";

--- a/test/src/concrete/deploy/StoxUnifiedDeployer.prod.base.t.sol
+++ b/test/src/concrete/deploy/StoxUnifiedDeployer.prod.base.t.sol
@@ -10,9 +10,9 @@ import {LibTestProd} from "../../../lib/LibTestProd.sol";
 import {LibTestDeploy} from "../../../lib/LibTestDeploy.sol";
 import {
     IOffchainAssetReceiptVaultBeaconSetDeployerV1
-} from "rain-vats-0.1.1/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
-import {OffchainAssetReceiptVaultConfigV2} from "rain-vats-0.1.1/src/concrete/vault/OffchainAssetReceiptVault.sol";
-import {ReceiptVaultConfigV2} from "rain-vats-0.1.1/src/abstract/ReceiptVault.sol";
+} from "rain-vats-0.1.2/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
+import {OffchainAssetReceiptVaultConfigV2} from "rain-vats-0.1.2/src/concrete/vault/OffchainAssetReceiptVault.sol";
+import {ReceiptVaultConfigV2} from "rain-vats-0.1.2/src/abstract/ReceiptVault.sol";
 import {
     StoxWrappedTokenVaultBeaconSetDeployer
 } from "../../../../src/concrete/deploy/StoxWrappedTokenVaultBeaconSetDeployer.sol";

--- a/test/src/concrete/deploy/StoxUnifiedDeployer.t.sol
+++ b/test/src/concrete/deploy/StoxUnifiedDeployer.t.sol
@@ -7,7 +7,7 @@ import {
     OffchainAssetReceiptVaultBeaconSetDeployer,
     OffchainAssetReceiptVaultConfigV2,
     OffchainAssetReceiptVault
-} from "rain-vats-0.1.1/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+} from "rain-vats-0.1.2/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
 import {StoxUnifiedDeployer} from "../../../../src/concrete/deploy/StoxUnifiedDeployer.sol";
 import {LibProdDeployV3} from "../../../../src/lib/LibProdDeployV3.sol";
 import {StoxWrappedTokenVault} from "../../../../src/concrete/StoxWrappedTokenVault.sol";
@@ -15,7 +15,7 @@ import {
     StoxWrappedTokenVaultBeaconSetDeployer
 } from "../../../../src/concrete/deploy/StoxWrappedTokenVaultBeaconSetDeployer.sol";
 import {LibTestDeploy} from "../../../lib/LibTestDeploy.sol";
-import {ReceiptVaultConfigV2} from "rain-vats-0.1.1/src/abstract/ReceiptVault.sol";
+import {ReceiptVaultConfigV2} from "rain-vats-0.1.2/src/abstract/ReceiptVault.sol";
 import {MockERC20} from "../../../concrete/MockERC20.sol";
 
 contract StoxUnifiedDeployerTest is Test {

--- a/test/src/lib/LibProdDeployV3.t.sol
+++ b/test/src/lib/LibProdDeployV3.t.sol
@@ -38,7 +38,7 @@ import {
 } from "../../../src/concrete/deploy/StoxOffchainAssetReceiptVaultBeaconSetDeployer.sol";
 import {
     IOffchainAssetReceiptVaultBeaconSetDeployerV2
-} from "rain-vats-0.1.1/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol";
+} from "rain-vats-0.1.2/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV2.sol";
 import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
 import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
 import {

--- a/test/src/lib/LibProdTokensBase.t.sol
+++ b/test/src/lib/LibProdTokensBase.t.sol
@@ -8,12 +8,12 @@ import {LibProdDeployV1} from "../../../src/lib/LibProdDeployV1.sol";
 import {LibTestProd} from "../../lib/LibTestProd.sol";
 import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensions/IERC20Metadata.sol";
 import {IERC4626} from "@openzeppelin-contracts-5.6.1/interfaces/IERC4626.sol";
-import {IReceiptVaultV3} from "rain-vats-0.1.1/src/interface/IReceiptVaultV3.sol";
-import {IReceiptV3} from "rain-vats-0.1.1/src/interface/IReceiptV3.sol";
+import {IReceiptVaultV3} from "rain-vats-0.1.2/src/interface/IReceiptVaultV3.sol";
+import {IReceiptV3} from "rain-vats-0.1.2/src/interface/IReceiptV3.sol";
 import {
     IOffchainAssetReceiptVaultBeaconSetDeployerV1
-} from "rain-vats-0.1.1/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
-import {ICertifiableV1} from "rain-vats-0.1.1/src/interface/ICertifiableV1.sol";
+} from "rain-vats-0.1.2/src/interface/IOffchainAssetReceiptVaultBeaconSetDeployerV1.sol";
+import {ICertifiableV1} from "rain-vats-0.1.2/src/interface/ICertifiableV1.sol";
 import {
     ERC1967_BEACON_SLOT,
     LibExtrospectERC1967BeaconProxy


### PR DESCRIPTION
Closes the rainlang 0.1.2 -> rain.flare 0.1.2 -> rain.vats 0.1.2 propagation chain. Picks up the audit fixes (H01, M05, M06, L02, L03, I04, I06, I07, I08) and the OwnerFreezable.__OwnerFreezable_init mutability fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external dependencies to the latest compatible versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/S01-Issuer/st0x.deploy/pull/184)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->