### PR TITLE
feat(safe): LibSafeOps — SafeTxHash + simulation + Tx Builder JSON helpers

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -20,7 +20,13 @@ evm_version = "cancun"
 bytecode_hash = "none"
 cbor_metadata = false
 
-fs_permissions = [{ access = "read-write", path = "src/generated" }]
+fs_permissions = [
+  { access = "read-write", path = "src/generated" },
+  # `out` is needed by the RAI-296 multisig migration script and its tests:
+  # the script writes the Safe Tx Builder JSON artifact under `out/`, and
+  # the LibSafeOps round-trip tests round-trip the JSON through disk.
+  { access = "read-write", path = "out" },
+]
 
 remappings = [
   # Third-party soldeer dep whose own source uses unversioned import

--- a/src/interface/IGnosisSafe.sol
+++ b/src/interface/IGnosisSafe.sol
@@ -101,4 +101,48 @@ interface IGnosisSafe {
     /// renaming would break ABI compatibility with the live deployment.
     //slither-disable-next-line naming-convention
     function VERSION() external view returns (string memory);
+
+    /// @notice Marks the supplied Safe transaction hash as pre-approved by
+    /// `msg.sender`. Subsequent `execTransaction` calls can satisfy
+    /// `checkSignatures` for this hash by supplying a `v=1` signature entry
+    /// whose `r` field is `bytes32(uint256(uint160(msg.sender)))` instead of
+    /// an ECDSA tuple.
+    /// @dev Only callable by an owner of the Safe. Used by the reversibility
+    /// helper in `LibSafeOps` to satisfy signature verification under a
+    /// `vm.prank` without requiring test private keys for owner addresses.
+    /// @param hashToApprove The Safe transaction hash to pre-approve.
+    function approveHash(bytes32 hashToApprove) external;
+
+    /// @notice Executes a Safe transaction. Signature verification routes
+    /// through `checkSignatures`, which accepts both ECDSA signatures and
+    /// the `v=1` pre-approved-hash variant produced by `approveHash`.
+    /// @dev The Safe v1.4.1 source asserts the packed `signatures` blob is
+    /// sorted ascending by signer address and contains at least `threshold`
+    /// entries (`GS020`: "Signatures data too short" when too few).
+    /// @param to Destination of the inner transaction.
+    /// @param value Native value forwarded to `to`.
+    /// @param data Calldata forwarded to `to`.
+    /// @param operation `0` for `CALL`, `1` for `DELEGATECALL`.
+    /// @param safeTxGas Gas forwarded to the inner call.
+    /// @param baseGas Fixed gas costs added on top of `safeTxGas` for refund.
+    /// @param gasPrice Refund gas price (zero for non-refunded executions).
+    /// @param gasToken Token used for the refund (zero address for native).
+    /// @param refundReceiver Refund receiver (zero address for `tx.origin`).
+    /// @param signatures Packed owner signatures, ordered ascending by
+    /// signer address. Each entry is 65 bytes (`r || s || v`); the `v=1`
+    /// variant treats `r` as a pre-approver address.
+    /// @return success Whether the inner call succeeded after signature
+    /// verification.
+    function execTransaction(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes calldata signatures
+    ) external payable returns (bool success);
 }

--- a/src/lib/LibSafeOps.sol
+++ b/src/lib/LibSafeOps.sol
@@ -28,11 +28,11 @@ struct SafeTx {
 }
 
 /// @title LibSafeOps
-/// @notice Off-chain Safe transaction helpers shared between the RAI-296
-/// migration script and its tests. Wraps the canonical `getTransactionHash`
-/// view, foundry-level simulation of self-calls and external calls, and the
-/// Safe Tx Builder JSON serialise/parse round-trip used to hand the bundle
-/// to signers via the Safe UI.
+/// @notice Off-chain Safe transaction helpers shared between the multisig
+/// threshold migration script and its tests. Wraps the canonical
+/// `getTransactionHash` view, foundry-level simulation of self-calls and
+/// external calls, and the Safe Tx Builder JSON serialise/parse round-trip
+/// used to hand the bundle to signers via the Safe UI.
 /// @dev The library is `Vm`-aware: it pokes the foundry cheatcode address
 /// directly so callers can use it from non-Test contracts (notably the
 /// `MigrateMultisigThreshold` script). The JSON helpers hand-assemble the
@@ -48,13 +48,14 @@ library LibSafeOps {
 
     /// @notice Safe Tx Builder version stamped into the `meta` block of
     /// emitted JSON bundles. Currently pinned at `"1.16.5"` to match the
-    /// version produced by the public Safe Tx Builder app at the time of
-    /// RAI-296 tooling authorship.
+    /// version produced by the public Safe Tx Builder app at the time
+    /// this library was authored.
     string internal constant TX_BUILDER_VERSION = "1.16.5";
 
     /// @notice Tx Builder JSON schema version stamped into the top-level
     /// `version` field. Pinned at `"1.0"` (the only version the public Tx
-    /// Builder UI currently accepts as of RAI-296 authorship).
+    /// Builder UI currently accepts at the time this library was
+    /// authored).
     string internal constant TX_BUILDER_SCHEMA_VERSION = "1.0";
 
     /// @notice Wrapper around `getTransactionHash` on the live Safe.
@@ -236,7 +237,7 @@ library LibSafeOps {
         // a wildcard path mis-decodes a single match, so we discover the
         // array length by probing `.transactions[i]` via `keyExistsJson`
         // until the index is no longer present. The cap is a defensive
-        // upper bound — RAI-296's migration bundle is single-tx, and the
+        // upper bound — the threshold migration bundle is single-tx, and the
         // Tx Builder UI itself imposes a far smaller practical limit.
         uint256 cap = 256;
         SafeTx[] memory scratch = new SafeTx[](cap);

--- a/src/lib/LibSafeOps.sol
+++ b/src/lib/LibSafeOps.sol
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+import {IGnosisSafe} from "../interface/IGnosisSafe.sol";
+
+/// @notice The parsed Tx Builder JSON has zero transactions. Empty bundles
+/// are never produced by `emitTxBuilderJson` and so a zero-length
+/// `transactions` array is treated as an invariant break rather than a
+/// no-op.
+error TxBuilderJsonNoTransactions();
+
+/// @notice A single Safe-Tx Builder transaction in canonical form. Mirrors
+/// the per-transaction shape of the Safe Tx Builder JSON.
+/// @param to The destination address of the inner transaction.
+/// @param value The native value forwarded to `to`.
+/// @param data The calldata forwarded to `to`. Self-mutating Safe calls
+/// (e.g. `changeThreshold`) encode the inner call here and target the Safe
+/// itself.
+/// @param operation The Safe `Operation` enum: `0` for `CALL`, `1` for
+/// `DELEGATECALL`.
+struct SafeTx {
+    address to;
+    uint256 value;
+    bytes data;
+    uint8 operation;
+}
+
+/// @title LibSafeOps
+/// @notice Off-chain Safe transaction helpers shared between the RAI-296
+/// migration script and its tests. Wraps the canonical `getTransactionHash`
+/// view, foundry-level simulation of self-calls and external calls, and the
+/// Safe Tx Builder JSON serialise/parse round-trip used to hand the bundle
+/// to signers via the Safe UI.
+/// @dev The library is `Vm`-aware: it pokes the foundry cheatcode address
+/// directly so callers can use it from non-Test contracts (notably the
+/// `MigrateMultisigThreshold` script). The JSON helpers hand-assemble the
+/// output rather than going through `vm.serializeJson` because the Tx
+/// Builder schema requires `transactions` to be a JSON array of objects —
+/// `vm.serializeString` keyed by index emits an object, not an array.
+library LibSafeOps {
+    /// @notice Reference to the foundry HEVM cheatcode address. Computed
+    /// the same way `forge-std` computes its own `vm` reference, but here
+    /// captured at library scope so non-Test callers (the script) can use
+    /// the simulation/JSON helpers without inheriting `Test`.
+    Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /// @notice Safe Tx Builder version stamped into the `meta` block of
+    /// emitted JSON bundles. Currently pinned at `"1.16.5"` to match the
+    /// version produced by the public Safe Tx Builder app at the time of
+    /// RAI-296 tooling authorship.
+    string internal constant TX_BUILDER_VERSION = "1.16.5";
+
+    /// @notice Tx Builder JSON schema version stamped into the top-level
+    /// `version` field. Pinned at `"1.0"` (the only version the public Tx
+    /// Builder UI currently accepts as of RAI-296 authorship).
+    string internal constant TX_BUILDER_SCHEMA_VERSION = "1.0";
+
+    /// @notice Wrapper around `getTransactionHash` on the live Safe.
+    /// Binds the hash to the Safe's own EIP-712 domain separator (chain id,
+    /// verifying contract) rather than recomputing it locally, so the
+    /// off-chain artifact and on-chain verification can't drift apart. The
+    /// inner-tx gas parameters are zeroed because the migration bundle does
+    /// not request a refund and the Safe Tx Builder defaults the same way.
+    /// @param safe The Safe whose nonce/domain are bound into the hash.
+    /// @param txn The transaction to be hashed.
+    /// @param nonce The Safe nonce the transaction will consume on execute.
+    /// @return The canonical Safe transaction hash that owners must sign.
+    function computeSafeTxHashViaSafe(IGnosisSafe safe, SafeTx memory txn, uint256 nonce)
+        internal
+        view
+        returns (bytes32)
+    {
+        return safe.getTransactionHash(
+            txn.to,
+            txn.value,
+            txn.data,
+            txn.operation,
+            // safeTxGas, baseGas, gasPrice, gasToken, refundReceiver: all
+            // zero. The Safe Tx Builder defaults to the same values for
+            // bundles built via its UI.
+            0,
+            0,
+            0,
+            address(0),
+            address(0),
+            nonce
+        );
+    }
+
+    /// @notice Simulate a Safe self-call: `vm.prank` as the Safe itself and
+    /// invoke the supplied calldata on the Safe address. Mirrors what the
+    /// inner `execTransaction` path does after signature verification, so
+    /// post-state assertions (threshold, owners, etc.) made against the
+    /// fork after this call reflect the on-chain post-exec state.
+    /// @dev The Safe's nonce is NOT advanced by this simulation — only
+    /// `execTransaction` advances the nonce, and we explicitly do not
+    /// invoke it because the goal is to assert the state the inner call
+    /// produces, not to model the wrapping exec.
+    /// @param safe The Safe to prank-call as.
+    /// @param data The calldata to forward to the Safe.
+    function simulateSelfCall(IGnosisSafe safe, bytes memory data) internal {
+        address safeAddr = address(safe);
+        VM.prank(safeAddr);
+        // The returndata is intentionally discarded: callers assert against
+        // post-state, not the inner return. If the inner call reverts we
+        // bubble the reason rather than swallowing a low-level failure.
+        // slither-disable-next-line low-level-calls
+        (bool ok, bytes memory ret) = safeAddr.call(data);
+        if (!ok) {
+            assembly ("memory-safe") {
+                revert(add(ret, 0x20), mload(ret))
+            }
+        }
+    }
+
+    /// @notice Simulate a Safe-originated external call: `vm.prank` as the
+    /// Safe and invoke `data` against `target`. Used when a bundle has the
+    /// Safe call out to a non-self address (e.g. taking ownership of a
+    /// dependency) so the same post-state assertions apply.
+    /// @param safe The Safe to prank-call as.
+    /// @param target The destination of the prank call.
+    /// @param data The calldata to forward to `target`.
+    function simulateExternalCall(IGnosisSafe safe, address target, bytes memory data) internal {
+        VM.prank(address(safe));
+        // slither-disable-next-line low-level-calls
+        (bool ok, bytes memory ret) = target.call(data);
+        if (!ok) {
+            assembly ("memory-safe") {
+                revert(add(ret, 0x20), mload(ret))
+            }
+        }
+    }
+
+    /// @notice Serialise a Safe Tx Builder JSON bundle from the supplied
+    /// inputs. The shape matches the Safe Tx Builder app's import format so
+    /// the artifact can be loaded directly into the Safe UI for signing.
+    /// @dev Field set:
+    /// - `version`: pinned at `TX_BUILDER_SCHEMA_VERSION` (`"1.0"`).
+    /// - `chainId`: the EVM chain id the bundle is scoped to (as a
+    ///   decimal string — Tx Builder schema uses string-form chain ids).
+    /// - `createdAt`: `block.timestamp` of the producing run (number).
+    /// - `meta.name`: the human-readable bundle name (passed through).
+    /// - `meta.txBuilderVersion`: pinned at `TX_BUILDER_VERSION`.
+    /// - `meta.safeAddress`: echoes `safeAddr` so the bundle records
+    ///   which Safe it was authored against. The Tx Builder UI ignores
+    ///   unknown `meta` fields, so this is a forward-compatible pin.
+    /// - `transactions`: array of per-tx objects `{to, value, data}`.
+    /// `value` is serialised as a decimal string to match the Tx Builder
+    /// schema.
+    ///
+    /// Output is hand-assembled with `string.concat` rather than
+    /// `vm.serializeJson` because the cheatcode emits index-keyed objects
+    /// for arrays, which the Tx Builder schema does not accept.
+    /// @param safeAddr The Safe address the bundle targets. Echoed under
+    /// `meta.safeAddress` so a parsed bundle can be cross-checked against
+    /// the Safe an audit thinks it belongs to.
+    /// @param chainId The chain id the bundle is scoped to.
+    /// @param name The bundle name to embed in `meta.name`.
+    /// @param txs The transactions to serialise.
+    /// @return The serialised JSON string.
+    function emitTxBuilderJson(address safeAddr, uint256 chainId, string memory name, SafeTx[] memory txs)
+        internal
+        view
+        returns (string memory)
+    {
+        string memory transactions = "[";
+        for (uint256 i = 0; i < txs.length; i++) {
+            string memory txJson = string.concat(
+                "{",
+                _jsonField("to", _quote(VM.toString(txs[i].to))),
+                ",",
+                _jsonField("value", _quote(VM.toString(txs[i].value))),
+                ",",
+                _jsonField("data", _quote(VM.toString(txs[i].data))),
+                "}"
+            );
+            transactions = string.concat(transactions, txJson);
+            if (i + 1 < txs.length) {
+                transactions = string.concat(transactions, ",");
+            }
+        }
+        transactions = string.concat(transactions, "]");
+
+        // Embed `safeAddr` under `meta.safeAddress` so the bundle records
+        // the Safe it was authored against. The Tx Builder UI ignores
+        // unknown `meta` fields, so this is a forward-compatible pin.
+        string memory meta = string.concat(
+            "{",
+            _jsonField("name", _quote(name)),
+            ",",
+            _jsonField("txBuilderVersion", _quote(TX_BUILDER_VERSION)),
+            ",",
+            _jsonField("safeAddress", _quote(VM.toString(safeAddr))),
+            "}"
+        );
+
+        return string.concat(
+            "{",
+            _jsonField("version", _quote(TX_BUILDER_SCHEMA_VERSION)),
+            ",",
+            _jsonField("chainId", _quote(VM.toString(chainId))),
+            ",",
+            _jsonField("createdAt", VM.toString(block.timestamp)),
+            ",",
+            _jsonField("meta", meta),
+            ",",
+            _jsonField("transactions", transactions),
+            "}"
+        );
+    }
+
+    /// @notice Parse a Safe Tx Builder JSON file from disk and return the
+    /// chain id, target Safe, and transactions array.
+    /// @dev The Tx Builder JSON's `transactions[*].value` is a decimal
+    /// string and `data` is a `0x`-prefixed hex byte string. The first
+    /// transaction's `to` is reported as the bundle's target Safe address
+    /// because by Tx Builder convention every Safe-self-mutating bundle
+    /// has every tx target the Safe itself; bundles with cross-target
+    /// calls have to inspect the array directly.
+    /// @param jsonPath Filesystem path to the JSON file.
+    /// @return chainId The chain id parsed from the JSON.
+    /// @return safeAddr The Safe address (parsed from `transactions[0].to`).
+    /// @return txs The decoded transactions array.
+    function parseTxBuilderJson(string memory jsonPath)
+        internal
+        view
+        returns (uint256 chainId, address safeAddr, SafeTx[] memory txs)
+    {
+        string memory json = VM.readFile(jsonPath);
+        chainId = _parseDecimalUint(VM.parseJsonString(json, ".chainId"));
+
+        // The Tx Builder schema's `transactions` is an array of objects.
+        // `parseJsonKeys` rejects arrays and `parseJsonAddressArray` with
+        // a wildcard path mis-decodes a single match, so we discover the
+        // array length by probing `.transactions[i]` via `keyExistsJson`
+        // until the index is no longer present. The cap is a defensive
+        // upper bound — RAI-296's migration bundle is single-tx, and the
+        // Tx Builder UI itself imposes a far smaller practical limit.
+        uint256 cap = 256;
+        SafeTx[] memory scratch = new SafeTx[](cap);
+        uint256 count = 0;
+        for (uint256 i = 0; i < cap; i++) {
+            string memory iStr = VM.toString(i);
+            if (!VM.keyExistsJson(json, string.concat(".transactions[", iStr, "].to"))) {
+                break;
+            }
+            address to = VM.parseJsonAddress(json, string.concat(".transactions[", iStr, "].to"));
+            uint256 value =
+                _parseDecimalUint(VM.parseJsonString(json, string.concat(".transactions[", iStr, "].value")));
+            bytes memory data = VM.parseJsonBytes(json, string.concat(".transactions[", iStr, "].data"));
+            scratch[count] = SafeTx({to: to, value: value, data: data, operation: 0});
+            count++;
+        }
+        if (count == 0) {
+            revert TxBuilderJsonNoTransactions();
+        }
+        txs = new SafeTx[](count);
+        for (uint256 i = 0; i < count; i++) {
+            txs[i] = scratch[i];
+        }
+        safeAddr = txs[0].to;
+    }
+
+    /// @notice Parse a decimal-formatted unsigned integer string. The Tx
+    /// Builder schema serialises `chainId` and `value` as decimal strings,
+    /// so this is the inverse of `vm.toString(uint256)`.
+    /// @param decimal The decimal-formatted string. Must contain only
+    /// `0..9` digits; any non-digit reverts with a static message.
+    /// @return The parsed unsigned integer.
+    function _parseDecimalUint(string memory decimal) private pure returns (uint256) {
+        bytes memory raw = bytes(decimal);
+        uint256 result = 0;
+        for (uint256 i = 0; i < raw.length; i++) {
+            uint8 c = uint8(raw[i]);
+            // ASCII digits run `0x30..0x39`.
+            require(c >= 0x30 && c <= 0x39, "LibSafeOps: non-decimal digit");
+            result = result * 10 + (c - 0x30);
+        }
+        return result;
+    }
+
+    /// @notice Helper: emit a JSON `"key": value` field. The value must
+    /// already be a serialised JSON literal (quoted string, number, or
+    /// object); use `_quote` to wrap raw strings.
+    /// @param key The JSON object key.
+    /// @param valueLiteral The serialised JSON value.
+    /// @return The serialised `"key":value` fragment.
+    function _jsonField(string memory key, string memory valueLiteral) private pure returns (string memory) {
+        return string.concat('"', key, '":', valueLiteral);
+    }
+
+    /// @notice Helper: wrap a raw string in JSON-quote delimiters. Does not
+    /// escape inner quotes/control characters — callers in this library
+    /// pass values from `vm.toString` (which never emits a quote) or
+    /// hard-coded literals, so the simpler implementation suffices.
+    /// @param raw The raw string.
+    /// @return The quoted JSON string literal.
+    function _quote(string memory raw) private pure returns (string memory) {
+        return string.concat('"', raw, '"');
+    }
+}

--- a/src/lib/LibSafeOps.sol
+++ b/src/lib/LibSafeOps.sol
@@ -282,6 +282,178 @@ library LibSafeOps {
         return result;
     }
 
+    /// @notice Reversibility / "not stuck" check for a state-changing
+    /// operation. After a script has simulated its forward state change
+    /// (e.g. `changeThreshold(newThreshold)`), this helper proves on the
+    /// same fork that the safe accepts a valid `execTransaction` under the
+    /// new threshold and that the threshold gate correctly rejects
+    /// undersigned attempts. Specifically, builds an inverse follow-up
+    /// transaction (`changeThreshold(oldThreshold)`) and:
+    ///
+    /// 1. Pre-approves the followup hash from `newThreshold` owners via
+    ///    `vm.prank(owner) + safe.approveHash(hash)`. Sorted ascending by
+    ///    signer address to satisfy Safe v1.4.1's `checkSignatures`.
+    /// 2. Calls `execTransaction` with only `newThreshold - 1` packed
+    ///    approved-hash signatures; asserts the call reverts with
+    ///    `"GS020"` (Safe v1.4.1's "Signatures data too short").
+    /// 3. Calls `execTransaction` with all `newThreshold` packed
+    ///    approved-hash signatures; asserts success and that
+    ///    `getThreshold()` is now back at `oldThreshold`.
+    ///
+    /// The check uses pre-approved hashes (`approvedHashes` mapping +
+    /// `v=1` signature type) rather than ECDSA signatures, avoiding the
+    /// need for test private keys or owner-slot overwrites. The real
+    /// `checkSignatures` path is exercised end-to-end; only the source of
+    /// the approval is the cheatcode prank.
+    ///
+    /// Intended to be called from operational scripts as the final post-
+    /// state assertion, so every dry-run proves the new state is not a
+    /// dead-end. Generalises to other critical state changes (e.g.
+    /// authoriser swaps, role grants) by parameterising the inverse op
+    /// in a future variant.
+    ///
+    /// @param safe The Safe whose post-mutation state to exercise.
+    /// @param oldThreshold The threshold the safe should return to after
+    /// the reversal executes. Must match the safe's threshold before the
+    /// forward change.
+    /// @param newThreshold The threshold the safe is currently in. Both
+    /// the number of approvals collected and the number passed in the
+    /// successful `execTransaction` call.
+    function simulateNPlus1Reversal(IGnosisSafe safe, uint256 oldThreshold, uint256 newThreshold) internal {
+        // Construct the inverse calldata: `changeThreshold(oldThreshold)`.
+        // The follow-up is by definition a self-call; the inverse threshold
+        // change is the simplest, most reversible "n+1" transaction we can
+        // model and it carries no side effects other than the threshold
+        // mutation itself.
+        bytes memory revertData = abi.encodeCall(IGnosisSafe.changeThreshold, (oldThreshold));
+        SafeTx memory followup = SafeTx({to: address(safe), value: 0, data: revertData, operation: 0});
+        uint256 followupNonce = safe.nonce();
+        bytes32 followupHash = computeSafeTxHashViaSafe(safe, followup, followupNonce);
+
+        // Collect approvals from `newThreshold` owners. We always take the
+        // first `newThreshold` entries from `getOwners()` — the linked-list
+        // order is deterministic per-Safe so the choice is stable, and
+        // sorting the resulting array by address normalises against the
+        // arbitrary Safe-internal ordering before passing to
+        // `checkSignatures`.
+        address[] memory owners = safe.getOwners();
+        require(owners.length >= newThreshold, "LibSafeOps: not enough owners for n+1");
+        address[] memory approvers = new address[](newThreshold);
+        for (uint256 i = 0; i < newThreshold; i++) {
+            approvers[i] = owners[i];
+            VM.prank(owners[i]);
+            safe.approveHash(followupHash);
+        }
+
+        // Sort ascending by signer address — Safe v1.4.1's `checkSignatures`
+        // requires the packed signature blob to be ordered by signer to
+        // prevent the same signer counting twice.
+        address[] memory sortedSigners = sortAddressesAscending(approvers);
+
+        // Negative case: undersigned call must revert with `GS020`
+        // ("Signatures data too short"). This is what proves the threshold
+        // gate is doing its job — a follow-up tx is not magically waveable
+        // through just because the approvals exist; the packed blob has to
+        // contain at least `threshold` entries.
+        bytes memory tooFewSigs = packApprovedHashSignatures(sortedSigners, newThreshold - 1);
+        VM.expectRevert(bytes("GS020"));
+        // The return value is meaningless under `expectRevert` — the call
+        // must revert with the literal `GS020` reason, and the cheatcode
+        // bubbles a test failure if it does not. Discarding the return is
+        // therefore the correct behaviour.
+        //slither-disable-next-line unused-return
+        safe.execTransaction(
+            followup.to,
+            followup.value,
+            followup.data,
+            followup.operation,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            tooFewSigs
+        );
+
+        // Positive case: full `newThreshold`-many signatures must succeed
+        // and roll the threshold back to `oldThreshold`. The success
+        // assertion plus the threshold check together prove that the new
+        // state is genuinely exitable: the signature path verifies, the
+        // inner call executes, and the safe is back in a state another
+        // forward migration could run against.
+        bytes memory enoughSigs = packApprovedHashSignatures(sortedSigners, newThreshold);
+        bool ok = safe.execTransaction(
+            followup.to,
+            followup.value,
+            followup.data,
+            followup.operation,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            enoughSigs
+        );
+        require(ok, "LibSafeOps: n+1 execTransaction reverted unexpectedly");
+        require(safe.getThreshold() == oldThreshold, "LibSafeOps: n+1 did not restore the prior threshold");
+    }
+
+    /// @notice Insertion-sort an in-memory address array ascending. Used to
+    /// satisfy Safe v1.4.1's requirement that packed signatures are ordered
+    /// by signer address before being passed to `checkSignatures`.
+    /// @dev Insertion sort is O(n^2) but the input is bounded by the Safe
+    /// owner count (single-digit in practice), so the constant factor wins
+    /// over any more elaborate algorithm. The function returns a fresh array
+    /// rather than sorting in place so callers can keep the original-order
+    /// approver list around if they need it.
+    /// @param addrs The unsorted address array.
+    /// @return The same addresses in ascending order, in a freshly-allocated
+    /// array of the same length.
+    function sortAddressesAscending(address[] memory addrs) internal pure returns (address[] memory) {
+        address[] memory sorted = new address[](addrs.length);
+        for (uint256 i = 0; i < addrs.length; i++) {
+            sorted[i] = addrs[i];
+        }
+        for (uint256 i = 1; i < sorted.length; i++) {
+            address current = sorted[i];
+            uint256 j = i;
+            while (j > 0 && sorted[j - 1] > current) {
+                sorted[j] = sorted[j - 1];
+                j--;
+            }
+            sorted[j] = current;
+        }
+        return sorted;
+    }
+
+    /// @notice Pack the first `count` entries of `sortedSigners` into a
+    /// Safe v1.4.1 approved-hash signature bytes blob. Each entry is 65
+    /// bytes laid out as `r || s || v` where `r = bytes32(signerAddress)`
+    /// (left-zero-padded), `s = bytes32(0)`, `v = 0x01`.
+    /// @dev `v = 1` is the Safe v1.4.1 marker for "this hash was previously
+    /// approved by `r` via `approveHash`": `checkSignatures` reads `r` as an
+    /// address and consults the Safe's `approvedHashes[r][hash]` mapping
+    /// instead of doing ECDSA recovery. `sortedSigners` MUST already be in
+    /// ascending order — Safe's own ordering check rejects duplicates by
+    /// requiring strict ascent.
+    /// @param sortedSigners The signer addresses, sorted ascending.
+    /// @param count The number of leading entries to pack. Allows callers
+    /// to pack a deliberately-undersigned blob (for the negative branch of
+    /// `simulateNPlus1Reversal`) without rebuilding the input array.
+    /// @return packed The packed signature bytes, `count * 65` bytes long.
+    function packApprovedHashSignatures(address[] memory sortedSigners, uint256 count)
+        internal
+        pure
+        returns (bytes memory packed)
+    {
+        require(count <= sortedSigners.length, "LibSafeOps: pack count exceeds signers");
+        packed = new bytes(0);
+        for (uint256 i = 0; i < count; i++) {
+            packed =
+                bytes.concat(packed, bytes32(uint256(uint160(sortedSigners[i]))), bytes32(uint256(0)), bytes1(0x01));
+        }
+    }
+
     /// @notice Helper: emit a JSON `"key": value` field. The value must
     /// already be a serialised JSON literal (quoted string, number, or
     /// object); use `_quote` to wrap raw strings.

--- a/test/src/lib/LibSafeOps.t.sol
+++ b/test/src/lib/LibSafeOps.t.sol
@@ -59,7 +59,7 @@ contract LibSafeOpsTest is Test {
         selectBaseFork();
         uint256 nonceBefore = safe.nonce();
         uint256 thresholdBefore = safe.getThreshold();
-        assertEq(thresholdBefore, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_RAI296);
+        assertEq(thresholdBefore, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION);
 
         SafeTx memory txn = _buildThresholdTx();
         LibSafeOps.simulateSelfCall(safe, txn.data);
@@ -90,7 +90,7 @@ contract LibSafeOpsTest is Test {
         SafeTx[] memory txs = new SafeTx[](1);
         txs[0] = txn;
 
-        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, "rai-296-threshold-test", txs);
+        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, "safe-threshold-test", txs);
 
         // Write the emitted JSON through forge's writeFile cheatcode then
         // re-read via parseTxBuilderJson. The on-disk hop ensures we
@@ -119,7 +119,7 @@ contract LibSafeOpsTest is Test {
         SafeTx[] memory txs = new SafeTx[](1);
         txs[0] = _buildThresholdTx();
 
-        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, "rai-296-shape-test", txs);
+        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, "safe-shape-test", txs);
 
         string memory schemaVersion = vm.parseJsonString(json, ".version");
         string memory txBuilderVersion = vm.parseJsonString(json, ".meta.txBuilderVersion");
@@ -134,7 +134,7 @@ contract LibSafeOpsTest is Test {
 
         assertEq(schemaVersion, "1.0", "schema version pin");
         assertEq(txBuilderVersion, "1.16.5", "tx builder version pin");
-        assertEq(bundleName, "rai-296-shape-test", "name pass-through");
+        assertEq(bundleName, "safe-shape-test", "name pass-through");
         assertTrue(hasFirst, "transactions[0] should exist");
         assertFalse(hasSecond, "transactions[1] should not exist");
     }

--- a/test/src/lib/LibSafeOps.t.sol
+++ b/test/src/lib/LibSafeOps.t.sol
@@ -59,7 +59,7 @@ contract LibSafeOpsTest is Test {
         selectBaseFork();
         uint256 nonceBefore = safe.nonce();
         uint256 thresholdBefore = safe.getThreshold();
-        assertEq(thresholdBefore, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION);
+        assertEq(thresholdBefore, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD);
 
         SafeTx memory txn = _buildThresholdTx();
         LibSafeOps.simulateSelfCall(safe, txn.data);

--- a/test/src/lib/LibSafeOps.t.sol
+++ b/test/src/lib/LibSafeOps.t.sol
@@ -6,7 +6,7 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibSafeOps, SafeTx, TxBuilderJsonNoTransactions} from "../../../src/lib/LibSafeOps.sol";
 import {LibProdSafes} from "../../../src/lib/LibProdSafes.sol";
 import {IGnosisSafe} from "../../../src/interface/IGnosisSafe.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 
 /// @title LibSafeOpsTest
 /// @notice Live fork tests for `LibSafeOps`: cross-checks the local hash

--- a/test/src/lib/LibSafeOps.t.sol
+++ b/test/src/lib/LibSafeOps.t.sol
@@ -158,6 +158,134 @@ contract LibSafeOpsTest is Test {
         vm.expectRevert(TxBuilderJsonNoTransactions.selector);
         harness.callParse(path);
     }
+
+    /// @notice `simulateNPlus1Reversal` round-trips the Safe through a
+    /// forward state change (`changeThreshold(3)`) and back. We first
+    /// simulate the forward change via `vm.prank(safe) + changeThreshold(3)`
+    /// — modelling what the migration script does post-`assertAll` — then
+    /// invoke the helper with `(oldThreshold = 1, newThreshold = 3)`. The
+    /// helper's internal `expectRevert(GS020)` exercises the threshold
+    /// gate, and the successful `execTransaction` exercises the real
+    /// signature-verification path end-to-end. Final state must be back at
+    /// the pinned pre-migration threshold.
+    function testSimulateNPlus1ReversalRoundTrip() external {
+        selectBaseFork();
+        uint256 oldThreshold = safe.getThreshold();
+        assertEq(oldThreshold, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD, "pre-state threshold pin");
+
+        // Simulate the forward state change the migration script makes.
+        // After this prank-call the Safe is in the "post-migration" state
+        // the helper is meant to prove is not stuck.
+        uint256 newThreshold = 3;
+        vm.prank(address(safe));
+        safe.changeThreshold(newThreshold);
+        assertEq(safe.getThreshold(), newThreshold, "post-forward-change threshold");
+
+        LibSafeOps.simulateNPlus1Reversal(safe, oldThreshold, newThreshold);
+
+        assertEq(safe.getThreshold(), oldThreshold, "threshold restored by n+1 reversal");
+    }
+
+    /// @notice `simulateNPlus1Reversal` reverts cleanly if the Safe's
+    /// owner count is below `newThreshold`. The require message protects
+    /// against a misuse where the helper is called with a threshold higher
+    /// than the live roster can satisfy, which would otherwise blow up
+    /// deep inside `approveHash`/`execTransaction` with a less-actionable
+    /// error.
+    function testSimulateNPlus1ReversalFailsWithTooFewOwners() external {
+        selectBaseFork();
+        // Mock the live Safe to expose only 2 owners, then ask the helper
+        // for `newThreshold = 3`. The require in `simulateNPlus1Reversal`
+        // should fire before any prank/approve hit the Safe.
+        address[] memory shortRoster = new address[](2);
+        shortRoster[0] = LibProdSafes.STOX_TOKEN_OWNER_SAFE_OWNER_1;
+        shortRoster[1] = LibProdSafes.STOX_TOKEN_OWNER_SAFE_OWNER_2;
+        vm.mockCall(address(safe), abi.encodeWithSelector(IGnosisSafe.getOwners.selector), abi.encode(shortRoster));
+
+        NPlus1Harness harness = new NPlus1Harness();
+        vm.expectRevert(bytes("LibSafeOps: not enough owners for n+1"));
+        harness.callSimulateNPlus1Reversal(safe, 1, 3);
+    }
+
+    /// @notice `packApprovedHashSignatures` lays out 65-byte entries in the
+    /// Safe v1.4.1 approved-hash format: `r = bytes32(address)`,
+    /// `s = bytes32(0)`, `v = 0x01`. For three signers the blob is 195
+    /// bytes; per-entry slices must round-trip back to the input addresses.
+    function testPackApprovedHashSignatures() external pure {
+        address[] memory signers = new address[](3);
+        signers[0] = address(0x0000000000000000000000000000000000000001);
+        signers[1] = address(0x1234567890123456789012345678901234567890);
+        signers[2] = address(0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF);
+
+        bytes memory packed = LibSafeOps.packApprovedHashSignatures(signers, 3);
+        assertEq(packed.length, 3 * 65, "65 bytes per approved-hash entry");
+
+        // Walk the blob: every entry has its r-field at offset i*65, the
+        // s-field zeroed at offset i*65 + 32, and v=0x01 at offset i*65 + 64.
+        for (uint256 i = 0; i < 3; i++) {
+            uint256 entryStart = i * 65;
+            bytes32 rWord;
+            bytes32 sWord;
+            uint8 vByte;
+            for (uint256 b = 0; b < 32; b++) {
+                rWord |= bytes32(uint256(uint8(packed[entryStart + b])) << ((31 - b) * 8));
+                sWord |= bytes32(uint256(uint8(packed[entryStart + 32 + b])) << ((31 - b) * 8));
+            }
+            vByte = uint8(packed[entryStart + 64]);
+            assertEq(address(uint160(uint256(rWord))), signers[i], "r decodes to signer address");
+            assertEq(sWord, bytes32(0), "s is zeroed");
+            assertEq(vByte, uint8(0x01), "v is the approved-hash marker");
+        }
+    }
+
+    /// @notice `packApprovedHashSignatures` truncates the output to `count`
+    /// entries when `count < sortedSigners.length`. Used by the negative
+    /// branch of `simulateNPlus1Reversal` to feed `execTransaction` a
+    /// deliberately-undersigned blob without reallocating the source array.
+    function testPackApprovedHashSignaturesPartialCount() external pure {
+        address[] memory signers = new address[](3);
+        signers[0] = address(0x1);
+        signers[1] = address(0x2);
+        signers[2] = address(0x3);
+
+        bytes memory packed = LibSafeOps.packApprovedHashSignatures(signers, 2);
+        assertEq(packed.length, 2 * 65, "truncated to 2 entries");
+    }
+
+    /// @notice `packApprovedHashSignatures` reverts if asked to pack more
+    /// entries than the input contains. Prevents an out-of-bounds index
+    /// read silently producing a partial blob.
+    function testPackApprovedHashSignaturesRejectsOverflow() external {
+        address[] memory signers = new address[](2);
+        signers[0] = address(0x1);
+        signers[1] = address(0x2);
+
+        PackHarness harness = new PackHarness();
+        vm.expectRevert(bytes("LibSafeOps: pack count exceeds signers"));
+        harness.callPack(signers, 3);
+    }
+
+    /// @notice `sortAddressesAscending` returns a fresh array whose entries
+    /// are the input addresses in strict ascending order. Verified against
+    /// a hand-picked unsorted input (descending, with duplicates would only
+    /// matter if Safe accepted them — which it doesn't — so distinct values
+    /// suffice).
+    function testSortAddressesAscending() external pure {
+        address[] memory input = new address[](4);
+        input[0] = address(0x000000000000000000000000000000000000bEEF);
+        input[1] = address(0x000000000000000000000000000000000000cafE);
+        input[2] = address(0x0000000000000000000000000000000000000001);
+        input[3] = address(0x000000000000000000000000000000000000dEaD);
+
+        address[] memory sorted = LibSafeOps.sortAddressesAscending(input);
+        assertEq(sorted.length, input.length, "length preserved");
+        for (uint256 i = 1; i < sorted.length; i++) {
+            assertTrue(sorted[i - 1] < sorted[i], "strictly ascending");
+        }
+        // Spot-check the smallest and largest entries.
+        assertEq(sorted[0], address(0x0000000000000000000000000000000000000001), "min at index 0");
+        assertEq(sorted[3], address(0x000000000000000000000000000000000000dEaD), "max at last index");
+    }
 }
 
 /// @notice Stub contract used by `testSimulateExternalCallPrankRoutes` to
@@ -181,5 +309,25 @@ contract CallerRecorder {
 contract ParseHarness {
     function callParse(string calldata jsonPath) external view {
         LibSafeOps.parseTxBuilderJson(jsonPath);
+    }
+}
+
+/// @notice External-call harness around `LibSafeOps.simulateNPlus1Reversal`
+/// for cases where the helper itself is expected to revert (e.g. the
+/// "not enough owners" require). `vm.expectRevert` needs the revert to
+/// originate from a deeper call frame than the cheatcode call, which a
+/// direct library invocation from the test does not produce.
+contract NPlus1Harness {
+    function callSimulateNPlus1Reversal(IGnosisSafe safe, uint256 oldThreshold, uint256 newThreshold) external {
+        LibSafeOps.simulateNPlus1Reversal(safe, oldThreshold, newThreshold);
+    }
+}
+
+/// @notice External-call harness around `LibSafeOps.packApprovedHashSignatures`
+/// so the pure-function's overflow `require` can be caught by
+/// `vm.expectRevert`.
+contract PackHarness {
+    function callPack(address[] calldata sortedSigners, uint256 count) external pure returns (bytes memory) {
+        return LibSafeOps.packApprovedHashSignatures(sortedSigners, count);
     }
 }

--- a/test/src/lib/LibSafeOps.t.sol
+++ b/test/src/lib/LibSafeOps.t.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibSafeOps, SafeTx, TxBuilderJsonNoTransactions} from "../../../src/lib/LibSafeOps.sol";
+import {LibProdSafes} from "../../../src/lib/LibProdSafes.sol";
+import {IGnosisSafe} from "../../../src/interface/IGnosisSafe.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+
+/// @title LibSafeOpsTest
+/// @notice Live fork tests for `LibSafeOps`: cross-checks the local hash
+/// helper against the Safe's own `getTransactionHash`, asserts that the
+/// `simulateSelfCall` helper applies the inner call without advancing the
+/// nonce, and round-trips the Safe Tx Builder JSON serialise/parse pair.
+contract LibSafeOpsTest is Test {
+    /// @notice Live Safe handle reset by each test's `selectBaseFork`.
+    IGnosisSafe internal safe;
+
+    /// @notice Selects the Base fork at chain head — deliberately unpinned.
+    /// Mirrors `LibProdSafes.t.sol::selectBaseFork` and
+    /// `StoxProdV2.t.sol::testProdDeployBaseV2`: any drift in the live Safe
+    /// surfaces immediately on the next CI run.
+    function selectBaseFork() internal {
+        vm.createSelectFork(LibRainDeploy.BASE);
+        safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
+    }
+
+    /// @notice Build a single-tx bundle that changes the Safe's threshold
+    /// to `3`. Used by every test that needs a representative `SafeTx`.
+    function _buildThresholdTx() internal view returns (SafeTx memory) {
+        return SafeTx({
+            to: address(safe), value: 0, data: abi.encodeCall(IGnosisSafe.changeThreshold, (uint256(3))), operation: 0
+        });
+    }
+
+    /// @notice `computeSafeTxHashViaSafe` returns the exact same hash the
+    /// live Safe returns when called with the same parameters. This is the
+    /// load-bearing assertion of the helper — if it ever returns a different
+    /// hash than `safe.getTransactionHash` we'd be asking owners to sign a
+    /// hash that doesn't match the on-chain verifier.
+    function testHashMatchesLiveSafe() external {
+        selectBaseFork();
+        SafeTx memory txn = _buildThresholdTx();
+        uint256 nonce = safe.nonce();
+
+        bytes32 helperHash = LibSafeOps.computeSafeTxHashViaSafe(safe, txn, nonce);
+        bytes32 directHash =
+            safe.getTransactionHash(txn.to, txn.value, txn.data, txn.operation, 0, 0, 0, address(0), address(0), nonce);
+
+        assertEq(helperHash, directHash, "hash drift between helper and live Safe");
+    }
+
+    /// @notice `simulateSelfCall` applies the inner call against the
+    /// Safe's storage (threshold flips to 3) but does NOT advance the
+    /// Safe's nonce. The nonce is only advanced by a full `execTransaction`
+    /// path; we want the simulated post-state, not a nonce burn.
+    function testSimulateSelfCallChangesThresholdButNotNonce() external {
+        selectBaseFork();
+        uint256 nonceBefore = safe.nonce();
+        uint256 thresholdBefore = safe.getThreshold();
+        assertEq(thresholdBefore, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_RAI296);
+
+        SafeTx memory txn = _buildThresholdTx();
+        LibSafeOps.simulateSelfCall(safe, txn.data);
+
+        assertEq(safe.getThreshold(), 3, "post-simulation threshold should be 3");
+        assertEq(safe.nonce(), nonceBefore, "nonce must not advance under simulation");
+    }
+
+    /// @notice `simulateExternalCall` prank-routes a call to an arbitrary
+    /// target as if from the Safe. We mock a target that records its
+    /// caller and assert the recorded caller is the Safe.
+    function testSimulateExternalCallPrankRoutes() external {
+        selectBaseFork();
+        CallerRecorder recorder = new CallerRecorder();
+        bytes memory pingData = abi.encodeCall(CallerRecorder.ping, ());
+        LibSafeOps.simulateExternalCall(safe, address(recorder), pingData);
+        assertEq(recorder.lastCaller(), address(safe), "external call must originate from the Safe");
+    }
+
+    /// @notice The JSON round-trip (`emit` then `parse`) yields a
+    /// transactions array structurally identical to the input, with the
+    /// chain id and target Safe preserved. Round-tripping is the load-
+    /// bearing property here because the signers ingest the emitted JSON
+    /// directly via the Tx Builder UI.
+    function testEmitParseRoundtrip() external {
+        selectBaseFork();
+        SafeTx memory txn = _buildThresholdTx();
+        SafeTx[] memory txs = new SafeTx[](1);
+        txs[0] = txn;
+
+        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, "rai-296-threshold-test", txs);
+
+        // Write the emitted JSON through forge's writeFile cheatcode then
+        // re-read via parseTxBuilderJson. The on-disk hop ensures we
+        // exercise the same path the script uses (write-to-artifact +
+        // verify-from-artifact).
+        string memory path = string.concat(vm.projectRoot(), "/out/test-tx-builder.json");
+        vm.writeFile(path, json);
+
+        (uint256 parsedChainId, address parsedSafe, SafeTx[] memory parsedTxs) = LibSafeOps.parseTxBuilderJson(path);
+
+        assertEq(parsedChainId, block.chainid, "chain id should round-trip");
+        assertEq(parsedSafe, address(safe), "target Safe should round-trip");
+        assertEq(parsedTxs.length, txs.length, "tx count should round-trip");
+        assertEq(parsedTxs[0].to, txn.to, "to should round-trip");
+        assertEq(parsedTxs[0].value, txn.value, "value should round-trip");
+        assertEq(parsedTxs[0].data, txn.data, "data should round-trip");
+    }
+
+    /// @notice The emitted JSON shape includes the expected top-level keys
+    /// (`version`, `chainId`, `createdAt`, `meta`, `transactions`) and the
+    /// pinned `meta.txBuilderVersion`. Asserted by re-parsing the JSON
+    /// through forge cheatcodes — this is a fast structural check that
+    /// catches accidental schema regressions before the signer UI does.
+    function testEmittedJsonShape() external {
+        selectBaseFork();
+        SafeTx[] memory txs = new SafeTx[](1);
+        txs[0] = _buildThresholdTx();
+
+        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, "rai-296-shape-test", txs);
+
+        string memory schemaVersion = vm.parseJsonString(json, ".version");
+        string memory txBuilderVersion = vm.parseJsonString(json, ".meta.txBuilderVersion");
+        string memory bundleName = vm.parseJsonString(json, ".meta.name");
+        // The transactions array is an array of objects; forge's wildcard
+        // JSONPath returns the singular matched value for a single-element
+        // array (not a 1-length array), so we probe by index via
+        // `keyExistsJson` to count entries — the same trick the parser
+        // uses.
+        bool hasFirst = vm.keyExistsJson(json, ".transactions[0].to");
+        bool hasSecond = vm.keyExistsJson(json, ".transactions[1].to");
+
+        assertEq(schemaVersion, "1.0", "schema version pin");
+        assertEq(txBuilderVersion, "1.16.5", "tx builder version pin");
+        assertEq(bundleName, "rai-296-shape-test", "name pass-through");
+        assertTrue(hasFirst, "transactions[0] should exist");
+        assertFalse(hasSecond, "transactions[1] should not exist");
+    }
+
+    /// @notice `parseTxBuilderJson` reverts with `TxBuilderJsonNoTransactions`
+    /// when the bundle's `transactions` array is empty. Empty bundles are
+    /// never emitted by `emitTxBuilderJson`, so this is the structural
+    /// minimum invariant for inbound JSON.
+    function testParseRejectsEmptyTransactionsArray() external {
+        selectBaseFork();
+        // Hand-write a minimal-shape Tx Builder JSON with an empty array.
+        string memory empty = string.concat(
+            '{"version":"1.0","chainId":"',
+            vm.toString(block.chainid),
+            '","createdAt":0,"meta":{"name":"empty","txBuilderVersion":"1.16.5"},"transactions":[]}'
+        );
+        string memory path = string.concat(vm.projectRoot(), "/out/test-tx-builder-empty.json");
+        vm.writeFile(path, empty);
+
+        ParseHarness harness = new ParseHarness();
+        vm.expectRevert(TxBuilderJsonNoTransactions.selector);
+        harness.callParse(path);
+    }
+}
+
+/// @notice Stub contract used by `testSimulateExternalCallPrankRoutes` to
+/// capture the caller address of an external call. Kept inline because it
+/// is single-use and trivially small.
+contract CallerRecorder {
+    /// @notice The most recent `msg.sender` to call `ping`.
+    address public lastCaller;
+
+    /// @notice Records the caller address. No return value; the recording
+    /// is the side effect under test.
+    function ping() external {
+        lastCaller = msg.sender;
+    }
+}
+
+/// @notice External-call harness around `LibSafeOps.parseTxBuilderJson` so
+/// `vm.expectRevert` can catch the typed error. `expectRevert` only sees
+/// reverts that bubble from a lower call depth than the cheatcode itself,
+/// and library-internal reverts inline.
+contract ParseHarness {
+    function callParse(string calldata jsonPath) external view {
+        LibSafeOps.parseTxBuilderJson(jsonPath);
+    }
+}


