### PR TITLE
feat(safe): LibSafeInvariants — base invariant assertions + inverted tests

### DIFF
--- a/src/lib/LibProdSafes.sol
+++ b/src/lib/LibProdSafes.sol
@@ -58,7 +58,7 @@ library LibProdSafes {
     /// @notice CompatibilityFallbackHandler v1.4.1 address on Base. Verified
     /// against the live Safe's fallback handler storage slot. Pinned so a
     /// swapped-in malicious handler that shadows view selectors via
-    /// fallback can be detected by `assertBaseSafeInvariants`.
+    /// fallback can be detected by `LibSafeInvariants.assertImmutableInvariants`.
     /// @dev Source: github.com/safe-global/safe-deployments
     /// `src/assets/v1.4.1/compatibility_fallback_handler.json` (chainId
     /// 8453 entry). Cross-checked on Base on 2026-05-20.

--- a/src/lib/LibProdTokensBase.sol
+++ b/src/lib/LibProdTokensBase.sol
@@ -216,4 +216,26 @@ library LibProdTokensBase {
     /// @dev Wrapped token vault (ERC-4626, "wtSGOV") — the StoxWrappedTokenVault instance.
     /// https://basescan.org/address/0x78c31580c97101694c70022c83d570150c11e935
     address constant SGOV_WRAPPED_TOKEN_VAULT = address(0x78c31580c97101694C70022c83D570150c11e935);
+
+    /// @notice Returns the 13 production receipt vault addresses on Base, in
+    /// the order they were deployed. Provided so consumers (e.g. invariant
+    /// assertions, migration scripts) can iterate without hardcoding the
+    /// list inline.
+    /// @return vaults The 13 production receipt vault addresses on Base.
+    function productionReceiptVaults() internal pure returns (address[] memory vaults) {
+        vaults = new address[](13);
+        vaults[0] = MSTR_RECEIPT_VAULT;
+        vaults[1] = TSLA_RECEIPT_VAULT;
+        vaults[2] = COIN_RECEIPT_VAULT;
+        vaults[3] = SPYM_RECEIPT_VAULT;
+        vaults[4] = SIVR_RECEIPT_VAULT;
+        vaults[5] = CRCL_RECEIPT_VAULT;
+        vaults[6] = NVDA_RECEIPT_VAULT;
+        vaults[7] = IAU_RECEIPT_VAULT;
+        vaults[8] = PPLT_RECEIPT_VAULT;
+        vaults[9] = AMZN_RECEIPT_VAULT;
+        vaults[10] = BMNR_RECEIPT_VAULT;
+        vaults[11] = IBHG_RECEIPT_VAULT;
+        vaults[12] = SGOV_RECEIPT_VAULT;
+    }
 }

--- a/src/lib/LibSafeInvariants.sol
+++ b/src/lib/LibSafeInvariants.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 
 import {IGnosisSafe} from "../interface/IGnosisSafe.sol";
 import {LibProdSafes} from "./LibProdSafes.sol";
+import {LibTokenOwnership} from "./LibTokenOwnership.sol";
 
 /// @notice The runtime codehash at the Safe's address does not match the
 /// pinned Safe v1.4.1 L2 proxy codehash. Signals either that the address has
@@ -103,12 +104,30 @@ error SafeThresholdMismatch(address safe, uint256 expected, uint256 actual);
 /// pinned to the ST0x token-owner deployment. Each public assertion either
 /// returns silently when the invariant holds against the live chain state
 /// or reverts with a typed error that pinpoints the drift.
-/// @dev The library is consumed by the RAI-296 migration script (and
-/// post-migration drift tests) as a single chokepoint for "is this Safe
-/// still the Safe we think it is?" checks. Centralising the assertions here
-/// keeps drift detection consistent across the script, its tests, and any
-/// future migrations: anyone extending the Safe touch-points only needs to
-/// add new invariants in one place.
+/// @dev The library splits checks into two categories:
+///
+/// - **Immutable invariants** (`assertImmutableInvariants`) — properties
+///   that always hold against this Safe regardless of any pending or past
+///   migration: proxy codehash, singleton pointer + bytecode, version,
+///   modules empty, guard zero, fallback handler pinned, and uniform
+///   `owner()` across every production receipt vault. The same set is
+///   evaluated pre-migration and post-migration; nothing here is
+///   parameterised on operational intent.
+///
+/// - **Parameterised state assertions** (`assertOwnerSet`, `assertThreshold`)
+///   — properties whose expected value is supplied by the caller because
+///   the caller is deliberately mutating that property (notably the
+///   threshold migration). Wrong values here are caller intent, not Safe
+///   drift, so the comparison target is an argument.
+///
+/// `assertAllChecks` bundles the immutable invariants and the two
+/// parameterised checks into a single call site, so a migration script's
+/// pre-flight and post-state are both expressed as one line per phase.
+///
+/// Centralising the assertions here keeps drift detection consistent
+/// across the threshold migration script, its tests, the post-migration
+/// pin, and any future migrations: anyone extending the Safe touch-points
+/// only needs to add new invariants in one place.
 ///
 /// All storage-slot constants come from the Safe v1.4.1 source:
 /// https://github.com/safe-global/safe-contracts/tree/v1.4.1/contracts
@@ -145,18 +164,36 @@ library LibSafeInvariants {
     /// `safe-contracts/contracts/base/ModuleManager.sol` at the v1.4.1 tag.
     address internal constant SAFE_MODULES_SENTINEL = address(0x1);
 
-    /// @notice Assert that the Safe at `safe` is structurally the Safe we
-    /// expect: pinned proxy codehash, pinned singleton, pinned version, no
-    /// modules, no guard, and pinned fallback handler. Reverts with a typed
-    /// error on first failure; returns silently otherwise.
-    /// @dev The check ordering is deliberate. Codehash first (cheapest, and
+    /// @notice Assert every immutable invariant of the Safe at `safe`:
+    /// pinned proxy codehash, pinned singleton pointer, pinned singleton
+    /// bytecode, pinned version, no modules, no guard, pinned fallback
+    /// handler, and uniform `owner()` across every production ST0x receipt
+    /// vault. Reverts with a typed error (from this library or from
+    /// `LibTokenOwnership`) on first failure; returns silently otherwise.
+    /// @dev "Immutable" here means properties that should hold against the
+    /// production Safe at any point in time, regardless of pending or
+    /// past operational migrations. The same set is asserted pre-migration
+    /// and post-migration; nothing in this call is parameterised on
+    /// caller intent.
+    ///
+    /// Token-side uniform ownership is included as an immutable Safe
+    /// invariant because the threshold migration (and any future Safe
+    /// migration on this deployment) does not independently transfer
+    /// vault ownership: drift in the vault ownership set against the Safe
+    /// at migration time is therefore an invariant break to surface here,
+    /// not a separate pre-flight concern of every consumer.
+    ///
+    /// The check ordering is deliberate. Codehash first (cheapest, and
     /// catches an EOA at the address or a fake proxy). Singleton slot next
-    /// (catches a swap of the implementation pointer). VERSION() third
-    /// (catches an unexpected implementation that happens to have the same
-    /// bytecode hash). Modules/guard/fallback handler last, after the proxy
-    /// has been proven to be the singleton we expect.
-    /// @param safe The Safe to assert invariants on.
-    function assertBaseSafeInvariants(IGnosisSafe safe) internal view {
+    /// (catches a swap of the implementation pointer). Singleton bytecode
+    /// third (catches a swap behind the singleton address). VERSION()
+    /// fourth (catches an unexpected implementation that happens to have
+    /// the same bytecode hash). Modules/guard/fallback handler next, after
+    /// the proxy has been proven to be the singleton we expect. Uniform
+    /// vault ownership last, because it is the most expensive (13 external
+    /// calls) and only meaningful once the Safe itself has been validated.
+    /// @param safe The Safe to assert immutable invariants on.
+    function assertImmutableInvariants(IGnosisSafe safe) internal view {
         address safeAddr = address(safe);
 
         bytes32 actualCodehash;
@@ -218,6 +255,12 @@ library LibSafeInvariants {
                 safeAddr, LibProdSafes.SAFE_V1_4_1_COMPATIBILITY_FALLBACK_HANDLER, actualFallbackHandler
             );
         }
+
+        // Token-side uniform ownership: every production receipt vault
+        // reports `owner() == safe`. Bubbles `ReceiptVaultOwnerMismatch`
+        // from `LibTokenOwnership` on the first drift, which pinpoints
+        // the offending vault.
+        LibTokenOwnership.assertUniformOwnership(safeAddr);
     }
 
     /// @notice Reads a single 32-byte storage slot from a Safe via
@@ -264,5 +307,30 @@ library LibSafeInvariants {
         if (actual != expected) {
             revert SafeThresholdMismatch(address(safe), expected, actual);
         }
+    }
+
+    /// @notice Bundle every check exposed by this library into one call:
+    /// `assertImmutableInvariants` plus the two parameterised state
+    /// assertions (`assertOwnerSet`, `assertThreshold`). Migration scripts
+    /// call this twice — once pre-execution with the expected pre-state
+    /// threshold, once post-execution with the new threshold — and the
+    /// caller only changes one argument across the two calls.
+    /// @dev This is intentionally a thin wrapper rather than a separate
+    /// implementation: keeping each underlying check addressable in
+    /// isolation lets fork tests exercise individual drift surfaces, and
+    /// keeping the bundle alongside them means migration code never has
+    /// to remember which of the three pieces to run.
+    /// @param safe The Safe to validate.
+    /// @param expectedOwners The expected owner set in `getOwners()` order.
+    /// @param expectedThreshold The expected signature threshold (the
+    /// pre-state threshold for the pre-flight call; the post-state
+    /// threshold for the post-execution call).
+    function assertAllChecks(IGnosisSafe safe, address[] memory expectedOwners, uint256 expectedThreshold)
+        internal
+        view
+    {
+        assertImmutableInvariants(safe);
+        assertOwnerSet(safe, expectedOwners);
+        assertThreshold(safe, expectedThreshold);
     }
 }

--- a/src/lib/LibSafeInvariants.sol
+++ b/src/lib/LibSafeInvariants.sol
@@ -25,6 +25,21 @@ error SafeProxyCodehashMismatch(address safe, bytes32 expected, bytes32 actual);
 /// @param actual The singleton address read from slot `0x0` of the proxy.
 error SafeSingletonMismatch(address safe, address expected, address actual);
 
+/// @notice The Safe singleton's runtime bytecode codehash does not match the
+/// pinned `LibProdSafes.SAFE_V1_4_1_L2_SINGLETON_CODEHASH`. Pinning the
+/// singleton address alone trusts the bytecode at that address; a swap (e.g.
+/// `SELFDESTRUCT` + recreate, or a delegatecall-time substitution on a
+/// forked test environment) could preserve the address while replacing the
+/// implementation entirely. Asserting the singleton codehash closes that
+/// gap before any implementation-backed read (`VERSION()`, `getOwners()`,
+/// `getThreshold()`, etc.) is trusted.
+/// @param safe The Safe proxy address that was inspected.
+/// @param singleton The singleton address read from slot `0x0` of the proxy.
+/// @param expected The pinned singleton codehash
+/// (`LibProdSafes.SAFE_V1_4_1_L2_SINGLETON_CODEHASH`).
+/// @param actual The codehash observed at `singleton`.
+error SafeSingletonBytecodeMismatch(address safe, address singleton, bytes32 expected, bytes32 actual);
+
 /// @notice The Safe singleton's `VERSION()` selector returned a string other
 /// than `"1.4.1"`. This is a defence-in-depth check against the codehash and
 /// singleton-slot pins: it cross-references the version the implementation
@@ -158,6 +173,22 @@ library LibSafeInvariants {
         address actualSingleton = readSafeStorageAddress(safe, 0);
         if (actualSingleton != LibProdSafes.SAFE_V1_4_1_L2_SINGLETON) {
             revert SafeSingletonMismatch(safeAddr, LibProdSafes.SAFE_V1_4_1_L2_SINGLETON, actualSingleton);
+        }
+
+        // Address pin alone trusts whatever code lives at the singleton
+        // address. Pin the singleton's bytecode too so a swap there
+        // (preserving the proxy codehash and superficial view returns)
+        // cannot route every implementation-backed call through attacker
+        // code. Asserted before `VERSION()` and any other read that
+        // delegate-routes through the singleton.
+        bytes32 actualSingletonCodehash;
+        assembly ("memory-safe") {
+            actualSingletonCodehash := extcodehash(actualSingleton)
+        }
+        if (actualSingletonCodehash != LibProdSafes.SAFE_V1_4_1_L2_SINGLETON_CODEHASH) {
+            revert SafeSingletonBytecodeMismatch(
+                safeAddr, actualSingleton, LibProdSafes.SAFE_V1_4_1_L2_SINGLETON_CODEHASH, actualSingletonCodehash
+            );
         }
 
         string memory actualVersion = safe.VERSION();

--- a/src/lib/LibSafeInvariants.sol
+++ b/src/lib/LibSafeInvariants.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {IGnosisSafe} from "../interface/IGnosisSafe.sol";
+import {LibProdSafes} from "./LibProdSafes.sol";
+
+/// @notice The runtime codehash at the Safe's address does not match the
+/// pinned Safe v1.4.1 L2 proxy codehash. Signals either that the address has
+/// been swapped under us or that the Safe singleton has been redeployed with
+/// different bytecode.
+/// @param safe The Safe address whose codehash was checked.
+/// @param expected The pinned codehash that was expected
+/// (`LibProdSafes.SAFE_V1_4_1_L2_PROXY_CODEHASH`).
+/// @param actual The codehash returned by `extcodehash(safe)`.
+error SafeProxyCodehashMismatch(address safe, bytes32 expected, bytes32 actual);
+
+/// @notice The implementation pointer stored at Safe storage slot `0x0` does
+/// not match the pinned Safe v1.4.1 L2 singleton address. Used to detect a
+/// `setImplementation`-style takeover that would route every call through a
+/// different singleton.
+/// @param safe The Safe proxy address that was inspected.
+/// @param expected The pinned singleton address
+/// (`LibProdSafes.SAFE_V1_4_1_L2_SINGLETON`).
+/// @param actual The singleton address read from slot `0x0` of the proxy.
+error SafeSingletonMismatch(address safe, address expected, address actual);
+
+/// @notice The Safe singleton's `VERSION()` selector returned a string other
+/// than `"1.4.1"`. This is a defence-in-depth check against the codehash and
+/// singleton-slot pins: it cross-references the version the implementation
+/// reports about itself with the codehash we expect.
+/// @param safe The Safe address whose `VERSION()` was queried.
+/// @param expected The expected version string (`"1.4.1"`).
+/// @param actual The version string returned by the live Safe.
+error SafeVersionMismatch(address safe, string expected, string actual);
+
+/// @notice The Safe has at least one module enabled. The ST0x production Safe
+/// is expected to have an empty module list; modules can bypass the threshold
+/// requirement entirely and so are explicitly prohibited.
+/// @param safe The Safe address whose module list was paginated.
+/// @param firstModule The first module discovered in the paginated list.
+error SafeUnexpectedModules(address safe, address firstModule);
+
+/// @notice The Safe has a transaction guard installed. The ST0x production
+/// Safe is expected to run without a guard; a guard can both block and
+/// silently mutate transactions and so is explicitly prohibited.
+/// @param safe The Safe address whose guard slot was read.
+/// @param guard The guard address read from the well-known guard slot.
+error SafeUnexpectedGuard(address safe, address guard);
+
+/// @notice The Safe's fallback handler does not point at the pinned Safe
+/// v1.4.1 CompatibilityFallbackHandler. A swapped fallback handler can shadow
+/// any selector not implemented on the singleton (including view selectors
+/// used for introspection) so the pin is enforced as an invariant.
+/// @param safe The Safe address whose fallback handler slot was read.
+/// @param expected The pinned fallback handler address
+/// (`LibProdSafes.SAFE_V1_4_1_COMPATIBILITY_FALLBACK_HANDLER`).
+/// @param actual The fallback handler address read from the well-known
+/// fallback handler slot.
+error SafeFallbackHandlerMismatch(address safe, address expected, address actual);
+
+/// @notice The Safe's `getOwners()` array length does not match the
+/// caller-supplied `expected` array length.
+/// @param safe The Safe address whose owner set was queried.
+/// @param expectedLength The owner count the caller expected.
+/// @param actualLength The owner count returned by `getOwners()`.
+error SafeOwnerCountMismatch(address safe, uint256 expectedLength, uint256 actualLength);
+
+/// @notice The Safe's `getOwners()` returned an owner at `index` that does
+/// not match the caller-supplied `expected` array at the same index. The
+/// owner list is checked in Safe-internal linked-list order; reordering
+/// without a roster change therefore still trips this error.
+/// @param safe The Safe address whose owner set was queried.
+/// @param index The zero-based index in the owner list that mismatched.
+/// @param expectedOwner The owner address the caller expected at `index`.
+/// @param actualOwner The owner address returned by `getOwners()` at `index`.
+error SafeOwnerMismatch(address safe, uint256 index, address expectedOwner, address actualOwner);
+
+/// @notice The Safe's `getThreshold()` does not match the caller-supplied
+/// `expected` threshold.
+/// @param safe The Safe address whose threshold was queried.
+/// @param expected The threshold the caller expected.
+/// @param actual The threshold returned by `getThreshold()`.
+error SafeThresholdMismatch(address safe, uint256 expected, uint256 actual);
+
+/// @title LibSafeInvariants
+/// @notice Reusable invariant assertions for a Safe v1.4.1 L2 multisig
+/// pinned to the ST0x token-owner deployment. Each public assertion either
+/// returns silently when the invariant holds against the live chain state
+/// or reverts with a typed error that pinpoints the drift.
+/// @dev The library is consumed by the RAI-296 migration script (and
+/// post-migration drift tests) as a single chokepoint for "is this Safe
+/// still the Safe we think it is?" checks. Centralising the assertions here
+/// keeps drift detection consistent across the script, its tests, and any
+/// future migrations: anyone extending the Safe touch-points only needs to
+/// add new invariants in one place.
+///
+/// All storage-slot constants come from the Safe v1.4.1 source:
+/// https://github.com/safe-global/safe-contracts/tree/v1.4.1/contracts
+/// Singleton (master copy) lives at slot `0x0` of the proxy by virtue of
+/// `SafeProxy`'s minimal storage layout; the guard slot and fallback handler
+/// slot are explicit constants in `GuardManager`/`FallbackManager` chosen so
+/// they cannot collide with the owner/module/threshold linked-list slots.
+library LibSafeInvariants {
+    /// @notice Storage slot at which Safe v1.4.1 stores the transaction
+    /// guard address. Equal to
+    /// `keccak256("guard_manager.guard.address")`. A non-zero value here
+    /// means a guard contract is intercepting `execTransaction`; the ST0x
+    /// production Safe is required to have no guard.
+    /// @dev Source: `GuardManager` in
+    /// `safe-contracts/contracts/base/GuardManager.sol` at the v1.4.1 tag.
+    bytes32 internal constant SAFE_GUARD_STORAGE_SLOT =
+        0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+    /// @notice Storage slot at which Safe v1.4.1 stores the fallback handler
+    /// address. Equal to
+    /// `keccak256("fallback_manager.handler.address")`. The address read
+    /// here is the contract whose code services unknown selectors that fall
+    /// through to the Safe proxy's `fallback`.
+    /// @dev Source: `FallbackManager` in
+    /// `safe-contracts/contracts/base/FallbackManager.sol` at the v1.4.1
+    /// tag.
+    bytes32 internal constant SAFE_FALLBACK_HANDLER_STORAGE_SLOT =
+        0x6c9a6c4a39284e37ed1cf53d337577d14212a4870fb976a4366c693b939918d5;
+
+    /// @notice Sentinel head of the Safe modules linked list. The Safe
+    /// stores modules as a circular linked list seeded with this sentinel,
+    /// so paginated enumeration is started from `address(0x1)`.
+    /// @dev Source: `ModuleManager` in
+    /// `safe-contracts/contracts/base/ModuleManager.sol` at the v1.4.1 tag.
+    address internal constant SAFE_MODULES_SENTINEL = address(0x1);
+
+    /// @notice Assert that the Safe at `safe` is structurally the Safe we
+    /// expect: pinned proxy codehash, pinned singleton, pinned version, no
+    /// modules, no guard, and pinned fallback handler. Reverts with a typed
+    /// error on first failure; returns silently otherwise.
+    /// @dev The check ordering is deliberate. Codehash first (cheapest, and
+    /// catches an EOA at the address or a fake proxy). Singleton slot next
+    /// (catches a swap of the implementation pointer). VERSION() third
+    /// (catches an unexpected implementation that happens to have the same
+    /// bytecode hash). Modules/guard/fallback handler last, after the proxy
+    /// has been proven to be the singleton we expect.
+    /// @param safe The Safe to assert invariants on.
+    function assertBaseSafeInvariants(IGnosisSafe safe) internal view {
+        address safeAddr = address(safe);
+
+        bytes32 actualCodehash;
+        assembly ("memory-safe") {
+            actualCodehash := extcodehash(safeAddr)
+        }
+        if (actualCodehash != LibProdSafes.SAFE_V1_4_1_L2_PROXY_CODEHASH) {
+            revert SafeProxyCodehashMismatch(safeAddr, LibProdSafes.SAFE_V1_4_1_L2_PROXY_CODEHASH, actualCodehash);
+        }
+
+        // Slot 0 of a Safe proxy holds the singleton (master copy) address.
+        // Read it raw via `getStorageAt` rather than going through any
+        // accessor so a malicious fallback can't shadow the result.
+        address actualSingleton = readSafeStorageAddress(safe, 0);
+        if (actualSingleton != LibProdSafes.SAFE_V1_4_1_L2_SINGLETON) {
+            revert SafeSingletonMismatch(safeAddr, LibProdSafes.SAFE_V1_4_1_L2_SINGLETON, actualSingleton);
+        }
+
+        string memory actualVersion = safe.VERSION();
+        if (keccak256(bytes(actualVersion)) != keccak256(bytes(LibProdSafes.SAFE_V1_4_1_VERSION))) {
+            revert SafeVersionMismatch(safeAddr, LibProdSafes.SAFE_V1_4_1_VERSION, actualVersion);
+        }
+
+        // Page size 10 is sufficient: any non-zero module count trips the
+        // invariant, and the ST0x production Safe has never had a module
+        // enabled. Walking further would only paper over a misconfiguration.
+        // The `next` cursor is intentionally discarded — we don't iterate
+        // because any non-empty first page already constitutes drift.
+        // slither-disable-next-line unused-return
+        (address[] memory modules,) = safe.getModulesPaginated(SAFE_MODULES_SENTINEL, 10);
+        if (modules.length != 0) {
+            revert SafeUnexpectedModules(safeAddr, modules[0]);
+        }
+
+        address actualGuard = readSafeStorageAddress(safe, uint256(SAFE_GUARD_STORAGE_SLOT));
+        if (actualGuard != address(0)) {
+            revert SafeUnexpectedGuard(safeAddr, actualGuard);
+        }
+
+        address actualFallbackHandler = readSafeStorageAddress(safe, uint256(SAFE_FALLBACK_HANDLER_STORAGE_SLOT));
+        if (actualFallbackHandler != LibProdSafes.SAFE_V1_4_1_COMPATIBILITY_FALLBACK_HANDLER) {
+            revert SafeFallbackHandlerMismatch(
+                safeAddr, LibProdSafes.SAFE_V1_4_1_COMPATIBILITY_FALLBACK_HANDLER, actualFallbackHandler
+            );
+        }
+    }
+
+    /// @notice Reads a single 32-byte storage slot from a Safe via
+    /// `getStorageAt(slot, 1)` and interprets the low 20 bytes as an
+    /// address. Centralised here so the bytes-to-address decoding is
+    /// auditable in one place and reusable across every Safe storage
+    /// pin in this library.
+    /// @param safe The Safe to query.
+    /// @param slot The storage slot index to read.
+    /// @return The address stored in the low 20 bytes of `slot`.
+    function readSafeStorageAddress(IGnosisSafe safe, uint256 slot) internal view returns (address) {
+        bytes memory word = safe.getStorageAt(slot, 1);
+        // `getStorageAt(_, 1)` returns exactly 32 bytes; decode through
+        // `bytes32` then truncate to `uint160`. Both casts are width-safe
+        // by construction and the result is opaque to forge-lint, so the
+        // unsafe-typecast warning is suppressed.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return address(uint160(uint256(bytes32(word))));
+    }
+
+    /// @notice Assert that the Safe's owner set matches `expected` in length
+    /// and member-by-member. The Safe returns owners in linked-list order;
+    /// callers must pass `expected` in the same order or the comparison will
+    /// flag a reorder as drift.
+    /// @param safe The Safe to query.
+    /// @param expected The expected owner addresses in `getOwners()` order.
+    function assertOwnerSet(IGnosisSafe safe, address[] memory expected) internal view {
+        address[] memory actual = safe.getOwners();
+        if (actual.length != expected.length) {
+            revert SafeOwnerCountMismatch(address(safe), expected.length, actual.length);
+        }
+        for (uint256 i = 0; i < expected.length; i++) {
+            if (actual[i] != expected[i]) {
+                revert SafeOwnerMismatch(address(safe), i, expected[i], actual[i]);
+            }
+        }
+    }
+
+    /// @notice Assert that the Safe's signature threshold matches `expected`.
+    /// @param safe The Safe to query.
+    /// @param expected The expected threshold.
+    function assertThreshold(IGnosisSafe safe, uint256 expected) internal view {
+        uint256 actual = safe.getThreshold();
+        if (actual != expected) {
+            revert SafeThresholdMismatch(address(safe), expected, actual);
+        }
+    }
+}

--- a/src/lib/LibSafeInvariants.sol
+++ b/src/lib/LibSafeInvariants.sol
@@ -4,7 +4,18 @@ pragma solidity ^0.8.25;
 
 import {IGnosisSafe} from "../interface/IGnosisSafe.sol";
 import {LibProdSafes} from "./LibProdSafes.sol";
-import {LibTokenOwnership} from "./LibTokenOwnership.sol";
+import {LibProdTokensBase} from "./LibProdTokensBase.sol";
+
+/// @notice Minimal `Ownable`-like surface used by ST0x receipt vaults.
+/// Every production receipt vault exposes `owner()`; this library only
+/// needs the getter, not the transfer/renounce mutators. Declared inline
+/// here so the Safe invariant bundle owns its only external surface
+/// rather than depending on a token-side interface that could drift.
+interface IOwnable {
+    /// @notice The current owner of the contract.
+    /// @return The owner address.
+    function owner() external view returns (address);
+}
 
 /// @notice The runtime codehash at the Safe's address does not match the
 /// pinned Safe v1.4.1 L2 proxy codehash. Signals either that the address has
@@ -75,6 +86,16 @@ error SafeUnexpectedGuard(address safe, address guard);
 /// fallback handler slot.
 error SafeFallbackHandlerMismatch(address safe, address expected, address actual);
 
+/// @notice A production receipt vault's `owner()` does not match the Safe
+/// the immutable-invariants leg expected to own every vault. Surfaces the
+/// exact vault address that breaks the uniform-ownership invariant rather
+/// than a generic mismatch.
+/// @param vault The receipt vault whose owner was read.
+/// @param expected The Safe address every vault is expected to report as
+/// `owner()`.
+/// @param actual The owner address returned by `vault.owner()`.
+error ReceiptVaultOwnerMismatch(address vault, address expected, address actual);
+
 /// @notice The Safe's `getOwners()` array length does not match the
 /// caller-supplied `expected` array length.
 /// @param safe The Safe address whose owner set was queried.
@@ -120,9 +141,14 @@ error SafeThresholdMismatch(address safe, uint256 expected, uint256 actual);
 ///   threshold migration). Wrong values here are caller intent, not Safe
 ///   drift, so the comparison target is an argument.
 ///
-/// `assertAllChecks` bundles the immutable invariants and the two
-/// parameterised checks into a single call site, so a migration script's
-/// pre-flight and post-state are both expressed as one line per phase.
+/// The `assertAll` overloads bundle the immutable invariants and the two
+/// parameterised checks into a single call site. The pattern mirrors
+/// `StoxProdV2Test::checkAllV2OnChain`: a full-args helper that takes
+/// every expected value, and a no-arg default that fills in the
+/// current-truth pins from `LibProdSafes`. Scripts default to the no-arg
+/// version for pre-flight; only the migration script with deliberate
+/// state changes uses the full-args overload for its post-state
+/// assertion.
 ///
 /// Centralising the assertions here keeps drift detection consistent
 /// across the threshold migration script, its tests, the post-migration
@@ -168,8 +194,9 @@ library LibSafeInvariants {
     /// pinned proxy codehash, pinned singleton pointer, pinned singleton
     /// bytecode, pinned version, no modules, no guard, pinned fallback
     /// handler, and uniform `owner()` across every production ST0x receipt
-    /// vault. Reverts with a typed error (from this library or from
-    /// `LibTokenOwnership`) on first failure; returns silently otherwise.
+    /// vault (as enumerated by
+    /// `LibProdTokensBase.productionReceiptVaults`). Reverts with a typed
+    /// error on first failure; returns silently otherwise.
     /// @dev "Immutable" here means properties that should hold against the
     /// production Safe at any point in time, regardless of pending or
     /// past operational migrations. The same set is asserted pre-migration
@@ -257,10 +284,17 @@ library LibSafeInvariants {
         }
 
         // Token-side uniform ownership: every production receipt vault
-        // reports `owner() == safe`. Bubbles `ReceiptVaultOwnerMismatch`
-        // from `LibTokenOwnership` on the first drift, which pinpoints
-        // the offending vault.
-        LibTokenOwnership.assertUniformOwnership(safeAddr);
+        // reports `owner() == safe`. Iterates the vault list emitted by
+        // `LibProdTokensBase.productionReceiptVaults` and reverts with
+        // `ReceiptVaultOwnerMismatch` on the first drift, surfacing the
+        // offending vault.
+        address[] memory vaults = LibProdTokensBase.productionReceiptVaults();
+        for (uint256 i = 0; i < vaults.length; i++) {
+            address actualOwner = IOwnable(vaults[i]).owner();
+            if (actualOwner != safeAddr) {
+                revert ReceiptVaultOwnerMismatch(vaults[i], safeAddr, actualOwner);
+            }
+        }
     }
 
     /// @notice Reads a single 32-byte storage slot from a Safe via
@@ -309,28 +343,42 @@ library LibSafeInvariants {
         }
     }
 
-    /// @notice Bundle every check exposed by this library into one call:
-    /// `assertImmutableInvariants` plus the two parameterised state
-    /// assertions (`assertOwnerSet`, `assertThreshold`). Migration scripts
-    /// call this twice — once pre-execution with the expected pre-state
-    /// threshold, once post-execution with the new threshold — and the
-    /// caller only changes one argument across the two calls.
-    /// @dev This is intentionally a thin wrapper rather than a separate
-    /// implementation: keeping each underlying check addressable in
+    /// @notice Full-args invariant bundle. Use when you want to override
+    /// the expected threshold or owner set from the `LibProdSafes`
+    /// current-truth pins — typically only when running a script that
+    /// intentionally changes one of those (post-state assertion).
+    /// @dev Mirrors the `StoxProdV2Test::checkAllV2OnChain` pattern: a
+    /// full-args helper alongside a no-arg overload. Migration scripts
+    /// call the no-arg overload pre-execution to assert the pinned
+    /// current truth, then call this overload post-execution with the
+    /// deliberately-changed expectation.
+    ///
+    /// Implementation is intentionally a thin wrapper rather than a
+    /// separate body: keeping each underlying check addressable in
     /// isolation lets fork tests exercise individual drift surfaces, and
     /// keeping the bundle alongside them means migration code never has
     /// to remember which of the three pieces to run.
     /// @param safe The Safe to validate.
+    /// @param expectedThreshold The expected signature threshold.
     /// @param expectedOwners The expected owner set in `getOwners()` order.
-    /// @param expectedThreshold The expected signature threshold (the
-    /// pre-state threshold for the pre-flight call; the post-state
-    /// threshold for the post-execution call).
-    function assertAllChecks(IGnosisSafe safe, address[] memory expectedOwners, uint256 expectedThreshold)
-        internal
-        view
-    {
+    function assertAll(IGnosisSafe safe, uint256 expectedThreshold, address[] memory expectedOwners) internal view {
         assertImmutableInvariants(safe);
         assertOwnerSet(safe, expectedOwners);
         assertThreshold(safe, expectedThreshold);
+    }
+
+    /// @notice No-arg invariant bundle that fills in the
+    /// `LibProdSafes`-pinned current-truth defaults: the threshold from
+    /// `STOX_TOKEN_OWNER_SAFE_THRESHOLD` and the owner set from
+    /// `expectedOwners()`. Pre-flight at the start of every script and
+    /// fork test that runs against the production Safe; if this passes
+    /// silently, the Safe is in its current expected state.
+    /// @dev The full-args overload is the right call site only when a
+    /// caller is *deliberately* asserting a state that diverges from the
+    /// pinned current truth (e.g. the migration script's post-state
+    /// re-check after it has simulated `changeThreshold`).
+    /// @param safe The Safe to validate against the pinned current truth.
+    function assertAll(IGnosisSafe safe) internal view {
+        assertAll(safe, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD, LibProdSafes.expectedOwners());
     }
 }

--- a/test/src/concrete/deploy/StoxProdV2.t.sol
+++ b/test/src/concrete/deploy/StoxProdV2.t.sol
@@ -5,6 +5,9 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibProdDeployV2} from "../../../../src/lib/LibProdDeployV2.sol";
 import {LibProdDeployV2BaseOverrides} from "../../../../src/lib/LibProdDeployV2BaseOverrides.sol";
