### PR TITLE
docs: surface the StoxReceipt vault-trust assumption (#181)

### DIFF
--- a/src/concrete/StoxReceipt.sol
+++ b/src/concrete/StoxReceipt.sol
@@ -157,6 +157,16 @@ contract StoxReceipt is Receipt {
     /// is no window for reentrancy to observe inconsistent data.
     /// If a future refactor moves ANY state mutation after `super._update`,
     /// this analysis is invalidated and reentrancy risk must be re-evaluated.
+    ///
+    /// **Vault trust:** migration walks `vault.nextOfType` /
+    /// `vault.getActionParameters` per node without snapshotting; the loop
+    /// trusts each STATICCALL return individually. A malicious vault
+    /// implementation installed via beacon upgrade could serve
+    /// inconsistent answers across iterations and inflate, zero, or drift
+    /// any first-touched balance. The protocol relies on
+    /// `BEACON_INITIAL_OWNER = rainlang.eth` only installing audited
+    /// vault implementations behind every receipt's manager pointer.
+    /// Beacon upgrade authority is the trust root.
     /// @inheritdoc ERC1155Upgradeable
     function _update(address from, address to, uint256[] memory ids, uint256[] memory amounts)
         internal

--- a/src/lib/LibReceiptRebase.sol
+++ b/src/lib/LibReceiptRebase.sol
@@ -45,6 +45,16 @@ import {LibRebaseMath} from "./LibRebaseMath.sol";
 /// view calls (`nextOfType` + `getActionParameters`). Stock splits are
 /// expected to be rare (O(10) over a contract's lifetime) so the
 /// per-receipt-holder migration cost is bounded and acceptable.
+///
+/// **Trust model.** The walk has no defence against a malicious vault
+/// implementation serving inconsistent answers across `nextOfType` /
+/// `getActionParameters` iterations — such an implementation could
+/// inflate, zero, or arbitrarily drift balances on first-touch. The
+/// receipt assumes the beacon owner (`BEACON_INITIAL_OWNER =
+/// rainlang.eth`) only installs audited vault implementations behind
+/// every receipt's manager pointer. Beacon upgrade authority is the
+/// trust root; if that key is compromised, every downstream balance
+/// derived from this walk is compromised.
 library LibReceiptRebase {
     /// @notice Walk the vault's completed stock split list from
     /// `fromActionId` forward, returning the rebased balance and the


### PR DESCRIPTION
Surfaces the trust contract from the audit at the call site:

- LibReceiptRebase trust-model NatSpec.
- StoxReceipt._update trust-root note alongside the existing reentrancy note.

The migration walk reads the vault's action list via per-iteration STATICCALLs; the assumption is BEACON_INITIAL_OWNER (rainlang.eth) only installs audited vault implementations.

Closes #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifications regarding the protocol's reliance on audited vault implementations and trust assumptions within the receipt system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/S01-Issuer/st0x.deploy/pull/185)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->