### PR DESCRIPTION
## Summary

Off-chain Safe transaction helpers shared by the threshold migration script and its tests:

- `computeSafeTxHashViaSafe(safe, txn, nonce)` — delegates hashing to the live Safe's own `getTransactionHash` so the produced hash binds to the Safe's declared EIP-712 domain separator. Cross-checked against the Safe's own selector in the tests.
- `simulateSelfCall(safe, data)` / `simulateExternalCall(safe, target, data)` — `vm.prank`-based simulation, no nonce advance (only `execTransaction` advances the nonce in production; we want the simulated post-state, not a nonce burn).
- `emitTxBuilderJson(...)` / `parseTxBuilderJson(path)` — Safe Tx Builder JSON serialise/parse round-trip used to hand the bundle to signers via the Safe UI.
- `simulateNPlus1Reversal(safe, oldThreshold, newThreshold)` — reversibility / "not stuck" check (see below).

JSON is hand-assembled with `string.concat` because the Tx Builder schema requires `transactions` to be a JSON array of objects, which `vm.serializeJson` keyed by index emits as an object instead. `fs_permissions` includes `"out"` so the script and the round-trip tests can read and write artifact JSON.

## simulateNPlus1Reversal

Reversibility check intended to be called from operational scripts as the final post-state assertion. After a script has simulated its forward state change (e.g. `changeThreshold(newThreshold)`), this helper proves on the same fork that the safe accepts a valid `execTransaction` under the new threshold and that the threshold gate correctly rejects undersigned attempts. Specifically, builds an inverse follow-up transaction (`changeThreshold(oldThreshold)`) and:

1. Pre-approves the followup hash from `newThreshold` owners via `vm.prank(owner) + safe.approveHash(hash)`. Sorted ascending by signer address to satisfy Safe v1.4.1's `checkSignatures`.
2. Calls `execTransaction` with only `newThreshold - 1` packed approved-hash signatures; asserts the call reverts with `GS020` (Safe v1.4.1's "Signatures data too short").
3. Calls `execTransaction` with all `newThreshold` packed approved-hash signatures; asserts success and that `getThreshold()` is now back at `oldThreshold`.

The check uses pre-approved hashes (`approvedHashes` mapping + `v=1` signature type) rather than ECDSA signatures, avoiding the need for test private keys or owner-slot overwrites. The real `checkSignatures` path is exercised end-to-end; only the source of the approval is the cheatcode prank. Generalises to other critical state changes (e.g. authoriser swaps, role grants) by parameterising the inverse op in a future variant.

Two internal sub-helpers exposed for direct unit testing:

- `sortAddressesAscending(addrs)` — insertion sort, fresh array out, ascending by signer address (Safe v1.4.1 requirement).
- `packApprovedHashSignatures(sortedSigners, count)` — packs the first `count` entries into the 65-byte-per-signer `r || s || v=0x01` approved-hash blob.

`IGnosisSafe` gains `approveHash` and `execTransaction` selectors.

## Files

- `src/interface/IGnosisSafe.sol` — adds `approveHash` and `execTransaction` selectors.
- `src/lib/LibSafeOps.sol` — the helpers + `SafeTx` struct + `TxBuilderJsonNoTransactions` error.
- `test/src/lib/LibSafeOps.t.sol` — fork tests covering hash parity, simulation effects, JSON round-trip, the empty-array rejection, the n+1 reversal round-trip (forward `changeThreshold(3)` via prank then helper restores to 1), too-few-owners rejection, pack helper layout/partial-count/overflow, and sort helper ascending invariant.

## Stack

- Parent: [#190](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/190) (`feat/lib-safe-invariants`).
- Next: [#193](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/193) (`feat/rai-296-migration-script`) — wires `simulateNPlus1Reversal` into the migration script's final post-state step.

## Test plan

- [x] `forge test --match-path test/src/lib/LibSafeOps.t.sol` — 12/12 passing.
- [x] `rainix-sol-static` — slither 0 findings, fmt clean.
- [x] `rainix-sol-legal` — REUSE compliant.
- [x] Full `rainix-sol-test` — passing (pre-existing ignored failures only).