+import {LibProdSafes} from "../../../../src/lib/LibProdSafes.sol";
+import {LibSafeInvariants} from "../../../../src/lib/LibSafeInvariants.sol";
+import {IGnosisSafe} from "../../../../src/interface/IGnosisSafe.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
 import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
@@ -118,6 +121,15 @@ contract StoxProdV2Test is Test {
         );
     }
 
+    /// Per-Safe invariant bundle for the ST0x token-owner Safe on Base.
+    /// Calls `LibSafeInvariants.assertAll` against the production Safe
+    /// address pinned in `LibProdSafes`. The Safe is Base-only (no Safe
+    /// on Arbitrum / Base Sepolia / Flare / Polygon for ST0x ops), so
+    /// this helper is only invoked from `testProdDeployBaseV2`.
+    function checkAllSafeBase() internal view {
+        LibSafeInvariants.assertAll(IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE));
+    }
+
     /// All V2 contracts MUST be deployed on Arbitrum.
     function testProdDeployArbitrumV2() external {
         vm.createSelectFork(LibRainDeploy.ARBITRUM_ONE);
@@ -127,6 +139,10 @@ contract StoxProdV2Test is Test {
     /// All V2 contracts MUST be deployed on Base.
     /// OARV deployer beacons on Base were corrupted post-deployment — see
     /// LibProdDeployV2BaseOverrides for details.
+    /// Also pins the ST0x token-owner Safe's invariants against the live
+    /// Base head fork via `checkAllSafeBase` — Base is the only network
+    /// where the Safe is deployed, so this is the unique site where the
+    /// Safe-state pins are exercised against on-chain reality.
     function testProdDeployBaseV2() external {
         vm.createSelectFork(LibRainDeploy.BASE);
         checkAllV2OnChain(
@@ -135,6 +151,7 @@ contract StoxProdV2Test is Test {
             LibProdDeployV2BaseOverrides.VAULT_BEACON_IMPLEMENTATION,
             LibProdDeployV2BaseOverrides.VAULT_BEACON_OWNER
         );
+        checkAllSafeBase();
     }
 
     /// All V2 contracts MUST be deployed on Base Sepolia.

--- a/test/src/lib/LibSafeInvariants.t.sol
+++ b/test/src/lib/LibSafeInvariants.t.sol
@@ -5,10 +5,12 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibSafeInvariants} from "../../../src/lib/LibSafeInvariants.sol";
 import {LibProdSafes} from "../../../src/lib/LibProdSafes.sol";
-import {LibTokenOwnership, IOwnable, ReceiptVaultOwnerMismatch} from "../../../src/lib/LibTokenOwnership.sol";
+import {LibProdTokensBase} from "../../../src/lib/LibProdTokensBase.sol";
 import {IGnosisSafe} from "../../../src/interface/IGnosisSafe.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 import {
+    IOwnable,
+    ReceiptVaultOwnerMismatch,
     SafeProxyCodehashMismatch,
     SafeSingletonMismatch,
     SafeSingletonBytecodeMismatch,
@@ -39,20 +41,26 @@ contract LibSafeInvariantsHarness {
         LibSafeInvariants.assertThreshold(safe, expected);
     }
 
-    function callAssertAllChecks(IGnosisSafe safe, address[] memory expectedOwners, uint256 expectedThreshold)
-        external
-        view
-    {
-        LibSafeInvariants.assertAllChecks(safe, expectedOwners, expectedThreshold);
+    function callAssertAll(IGnosisSafe safe, uint256 expectedThreshold, address[] memory expectedOwners) external view {
+        LibSafeInvariants.assertAll(safe, expectedThreshold, expectedOwners);
+    }
+
+    function callAssertAllDefaults(IGnosisSafe safe) external view {
+        LibSafeInvariants.assertAll(safe);
     }
 }
 
 /// @title LibSafeInvariantsTest
-/// @notice Live fork tests that exercise each invariant in `LibSafeInvariants`
-/// against the production ST0x token-owner Safe on Base, plus one inverted
-/// test per invariant that injects drift via `vm.mockCall` and asserts the
-/// matching typed error is raised. Uses an unpinned head fork to keep drift
-/// detection live; see the rationale in `LibProdSafes.t.sol::selectBaseFork`.
+/// @notice Inverted fork tests that exercise each invariant in
+/// `LibSafeInvariants` by injecting drift via `vm.etch` / `vm.mockCall` /
+/// `vm.store` and asserting the matching typed error is raised. The
+/// positive ("live state passes") cases live in
+/// `StoxProdV2.t.sol::testProdDeployBaseV2` (via `checkAllSafeBase`),
+/// so this file focuses on coverage of every error path.
+/// @dev Uses an unpinned Base head fork (same precedent as
+/// `StoxProdV2.t.sol::testProdDeployBaseV2`). Pinning would freeze the
+/// invariant assertions against a stale snapshot and let new drift slip
+/// through unnoticed.
 contract LibSafeInvariantsTest is Test {
     /// @notice Wrapper for the production Safe address; reset by every test
     /// after `selectBaseFork` because `vm.createSelectFork` resets cheatcode
@@ -60,60 +68,27 @@ contract LibSafeInvariantsTest is Test {
     IGnosisSafe internal safe;
 
     /// @notice External-call harness deployed fresh per test (via fork
-    /// rebuild). Kept off the fork via `vm.makePersistent` is unnecessary
-    /// here because each test calls `selectBaseFork` before deploying the
+    /// rebuild). Each test calls `selectBaseFork` before deploying the
     /// harness; the harness is recreated against the active fork.
     LibSafeInvariantsHarness internal harness;
 
-    /// @notice Selects the Base fork at chain head — deliberately unpinned.
-    /// Mirrors the precedent set in `LibProdSafes.t.sol::selectBaseFork`
-    /// (and `StoxProdV2.t.sol::testProdDeployBaseV2`): pinning would freeze
-    /// the invariant assertions against a stale snapshot and let new drift
-    /// slip through unnoticed.
+    /// @notice Selects the Base fork at chain head — deliberately
+    /// unpinned. Live drift detector; see contract-level rationale.
     function selectBaseFork() internal {
         vm.createSelectFork(LibRainDeploy.BASE);
         safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
         harness = new LibSafeInvariantsHarness();
     }
 
-    /// @notice The immutable-invariant bundle passes against the live Safe
-    /// (including the uniform-ownership leg now folded in via
-    /// `LibTokenOwnership.assertUniformOwnership`).
-    function testAssertImmutableInvariantsLive() external {
-        selectBaseFork();
-        LibSafeInvariants.assertImmutableInvariants(safe);
-    }
-
-    /// @notice The expected 4-owner roster matches the live Safe in order.
-    function testAssertOwnerSetLive() external {
-        selectBaseFork();
-        LibSafeInvariants.assertOwnerSet(safe, LibProdSafes.expectedOwners());
-    }
-
-    /// @notice The pre-migration threshold of `1` matches the live Safe.
-    function testAssertThresholdLive() external {
-        selectBaseFork();
-        LibSafeInvariants.assertThreshold(safe, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION);
-    }
-
-    /// @notice `assertAllChecks` accepts the live Safe at its pre-migration
-    /// pinned state (4-owner roster, threshold `1`). This is the call site
-    /// the migration script's pre-flight uses.
-    function testAssertAllChecksLivePreMigration() external {
-        selectBaseFork();
-        LibSafeInvariants.assertAllChecks(
-            safe, LibProdSafes.expectedOwners(), LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION
-        );
-    }
-
     /// @notice Token-side ownership drift bubbles
     /// `ReceiptVaultOwnerMismatch` through `assertImmutableInvariants`.
     /// Confirms the token-ownership leg is exercised by the immutable
-    /// bundle rather than only by direct calls into `LibTokenOwnership`.
+    /// bundle. The victim vault address comes from `LibProdTokensBase`
+    /// (the source of truth for production receipt vaults).
     function testInvertedImmutableInvariantsTokenOwnershipDrift() external {
         selectBaseFork();
         address rogueOwner = address(0xBADC0DE);
-        address victim = LibTokenOwnership.ST0X_RECEIPT_VAULT_NVDA;
+        address victim = LibProdTokensBase.MSTR_RECEIPT_VAULT;
         vm.mockCall(victim, abi.encodeWithSelector(IOwnable.owner.selector), abi.encode(rogueOwner));
         vm.expectRevert(abi.encodeWithSelector(ReceiptVaultOwnerMismatch.selector, victim, address(safe), rogueOwner));
         harness.callAssertImmutableInvariants(safe);
@@ -309,5 +284,34 @@ contract LibSafeInvariantsTest is Test {
         selectBaseFork();
         vm.expectRevert(abi.encodeWithSelector(SafeThresholdMismatch.selector, address(safe), uint256(3), uint256(1)));
         harness.callAssertThreshold(safe, 3);
+    }
+
+    /// @notice `assertAll(safe)` (no-arg overload) trips
+    /// `SafeThresholdMismatch` when the live threshold drifts from the
+    /// pinned current truth. Mocks `getThreshold()` to `5` and asserts the
+    /// bundle surfaces the threshold error rather than passing silently.
+    /// This is the load-bearing test for the no-arg overload's defaulting
+    /// to `LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD`.
+    function testInvertedAssertAllDefaultsThresholdDrift() external {
+        selectBaseFork();
+        vm.mockCall(address(safe), abi.encodeWithSelector(IGnosisSafe.getThreshold.selector), abi.encode(uint256(5)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeThresholdMismatch.selector, address(safe), LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD, uint256(5)
+            )
+        );
+        harness.callAssertAllDefaults(safe);
+    }
+
+    /// @notice `assertAll(safe, threshold, owners)` (full-args overload)
+    /// trips `SafeThresholdMismatch` when the caller's supplied threshold
+    /// diverges from the live Safe — covering the migration script's
+    /// post-state call site. Caller asks for `4` against a live threshold
+    /// of `1`; the bundle reports the mismatch with the caller's `4` as
+    /// the expected value, not the pinned constant.
+    function testInvertedAssertAllFullArgsThresholdMismatch() external {
+        selectBaseFork();
+        vm.expectRevert(abi.encodeWithSelector(SafeThresholdMismatch.selector, address(safe), uint256(4), uint256(1)));
+        harness.callAssertAll(safe, 4, LibProdSafes.expectedOwners());
     }
 }

--- a/test/src/lib/LibSafeInvariants.t.sol
+++ b/test/src/lib/LibSafeInvariants.t.sol
@@ -5,6 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibSafeInvariants} from "../../../src/lib/LibSafeInvariants.sol";
 import {LibProdSafes} from "../../../src/lib/LibProdSafes.sol";
+import {LibTokenOwnership, IOwnable, ReceiptVaultOwnerMismatch} from "../../../src/lib/LibTokenOwnership.sol";
 import {IGnosisSafe} from "../../../src/interface/IGnosisSafe.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
 import {
@@ -26,8 +27,8 @@ import {
 /// catches reverts from external calls; library `internal` functions inline
 /// and would fail the depth check otherwise.
 contract LibSafeInvariantsHarness {
-    function callAssertBaseSafeInvariants(IGnosisSafe safe) external view {
-        LibSafeInvariants.assertBaseSafeInvariants(safe);
+    function callAssertImmutableInvariants(IGnosisSafe safe) external view {
+        LibSafeInvariants.assertImmutableInvariants(safe);
     }
 
     function callAssertOwnerSet(IGnosisSafe safe, address[] memory expected) external view {
@@ -36,6 +37,13 @@ contract LibSafeInvariantsHarness {
 
     function callAssertThreshold(IGnosisSafe safe, uint256 expected) external view {
         LibSafeInvariants.assertThreshold(safe, expected);
+    }
+
+    function callAssertAllChecks(IGnosisSafe safe, address[] memory expectedOwners, uint256 expectedThreshold)
+        external
+        view
+    {
+        LibSafeInvariants.assertAllChecks(safe, expectedOwners, expectedThreshold);
     }
 }
 
@@ -68,10 +76,12 @@ contract LibSafeInvariantsTest is Test {
         harness = new LibSafeInvariantsHarness();
     }
 
-    /// @notice The full invariant bundle passes against the live Safe.
-    function testAssertBaseSafeInvariantsLive() external {
+    /// @notice The immutable-invariant bundle passes against the live Safe
+    /// (including the uniform-ownership leg now folded in via
+    /// `LibTokenOwnership.assertUniformOwnership`).
+    function testAssertImmutableInvariantsLive() external {
         selectBaseFork();
-        LibSafeInvariants.assertBaseSafeInvariants(safe);
+        LibSafeInvariants.assertImmutableInvariants(safe);
     }
 
     /// @notice The expected 4-owner roster matches the live Safe in order.
@@ -80,10 +90,33 @@ contract LibSafeInvariantsTest is Test {
         LibSafeInvariants.assertOwnerSet(safe, LibProdSafes.expectedOwners());
     }
 
-    /// @notice The pre-RAI-296 threshold of `1` matches the live Safe.
+    /// @notice The pre-migration threshold of `1` matches the live Safe.
     function testAssertThresholdLive() external {
         selectBaseFork();
-        LibSafeInvariants.assertThreshold(safe, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_RAI296);
+        LibSafeInvariants.assertThreshold(safe, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION);
+    }
+
+    /// @notice `assertAllChecks` accepts the live Safe at its pre-migration
+    /// pinned state (4-owner roster, threshold `1`). This is the call site
+    /// the migration script's pre-flight uses.
+    function testAssertAllChecksLivePreMigration() external {
+        selectBaseFork();
+        LibSafeInvariants.assertAllChecks(
+            safe, LibProdSafes.expectedOwners(), LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION
+        );
+    }
+
+    /// @notice Token-side ownership drift bubbles
+    /// `ReceiptVaultOwnerMismatch` through `assertImmutableInvariants`.
+    /// Confirms the token-ownership leg is exercised by the immutable
+    /// bundle rather than only by direct calls into `LibTokenOwnership`.
+    function testInvertedImmutableInvariantsTokenOwnershipDrift() external {
+        selectBaseFork();
+        address rogueOwner = address(0xBADC0DE);
+        address victim = LibTokenOwnership.ST0X_RECEIPT_VAULT_NVDA;
+        vm.mockCall(victim, abi.encodeWithSelector(IOwnable.owner.selector), abi.encode(rogueOwner));
+        vm.expectRevert(abi.encodeWithSelector(ReceiptVaultOwnerMismatch.selector, victim, address(safe), rogueOwner));
+        harness.callAssertImmutableInvariants(safe);
     }
 
     /// @notice Drift in the proxy runtime codehash trips
@@ -107,7 +140,7 @@ contract LibSafeInvariantsTest is Test {
                 mutatedCodehash
             )
         );
-        harness.callAssertBaseSafeInvariants(safe);
+        harness.callAssertImmutableInvariants(safe);
     }
 
     /// @notice Drift in the singleton pointer (slot 0) trips
@@ -126,7 +159,7 @@ contract LibSafeInvariantsTest is Test {
                 SafeSingletonMismatch.selector, address(safe), LibProdSafes.SAFE_V1_4_1_L2_SINGLETON, impostor
             )
         );
-        harness.callAssertBaseSafeInvariants(safe);
+        harness.callAssertImmutableInvariants(safe);
     }
 
     /// @notice Drift in the singleton's bytecode trips
@@ -160,7 +193,7 @@ contract LibSafeInvariantsTest is Test {
                 actual
             )
         );
-        harness.callAssertBaseSafeInvariants(safe);
+        harness.callAssertImmutableInvariants(safe);
     }
 
     /// @notice Drift in the singleton's reported version trips
@@ -173,7 +206,7 @@ contract LibSafeInvariantsTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(SafeVersionMismatch.selector, address(safe), LibProdSafes.SAFE_V1_4_1_VERSION, bogus)
         );
-        harness.callAssertBaseSafeInvariants(safe);
+        harness.callAssertImmutableInvariants(safe);
     }
 
     /// @notice A non-empty module list trips `SafeUnexpectedModules`.
@@ -192,7 +225,7 @@ contract LibSafeInvariantsTest is Test {
             abi.encode(mockModules, LibSafeInvariants.SAFE_MODULES_SENTINEL)
         );
         vm.expectRevert(abi.encodeWithSelector(SafeUnexpectedModules.selector, address(safe), rogueModule));
-        harness.callAssertBaseSafeInvariants(safe);
+        harness.callAssertImmutableInvariants(safe);
     }
 
     /// @notice A non-zero guard slot trips `SafeUnexpectedGuard`. Simulated
@@ -209,7 +242,7 @@ contract LibSafeInvariantsTest is Test {
             abi.encode(abi.encodePacked(bytes32(uint256(uint160(rogueGuard)))))
         );
         vm.expectRevert(abi.encodeWithSelector(SafeUnexpectedGuard.selector, address(safe), rogueGuard));
-        harness.callAssertBaseSafeInvariants(safe);
+        harness.callAssertImmutableInvariants(safe);
     }
 
     /// @notice Drift in the fallback handler slot trips
@@ -235,7 +268,7 @@ contract LibSafeInvariantsTest is Test {
                 impostor
             )
         );
-        harness.callAssertBaseSafeInvariants(safe);
+        harness.callAssertImmutableInvariants(safe);
     }
 
     /// @notice Owner count drift trips `SafeOwnerCountMismatch`. The caller

--- a/test/src/lib/LibSafeInvariants.t.sol
+++ b/test/src/lib/LibSafeInvariants.t.sol
@@ -10,6 +10,7 @@ import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
 import {
     SafeProxyCodehashMismatch,
     SafeSingletonMismatch,
+    SafeSingletonBytecodeMismatch,
     SafeVersionMismatch,
     SafeUnexpectedModules,
     SafeUnexpectedGuard,
@@ -123,6 +124,40 @@ contract LibSafeInvariantsTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(
                 SafeSingletonMismatch.selector, address(safe), LibProdSafes.SAFE_V1_4_1_L2_SINGLETON, impostor
+            )
+        );
+        harness.callAssertBaseSafeInvariants(safe);
+    }
+
+    /// @notice Drift in the singleton's bytecode trips
+    /// `SafeSingletonBytecodeMismatch`. Simulated by `vm.etch`-ing alien
+    /// bytecode at the singleton address — the codehash diverges from
+    /// the pinned `SAFE_V1_4_1_L2_SINGLETON_CODEHASH` even though slot
+    /// 0 still points at the canonical address.
+    /// @dev `vm.etch` on the singleton breaks every delegate-routed
+    /// read on the proxy, so the slot-0 fetch is mocked back to the
+    /// canonical singleton address. Only the explicit `getStorageAt(0,
+    /// 1)` calldata is mocked; later `getStorageAt` reads (guard slot,
+    /// fallback handler slot) are unaffected and never execute, because
+    /// the bytecode check reverts first.
+    function testInvertedSingletonBytecodeMismatch() external {
+        selectBaseFork();
+        bytes memory bogusCode = hex"60016000526001601ff3";
+        vm.etch(LibProdSafes.SAFE_V1_4_1_L2_SINGLETON, bogusCode);
+        vm.mockCall(
+            address(safe),
+            abi.encodeWithSelector(IGnosisSafe.getStorageAt.selector, uint256(0), uint256(1)),
+            abi.encode(abi.encodePacked(bytes32(uint256(uint160(LibProdSafes.SAFE_V1_4_1_L2_SINGLETON)))))
+        );
+        bytes32 expected = LibProdSafes.SAFE_V1_4_1_L2_SINGLETON_CODEHASH;
+        bytes32 actual = keccak256(bogusCode);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeSingletonBytecodeMismatch.selector,
+                address(safe),
+                LibProdSafes.SAFE_V1_4_1_L2_SINGLETON,
+                expected,
+                actual
             )
         );
         harness.callAssertBaseSafeInvariants(safe);

--- a/test/src/lib/LibSafeInvariants.t.sol
+++ b/test/src/lib/LibSafeInvariants.t.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibSafeInvariants} from "../../../src/lib/LibSafeInvariants.sol";
+import {LibProdSafes} from "../../../src/lib/LibProdSafes.sol";
+import {IGnosisSafe} from "../../../src/interface/IGnosisSafe.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {
+    SafeProxyCodehashMismatch,
+    SafeSingletonMismatch,
+    SafeVersionMismatch,
+    SafeUnexpectedModules,
+    SafeUnexpectedGuard,
+    SafeFallbackHandlerMismatch,
+    SafeOwnerCountMismatch,
+    SafeOwnerMismatch,
+    SafeThresholdMismatch
+} from "../../../src/lib/LibSafeInvariants.sol";
+
+/// @title LibSafeInvariantsHarness
+/// @notice External-call shim around the internal library so
+/// `vm.expectRevert` can intercept the typed errors. `vm.expectRevert` only
+/// catches reverts from external calls; library `internal` functions inline
+/// and would fail the depth check otherwise.
+contract LibSafeInvariantsHarness {
+    function callAssertBaseSafeInvariants(IGnosisSafe safe) external view {
+        LibSafeInvariants.assertBaseSafeInvariants(safe);
+    }
+
+    function callAssertOwnerSet(IGnosisSafe safe, address[] memory expected) external view {
+        LibSafeInvariants.assertOwnerSet(safe, expected);
+    }
+
+    function callAssertThreshold(IGnosisSafe safe, uint256 expected) external view {
+        LibSafeInvariants.assertThreshold(safe, expected);
+    }
+}
+
+/// @title LibSafeInvariantsTest
+/// @notice Live fork tests that exercise each invariant in `LibSafeInvariants`
+/// against the production ST0x token-owner Safe on Base, plus one inverted
+/// test per invariant that injects drift via `vm.mockCall` and asserts the
+/// matching typed error is raised. Uses an unpinned head fork to keep drift
+/// detection live; see the rationale in `LibProdSafes.t.sol::selectBaseFork`.
+contract LibSafeInvariantsTest is Test {
+    /// @notice Wrapper for the production Safe address; reset by every test
+    /// after `selectBaseFork` because `vm.createSelectFork` resets cheatcode
+    /// state between forks.
+    IGnosisSafe internal safe;
+
+    /// @notice External-call harness deployed fresh per test (via fork
+    /// rebuild). Kept off the fork via `vm.makePersistent` is unnecessary
+    /// here because each test calls `selectBaseFork` before deploying the
+    /// harness; the harness is recreated against the active fork.
+    LibSafeInvariantsHarness internal harness;
+
+    /// @notice Selects the Base fork at chain head — deliberately unpinned.
+    /// Mirrors the precedent set in `LibProdSafes.t.sol::selectBaseFork`
+    /// (and `StoxProdV2.t.sol::testProdDeployBaseV2`): pinning would freeze
+    /// the invariant assertions against a stale snapshot and let new drift
+    /// slip through unnoticed.
+    function selectBaseFork() internal {
+        vm.createSelectFork(LibRainDeploy.BASE);
+        safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
+        harness = new LibSafeInvariantsHarness();
+    }
+
+    /// @notice The full invariant bundle passes against the live Safe.
+    function testAssertBaseSafeInvariantsLive() external {
+        selectBaseFork();
+        LibSafeInvariants.assertBaseSafeInvariants(safe);
+    }
+
+    /// @notice The expected 4-owner roster matches the live Safe in order.
+    function testAssertOwnerSetLive() external {
+        selectBaseFork();
+        LibSafeInvariants.assertOwnerSet(safe, LibProdSafes.expectedOwners());
+    }
+
+    /// @notice The pre-RAI-296 threshold of `1` matches the live Safe.
+    function testAssertThresholdLive() external {
+        selectBaseFork();
+        LibSafeInvariants.assertThreshold(safe, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_RAI296);
+    }
+
+    /// @notice Drift in the proxy runtime codehash trips
+    /// `SafeProxyCodehashMismatch`. Simulated by overwriting the proxy
+    /// bytecode with a single `INVALID` opcode; `extcodehash` then returns
+    /// the hash of `0xFE`, which differs from the pinned codehash.
+    function testInvertedCodehashMismatch() external {
+        selectBaseFork();
+        bytes memory mutatedCode = hex"FE";
+        vm.etch(address(safe), mutatedCode);
+        bytes32 mutatedCodehash;
+        address safeAddr = address(safe);
+        assembly ("memory-safe") {
+            mutatedCodehash := extcodehash(safeAddr)
+        }
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeProxyCodehashMismatch.selector,
+                safeAddr,
+                LibProdSafes.SAFE_V1_4_1_L2_PROXY_CODEHASH,
+                mutatedCodehash
+            )
+        );
+        harness.callAssertBaseSafeInvariants(safe);
+    }
+
+    /// @notice Drift in the singleton pointer (slot 0) trips
+    /// `SafeSingletonMismatch`. Simulated by mocking `getStorageAt(0, 1)` to
+    /// return a different address.
+    function testInvertedSingletonMismatch() external {
+        selectBaseFork();
+        address impostor = address(0xDEAD);
+        vm.mockCall(
+            address(safe),
+            abi.encodeWithSelector(IGnosisSafe.getStorageAt.selector, uint256(0), uint256(1)),
+            abi.encode(abi.encodePacked(bytes32(uint256(uint160(impostor)))))
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeSingletonMismatch.selector, address(safe), LibProdSafes.SAFE_V1_4_1_L2_SINGLETON, impostor
+            )
+        );
+        harness.callAssertBaseSafeInvariants(safe);
+    }
+
+    /// @notice Drift in the singleton's reported version trips
+    /// `SafeVersionMismatch`. Simulated by mocking `VERSION()` to return an
+    /// unexpected string.
+    function testInvertedVersionMismatch() external {
+        selectBaseFork();
+        string memory bogus = "9.9.9";
+        vm.mockCall(address(safe), abi.encodeWithSelector(IGnosisSafe.VERSION.selector), abi.encode(bogus));
+        vm.expectRevert(
+            abi.encodeWithSelector(SafeVersionMismatch.selector, address(safe), LibProdSafes.SAFE_V1_4_1_VERSION, bogus)
+        );
+        harness.callAssertBaseSafeInvariants(safe);
+    }
+
+    /// @notice A non-empty module list trips `SafeUnexpectedModules`.
+    /// Simulated by mocking the paginated enumeration to return a single
+    /// rogue module.
+    function testInvertedUnexpectedModules() external {
+        selectBaseFork();
+        address rogueModule = address(0xBEEF);
+        address[] memory mockModules = new address[](1);
+        mockModules[0] = rogueModule;
+        vm.mockCall(
+            address(safe),
+            abi.encodeWithSelector(
+                IGnosisSafe.getModulesPaginated.selector, LibSafeInvariants.SAFE_MODULES_SENTINEL, uint256(10)
+            ),
+            abi.encode(mockModules, LibSafeInvariants.SAFE_MODULES_SENTINEL)
+        );
+        vm.expectRevert(abi.encodeWithSelector(SafeUnexpectedModules.selector, address(safe), rogueModule));
+        harness.callAssertBaseSafeInvariants(safe);
+    }
+
+    /// @notice A non-zero guard slot trips `SafeUnexpectedGuard`. Simulated
+    /// by mocking `getStorageAt` at the guard slot to return a guard
+    /// address.
+    function testInvertedUnexpectedGuard() external {
+        selectBaseFork();
+        address rogueGuard = address(0xCAFE);
+        vm.mockCall(
+            address(safe),
+            abi.encodeWithSelector(
+                IGnosisSafe.getStorageAt.selector, uint256(LibSafeInvariants.SAFE_GUARD_STORAGE_SLOT), uint256(1)
+            ),
+            abi.encode(abi.encodePacked(bytes32(uint256(uint160(rogueGuard)))))
+        );
+        vm.expectRevert(abi.encodeWithSelector(SafeUnexpectedGuard.selector, address(safe), rogueGuard));
+        harness.callAssertBaseSafeInvariants(safe);
+    }
+
+    /// @notice Drift in the fallback handler slot trips
+    /// `SafeFallbackHandlerMismatch`. Simulated by mocking `getStorageAt` at
+    /// the fallback handler slot to return a different address.
+    function testInvertedFallbackHandlerMismatch() external {
+        selectBaseFork();
+        address impostor = address(0xFACE);
+        vm.mockCall(
+            address(safe),
+            abi.encodeWithSelector(
+                IGnosisSafe.getStorageAt.selector,
+                uint256(LibSafeInvariants.SAFE_FALLBACK_HANDLER_STORAGE_SLOT),
+                uint256(1)
+            ),
+            abi.encode(abi.encodePacked(bytes32(uint256(uint160(impostor)))))
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeFallbackHandlerMismatch.selector,
+                address(safe),
+                LibProdSafes.SAFE_V1_4_1_COMPATIBILITY_FALLBACK_HANDLER,
+                impostor
+            )
+        );
+        harness.callAssertBaseSafeInvariants(safe);
+    }
+
+    /// @notice Owner count drift trips `SafeOwnerCountMismatch`. The caller
+    /// passes a 3-entry array against the live 4-owner Safe.
+    function testInvertedOwnerCountMismatch() external {
+        selectBaseFork();
+        address[] memory truncated = new address[](3);
+        truncated[0] = LibProdSafes.STOX_TOKEN_OWNER_SAFE_OWNER_1;
+        truncated[1] = LibProdSafes.STOX_TOKEN_OWNER_SAFE_OWNER_2;
+        truncated[2] = LibProdSafes.STOX_TOKEN_OWNER_SAFE_OWNER_3;
+        vm.expectRevert(abi.encodeWithSelector(SafeOwnerCountMismatch.selector, address(safe), uint256(3), uint256(4)));
+        harness.callAssertOwnerSet(safe, truncated);
+    }
+
+    /// @notice Owner address drift trips `SafeOwnerMismatch`. The caller
+    /// supplies an array with the correct length but a swapped owner at
+    /// index 1.
+    function testInvertedOwnerMismatch() external {
+        selectBaseFork();
+        address[] memory swapped = LibProdSafes.expectedOwners();
+        address impostor = address(0xC0FFEE);
+        swapped[1] = impostor;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SafeOwnerMismatch.selector,
+                address(safe),
+                uint256(1),
+                impostor,
+                LibProdSafes.STOX_TOKEN_OWNER_SAFE_OWNER_2
+            )
+        );
+        harness.callAssertOwnerSet(safe, swapped);
+    }
+
+    /// @notice Threshold drift trips `SafeThresholdMismatch`. Caller asks
+    /// for `3` against a live threshold of `1`.
+    function testInvertedThresholdMismatch() external {
+        selectBaseFork();
+        vm.expectRevert(abi.encodeWithSelector(SafeThresholdMismatch.selector, address(safe), uint256(3), uint256(1)));
+        harness.callAssertThreshold(safe, 3);
+    }
+}


### PR DESCRIPTION
## Summary

Reusable Safe v1.4.1 invariant assertions for the ST0x token-owner Safe, split into two categories so callers can express their intent precisely:

- **Immutable invariants** (`assertImmutableInvariants`): properties that always hold regardless of pending or past operational migrations — proxy codehash, singleton pointer + bytecode, version, modules empty, guard zero, fallback handler pinned, and uniform `owner()` across every production receipt vault. The vault list is sourced from `LibProdTokensBase.productionReceiptVaults()` (added here as a new helper alongside the existing per-token constants on `main`), so the canonical 13-vault list lives in one place.
- **Parameterised state assertions** (`assertOwnerSet(safe, expected)` and `assertThreshold(safe, expected)`): properties whose expected value is supplied by the caller because the caller is deliberately mutating that property. Wrong values here are caller intent, not Safe drift.

The `assertAll` bundle follows `StoxProdV2Test::checkAllV2OnChain`: a full-args helper plus a no-arg overload that fills in defaults from `LibProdSafes`:

```solidity
// Pre-flight / live-state pin — uses the current-truth pins.
LibSafeInvariants.assertAll(safe);

// Migration script's post-state — overrides the threshold deliberately.
LibSafeInvariants.assertAll(safe, TARGET_THRESHOLD, LibProdSafes.expectedOwners());
```

## Live-state pin

The Safe live-state pin lives in `test/src/concrete/deploy/StoxProdV2.t.sol::testProdDeployBaseV2`, invoked via a new `checkAllSafeBase()` helper that wraps `LibSafeInvariants.assertAll(safe)`. The Safe is Base-only, so the helper is only called from the Base test. Co-locating Safe-state drift detection with the rest of the prod V2 fork assertions keeps live-state pins in one place per network and lets the existing prod V2 head-fork pattern carry the drift detection.

## Files

- `src/lib/LibSafeInvariants.sol` — typed errors (including the inline `IOwnable` + `ReceiptVaultOwnerMismatch` that the uniform-ownership leg used to import from a separate file) + `assertImmutableInvariants` + `assertOwnerSet` + `assertThreshold` + overloaded `assertAll`.
- `src/lib/LibProdTokensBase.sol` — adds `productionReceiptVaults()` returning the 13 production receipt vault addresses in deploy order.
- `test/src/lib/LibSafeInvariants.t.sol` — inverted-only fork tests covering every error path (`vm.etch`/`vm.mockCall`/`vm.store`) plus two coverage tests for the `assertAll` overloads (no-arg defaulting + full-args override). Positive "live state passes" cases fold into `StoxProdV2.t.sol::testProdDeployBaseV2`.
- `test/src/concrete/deploy/StoxProdV2.t.sol` — new internal helper `checkAllSafeBase()` invoked from `testProdDeployBaseV2`.

## Stack

- Parent: [#189](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/189) (`feat/safe-iface`).
- Next: [#191](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/191) (`feat/lib-safe-ops`) — adds the off-chain `SafeTx` hash + simulation + Tx Builder JSON helpers.

This PR is now parented directly off `feat/safe-iface`. The earlier `LibTokenOwnership` PR (#192) has been closed — its 13 receipt vault addresses duplicated `src/lib/LibProdTokensBase.sol` on `main`, so the token-ownership leg is now folded into `LibSafeInvariants` and sources its vault list from `LibProdTokensBase.productionReceiptVaults()`.

## Test plan

- [x] `forge test --match-contract LibSafeInvariantsTest` — 13/13 passing.
- [x] `forge test --match-test testProdDeployBaseV2` — passing (now includes the Safe-state bundle via `checkAllSafeBase`).
- [x] `rainix-sol-static` — slither 0 findings, fmt clean.
- [x] `rainix-sol-legal` — REUSE compliant.
- [x] Full `rainix-sol-test` — 575 passing (pre-existing ignored failures only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Safe configuration validation library to verify Safe contract integrity against expected v1.4.1 L2 specifications.

* **Tests**
  * Added comprehensive test suite for Safe configuration validation across multiple error scenarios.
  * Enhanced Base network deployment verification with Safe state invariant checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/S01-Issuer/st0x.deploy/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->