### PR TITLE
feat(rai-296): multisig threshold migration script + Tx Builder artifact

### DIFF
--- a/.github/workflows/multisig-artifact.yaml
+++ b/.github/workflows/multisig-artifact.yaml
@@ -1,0 +1,34 @@
+name: multisig-artifact
+on:
+  push:
+    branches:
+      - 'feat/rai-296-*'
+# Builds the RAI-296 Safe Tx Builder JSON artifact via a forge-script
+# dry-run on the active branch's HEAD and uploads `out/*.json` so PR
+# reviewers can download the bundle directly. The dry-run uses the same
+# unpinned Base head fork as the migration script's tests, so any drift
+# in the Safe's owner set, threshold, or vault ownership trips the
+# pre-flight here before a signer ever sees the bundle.
+jobs:
+  build-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: DeterminateSystems/nix-installer-action@v17
+      - name: Build RAI-296 Tx Builder artifact (dry-run)
+        env:
+          BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK }}
+        run: |
+          nix develop --command bash -c '
+            forge script script/MigrateMultisigThreshold.s.sol \
+              --rpc-url base \
+              --no-storage-caching
+          '
+      - name: Upload Tx Builder JSON
+        uses: actions/upload-artifact@v4
+        with:
+          name: rai-296-tx-builder-json
+          path: out/*.json
+          if-no-files-found: error

--- a/.github/workflows/multisig-artifact.yaml
+++ b/.github/workflows/multisig-artifact.yaml
@@ -1,14 +1,25 @@
 name: multisig-artifact
 on:
-  push:
-    branches:
-      - 'feat/rai-296-*'
-# Builds the RAI-296 Safe Tx Builder JSON artifact via a forge-script
-# dry-run on the active branch's HEAD and uploads `out/*.json` so PR
-# reviewers can download the bundle directly. The dry-run uses the same
-# unpinned Base head fork as the migration script's tests, so any drift
-# in the Safe's owner set, threshold, or vault ownership trips the
-# pre-flight here before a signer ever sees the bundle.
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'script/MigrateMultisigThreshold.s.sol'
+      - 'src/lib/LibSafeOps.sol'
+      - 'src/lib/LibSafeInvariants.sol'
+      - 'src/lib/LibTokenOwnership.sol'
+      - 'src/lib/LibProdSafes.sol'
+      - 'src/interface/IGnosisSafe.sol'
+      - '.github/workflows/multisig-artifact.yaml'
+# Builds the Safe Tx Builder JSON for the multisig threshold migration
+# via a forge-script dry-run and uploads `out/*.json` as a build artifact.
+# `workflow_dispatch` lets a maintainer run the job manually from the
+# GitHub UI to produce the bundle for live submission; the `pull_request`
+# trigger (paths-filtered to the migration code and its dependencies)
+# runs the dry-run as a sanity check whenever the migration touches any
+# of those files. Either way, the dry-run uses the same unpinned Base
+# head fork as the migration script's tests, so any drift in the Safe's
+# owner set, threshold, or vault ownership trips the pre-flight here
+# before a signer ever sees the bundle.
 jobs:
   build-artifact:
     runs-on: ubuntu-latest
@@ -19,7 +30,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v17
       - name: Install Soldeer dependencies
         run: nix develop --command forge soldeer install
-      - name: Build RAI-296 Tx Builder artifact (dry-run)
+      - name: Build Tx Builder artifact (dry-run)
         env:
           BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK }}
         run: |
@@ -31,6 +42,6 @@ jobs:
       - name: Upload Tx Builder JSON
         uses: actions/upload-artifact@v4
         with:
-          name: rai-296-tx-builder-json
+          name: safe-threshold-tx-builder-json
           path: out/*.json
           if-no-files-found: error

--- a/.github/workflows/multisig-artifact.yaml
+++ b/.github/workflows/multisig-artifact.yaml
@@ -6,8 +6,8 @@ on:
       - 'script/MigrateMultisigThreshold.s.sol'
       - 'src/lib/LibSafeOps.sol'
       - 'src/lib/LibSafeInvariants.sol'
-      - 'src/lib/LibTokenOwnership.sol'
       - 'src/lib/LibProdSafes.sol'
+      - 'src/lib/LibProdTokensBase.sol'
       - 'src/interface/IGnosisSafe.sol'
       - '.github/workflows/multisig-artifact.yaml'
 # Builds the Safe Tx Builder JSON for the multisig threshold migration
@@ -25,8 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
       - uses: DeterminateSystems/nix-installer-action@v17
       - name: Install Soldeer dependencies
         run: nix develop --command forge soldeer install

--- a/.github/workflows/multisig-artifact.yaml
+++ b/.github/workflows/multisig-artifact.yaml
@@ -17,6 +17,8 @@ jobs:
         with:
           submodules: recursive
       - uses: DeterminateSystems/nix-installer-action@v17
+      - name: Install Soldeer dependencies
+        run: nix develop --command forge soldeer install
       - name: Build RAI-296 Tx Builder artifact (dry-run)
         env:
           BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK }}

--- a/README.md
+++ b/README.md
@@ -96,6 +96,56 @@ is delegatecalled by the vault. Key design choices:
 See `ICorporateActionsV1` NatSpec for the full external API and integrator
 guidance, and `docs/GLOSSARY.md` for domain terms.
 
+## Operational scripts
+
+Scripts under `script/` that produce off-chain artifacts (Safe Tx Builder JSON,
+signer briefs) live alongside the deploy contracts but are run manually rather
+than as part of CI deploys. Each runs a full on-chain pre-flight, simulates the
+post-state, emits the artifact, and logs the canonical hash that signers must
+verify.
+
+### RAI-296 — Safe threshold 1-of-4 → 3-of-4
+
+`script/MigrateMultisigThreshold.s.sol` bumps the `STOX_TOKEN_OWNER_SAFE`
+threshold against the current 4-owner roster. The script's pre-flight asserts
+the pinned Safe v1.4.1 proxy codehash, singleton, version, owner set, threshold
+(`= 1`), absence of modules and guard, and uniform `owner()` across every
+receipt vault returned by `LibTokenOwnership.allReceiptVaults()` (13
+production + 1 legacy NVDA). Only after those pass does it simulate
+`changeThreshold(3)` via `vm.prank` and emit the Tx Builder JSON.
+
+Dry-run and produce the artifact:
+
+```shell
+BASE_RPC_URL=https://base-rpc.publicnode.com \
+  forge script script/MigrateMultisigThreshold.s.sol --rpc-url base
+```
+
+The artifact is written to `out/rai-296-threshold-migration.json` and the
+canonical `SafeTxHash` is logged between explicit
+`==== TX BUILDER
+JSON BEGIN ====` / `==== TX BUILDER JSON END ====` markers so
+it is greppable from CI logs.
+
+Verify an existing artifact against the live Safe (signers should run this
+before signing):
+
+```shell
+BASE_RPC_URL=https://base-rpc.publicnode.com \
+  forge script script/MigrateMultisigThreshold.s.sol \
+  --rpc-url base \
+  --sig 'verify(string)' \
+  out/rai-296-threshold-migration.json
+```
+
+A successful `verify` exits silently. Any pre-flight or artifact- mismatch
+failure surfaces a typed error (`SafeThresholdMismatch`,
+`ReceiptVaultOwnerMismatch`, `VerifyMismatch`, etc.) that pinpoints the drift.
+
+The `multisig-artifact` GitHub workflow runs the dry-run on every push to a
+`feat/rai-296-*` branch and uploads `out/*.json` as a build artifact so
+reviewers can download the bundle directly from the PR.
+
 ## License
 
 LicenseRef-DCL-1.0 (DecentraLicense). REUSE-compliant.

--- a/README.md
+++ b/README.md
@@ -104,15 +104,18 @@ than as part of CI deploys. Each runs a full on-chain pre-flight, simulates the
 post-state, emits the artifact, and logs the canonical hash that signers must
 verify.
 
-### RAI-296 — Safe threshold 1-of-4 → 3-of-4
+### Worked example: the multisig threshold migration
 
 `script/MigrateMultisigThreshold.s.sol` bumps the `STOX_TOKEN_OWNER_SAFE`
-threshold against the current 4-owner roster. The script's pre-flight asserts
-the pinned Safe v1.4.1 proxy codehash, singleton, version, owner set, threshold
-(`= 1`), absence of modules and guard, and uniform `owner()` across every
-receipt vault returned by `LibTokenOwnership.allReceiptVaults()` (13
-production + 1 legacy NVDA). Only after those pass does it simulate
-`changeThreshold(3)` via `vm.prank` and emit the Tx Builder JSON.
+threshold from 1-of-4 to 3-of-4 against the current 4-owner roster. The script's
+pre-flight asserts, in one call into `LibSafeInvariants.assertAllChecks`, the
+pinned Safe v1.4.1 proxy codehash, singleton + bytecode, version, absence of
+modules and guard, fallback handler, uniform `owner()` across every production
+receipt vault returned by `LibTokenOwnership.productionReceiptVaults()` (13
+vaults), the expected owner set, and the expected pre-migration threshold
+(`= 1`). Only after that bundle passes does it simulate `changeThreshold(3)` via
+`vm.prank`, re-run the same bundle against the post-state with the new threshold
+argument, and emit the Tx Builder JSON.
 
 Dry-run and produce the artifact:
 
@@ -121,11 +124,9 @@ BASE_RPC_URL=https://base-rpc.publicnode.com \
   forge script script/MigrateMultisigThreshold.s.sol --rpc-url base
 ```
 
-The artifact is written to `out/rai-296-threshold-migration.json` and the
-canonical `SafeTxHash` is logged between explicit
-`==== TX BUILDER
-JSON BEGIN ====` / `==== TX BUILDER JSON END ====` markers so
-it is greppable from CI logs.
+The artifact is written to `out/safe-threshold-migration.json` and the canonical
+`SafeTxHash` is logged between explicit `==== TX BUILDER JSON BEGIN ====` /
+`==== TX BUILDER JSON END ====` markers so it is greppable from CI logs.
 
 Verify an existing artifact against the live Safe (signers should run this
 before signing):
@@ -135,16 +136,18 @@ BASE_RPC_URL=https://base-rpc.publicnode.com \
   forge script script/MigrateMultisigThreshold.s.sol \
   --rpc-url base \
   --sig 'verify(string)' \
-  out/rai-296-threshold-migration.json
+  out/safe-threshold-migration.json
 ```
 
-A successful `verify` exits silently. Any pre-flight or artifact- mismatch
+A successful `verify` exits silently. Any pre-flight or artifact-mismatch
 failure surfaces a typed error (`SafeThresholdMismatch`,
 `ReceiptVaultOwnerMismatch`, `VerifyMismatch`, etc.) that pinpoints the drift.
 
-The `multisig-artifact` GitHub workflow runs the dry-run on every push to a
-`feat/rai-296-*` branch and uploads `out/*.json` as a build artifact so
-reviewers can download the bundle directly from the PR.
+The `multisig-artifact` GitHub workflow runs the dry-run on `workflow_dispatch`
+(maintainer-triggered, for producing the bundle the signers actually use) and on
+`pull_request` events that touch the migration code or any of its direct
+dependencies, uploading `out/*.json` as a build artifact so reviewers can
+download the bundle directly from the run.
 
 ## License
 

--- a/script/MigrateMultisigThreshold.s.sol
+++ b/script/MigrateMultisigThreshold.s.sol
@@ -120,6 +120,21 @@ contract MigrateMultisigThreshold is Script {
         console2.log("==== TX BUILDER JSON END ====");
         console2.log("SafeTxHash:", vm.toString(safeTxHash));
         console2.log("Nonce:", nonce);
+
+        // n+1 reversibility check: prove the new state is not a dead end.
+        // Builds the inverse `changeThreshold(STOX_TOKEN_OWNER_SAFE_THRESHOLD)`
+        // as a follow-up tx; asserts undersigned attempts revert with
+        // `GS020` and that `TARGET_THRESHOLD`-many sigs successfully roll
+        // the threshold back. Per DevOps convention every critical state
+        // change ships with the proof that it isn't terminal — DM's "ppl
+        // put things in a state that cant be moved out of" framing.
+        //
+        // Sequenced AFTER the JSON emission so the artifact reflects the
+        // forward migration (`changeThreshold(3)`) rather than the
+        // reversal. The reversal exists only as a fork-local simulation;
+        // signers never see it.
+        LibSafeOps.simulateNPlus1Reversal(safe, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD, TARGET_THRESHOLD);
+        console2.log("n+1 reversibility check passed: threshold reverted to", safe.getThreshold());
     }
 
     /// @notice Re-runs the threshold migration pre-flight and asserts that

--- a/script/MigrateMultisigThreshold.s.sol
+++ b/script/MigrateMultisigThreshold.s.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+
+import {IGnosisSafe} from "../src/interface/IGnosisSafe.sol";
+import {LibProdSafes} from "../src/lib/LibProdSafes.sol";
+import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
+import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
+import {LibTokenOwnership} from "../src/lib/LibTokenOwnership.sol";
+
+/// @notice A previously emitted Tx Builder JSON artifact (parsed via
+/// `LibSafeOps.parseTxBuilderJson`) does not match the bundle the live
+/// pre-flight would emit. Surfaces the first field that drifts, so a
+/// signer can pinpoint where the off-chain artifact diverged from the
+/// on-chain state at verification time.
+/// @param field The name of the field that drifted (e.g. `"chainId"`,
+/// `"to"`, `"data"`, `"safeTxHash"`).
+error VerifyMismatch(string field);
+
+/// @notice The verify pre-flight got a non-1 tx count from the artifact.
+/// The RAI-296 migration is a single-tx bundle; a multi-tx artifact at
+/// this path is unambiguous drift rather than a future-proofing exercise.
+/// @param actualCount The number of transactions in the parsed artifact.
+error VerifyExpectedSingleTx(uint256 actualCount);
+
+/// @title MigrateMultisigThreshold
+/// @notice Forge script for RAI-296: bumps the ST0x token-owner Safe's
+/// signature threshold from 1-of-4 to 3-of-4. The script performs an
+/// exhaustive on-chain pre-flight (Safe invariants + owner set +
+/// threshold + uniform vault ownership), simulates the post-state, emits
+/// a Safe Tx Builder JSON artifact to `out/`, and logs the canonical
+/// `SafeTxHash` that owners must sign.
+/// @dev Two entrypoints:
+/// - `run()`: dry-run against the active fork (typically a Base head
+///   fork). Asserts every invariant the live execution will rely on,
+///   simulates the inner call, and writes the Tx Builder artifact.
+/// - `verify(jsonPath)`: re-runs the same pre-flight, parses an existing
+///   artifact, and asserts the parsed artifact matches what the live
+///   pre-flight would emit. Used by signers (or CI) to confirm an
+///   artifact wasn't tampered with between authoring and signing.
+contract MigrateMultisigThreshold is Script {
+    /// @notice Target signature threshold post-RAI-296. Hardcoded literal
+    /// (not derived from any constant) because the migration is a
+    /// one-shot: encoding `3` as `THRESHOLD_PRE + 2` or similar would
+    /// invite the "what if the pre-state changes" failure mode the script
+    /// is meant to surface.
+    uint256 internal constant TARGET_THRESHOLD = 3;
+
+    /// @notice Human-readable name embedded in the emitted Tx Builder
+    /// JSON's `meta.name`. Visible to signers in the Safe Tx Builder UI.
+    string internal constant BUNDLE_NAME = "RAI-296 ST0x Safe threshold 1->3";
+
+    /// @notice Output path (relative to the project root) for the Tx
+    /// Builder JSON artifact. Picked up by the multisig-artifact GH
+    /// workflow so PRs that touch RAI-296 expose the bundle as an
+    /// artifact for review.
+    string internal constant ARTIFACT_PATH = "out/rai-296-threshold-migration.json";
+
+    /// @notice Dry-run the RAI-296 migration: pre-flight every invariant,
+    /// simulate the post-state, emit the Tx Builder JSON artifact, and
+    /// log the canonical SafeTxHash. Does not broadcast anything — the
+    /// inner call is gated behind the Safe's own signature verification
+    /// in production and we explicitly simulate via `vm.prank`.
+    function run() external {
+        IGnosisSafe safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
+        _preFlight(safe);
+
+        // Build the single-tx bundle: a self-call to `changeThreshold(3)`.
+        SafeTx memory txn = SafeTx({
+            to: address(safe),
+            value: 0,
+            data: abi.encodeCall(IGnosisSafe.changeThreshold, (TARGET_THRESHOLD)),
+            operation: 0
+        });
+
+        // Capture the nonce before any simulation. `simulateSelfCall`
+        // doesn't advance the nonce, so the hash binds correctly to the
+        // current Safe state.
+        uint256 nonce = safe.nonce();
+        bytes32 safeTxHash = LibSafeOps.computeSafeTxHashViaSafe(safe, txn, nonce);
+
+        // Simulate the inner call and re-assert post-state. This is the
+        // load-bearing dry-run: if anything about the Safe rejects the
+        // changeThreshold(3) call in production, it would also reject it
+        // here (modulo the signature check, which `vm.prank` bypasses).
+        LibSafeOps.simulateSelfCall(safe, txn.data);
+        _postState(safe);
+
+        // Emit the Tx Builder JSON artifact and write it under `out/`.
+        SafeTx[] memory txs = new SafeTx[](1);
+        txs[0] = txn;
+        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, BUNDLE_NAME, txs);
+        vm.writeFile(ARTIFACT_PATH, json);
+
+        // Log the artifact with explicit BEGIN/END markers so CI can
+        // grep the bundle from the run log even when the JSON has been
+        // pretty-printed by an intermediate tool.
+        console2.log("==== TX BUILDER JSON BEGIN ====");
+        console2.log(json);
+        console2.log("==== TX BUILDER JSON END ====");
+        console2.log("SafeTxHash:", vm.toString(safeTxHash));
+        console2.log("Nonce:", nonce);
+    }
+
+    /// @notice Re-runs the RAI-296 pre-flight and asserts that a
+    /// pre-emitted Tx Builder JSON at `jsonPath` matches what the live
+    /// pre-flight would emit. Used by signers to confirm an artifact's
+    /// integrity before signing.
+    /// @param jsonPath Filesystem path to the Tx Builder JSON to verify.
+    function verify(string calldata jsonPath) external view {
+        IGnosisSafe safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
+        _preFlight(safe);
+
+        (uint256 parsedChainId, address parsedSafe, SafeTx[] memory parsedTxs) = LibSafeOps.parseTxBuilderJson(jsonPath);
+
+        if (parsedChainId != block.chainid) revert VerifyMismatch("chainId");
+        if (parsedSafe != address(safe)) revert VerifyMismatch("safeAddress");
+        if (parsedTxs.length != 1) revert VerifyExpectedSingleTx(parsedTxs.length);
+
+        SafeTx memory expected = SafeTx({
+            to: address(safe),
+            value: 0,
+            data: abi.encodeCall(IGnosisSafe.changeThreshold, (TARGET_THRESHOLD)),
+            operation: 0
+        });
+
+        if (parsedTxs[0].to != expected.to) revert VerifyMismatch("to");
+        if (parsedTxs[0].value != expected.value) revert VerifyMismatch("value");
+        if (keccak256(parsedTxs[0].data) != keccak256(expected.data)) revert VerifyMismatch("data");
+
+        // Cross-check the artifact's implied SafeTxHash against the live
+        // Safe's hash builder using the current on-chain nonce. Drift here
+        // is the strongest signal that the artifact is stale: a nonce bump
+        // (some other Safe tx executed in between) will cause this to
+        // flag, which is the desired safety property.
+        bytes32 liveHash = LibSafeOps.computeSafeTxHashViaSafe(safe, expected, safe.nonce());
+        bytes32 artifactHash = LibSafeOps.computeSafeTxHashViaSafe(safe, parsedTxs[0], safe.nonce());
+        if (liveHash != artifactHash) revert VerifyMismatch("safeTxHash");
+    }
+
+    /// @notice Run the full pre-flight: Safe structural invariants, the
+    /// pinned 4-owner roster, the pre-RAI-296 threshold of 1, and uniform
+    /// vault ownership. Reverts with the relevant typed error from the
+    /// underlying library on first mismatch.
+    /// @param safe The Safe to validate.
+    function _preFlight(IGnosisSafe safe) internal view {
+        LibSafeInvariants.assertBaseSafeInvariants(safe);
+        LibSafeInvariants.assertOwnerSet(safe, LibProdSafes.expectedOwners());
+        LibSafeInvariants.assertThreshold(safe, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_RAI296);
+        LibTokenOwnership.assertUniformOwnership(address(safe));
+    }
+
+    /// @notice Assert the post-simulation state: threshold is now
+    /// `TARGET_THRESHOLD`, owners are unchanged, and the base Safe
+    /// invariants still hold (codehash, singleton, version, modules,
+    /// guard, fallback handler). The owner-set re-check guards against a
+    /// `changeThreshold` implementation that secretly mutates the owner
+    /// roster as a side effect.
+    /// @param safe The Safe to validate post-simulation.
+    function _postState(IGnosisSafe safe) internal view {
+        LibSafeInvariants.assertThreshold(safe, TARGET_THRESHOLD);
+        LibSafeInvariants.assertOwnerSet(safe, LibProdSafes.expectedOwners());
+        LibSafeInvariants.assertBaseSafeInvariants(safe);
+    }
+}

--- a/script/MigrateMultisigThreshold.s.sol
+++ b/script/MigrateMultisigThreshold.s.sol
@@ -9,7 +9,6 @@ import {IGnosisSafe} from "../src/interface/IGnosisSafe.sol";
 import {LibProdSafes} from "../src/lib/LibProdSafes.sol";
 import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
 import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
-import {LibTokenOwnership} from "../src/lib/LibTokenOwnership.sol";
 
 /// @notice A previously emitted Tx Builder JSON artifact (parsed via
 /// `LibSafeOps.parseTxBuilderJson`) does not match the bundle the live
@@ -21,18 +20,20 @@ import {LibTokenOwnership} from "../src/lib/LibTokenOwnership.sol";
 error VerifyMismatch(string field);
 
 /// @notice The verify pre-flight got a non-1 tx count from the artifact.
-/// The RAI-296 migration is a single-tx bundle; a multi-tx artifact at
+/// The threshold migration is a single-tx bundle; a multi-tx artifact at
 /// this path is unambiguous drift rather than a future-proofing exercise.
 /// @param actualCount The number of transactions in the parsed artifact.
 error VerifyExpectedSingleTx(uint256 actualCount);
 
 /// @title MigrateMultisigThreshold
-/// @notice Forge script for RAI-296: bumps the ST0x token-owner Safe's
-/// signature threshold from 1-of-4 to 3-of-4. The script performs an
-/// exhaustive on-chain pre-flight (Safe invariants + owner set +
-/// threshold + uniform vault ownership), simulates the post-state, emits
-/// a Safe Tx Builder JSON artifact to `out/`, and logs the canonical
-/// `SafeTxHash` that owners must sign.
+/// @notice Forge script that authors the ST0x token-owner Safe's
+/// multisig threshold migration (1-of-4 -> 3-of-4). Performs an
+/// exhaustive on-chain pre-flight via `LibSafeInvariants.assertAllChecks`
+/// (proxy codehash, singleton + bytecode, version, modules, guard,
+/// fallback handler, uniform vault ownership, expected owner set,
+/// expected threshold), simulates the post-state, emits a Safe Tx
+/// Builder JSON artifact to `out/`, and logs the canonical `SafeTxHash`
+/// that owners must sign.
 /// @dev Two entrypoints:
 /// - `run()`: dry-run against the active fork (typically a Base head
 ///   fork). Asserts every invariant the live execution will rely on,
@@ -42,7 +43,7 @@ error VerifyExpectedSingleTx(uint256 actualCount);
 ///   pre-flight would emit. Used by signers (or CI) to confirm an
 ///   artifact wasn't tampered with between authoring and signing.
 contract MigrateMultisigThreshold is Script {
-    /// @notice Target signature threshold post-RAI-296. Hardcoded literal
+    /// @notice Target signature threshold post-migration. Hardcoded literal
     /// (not derived from any constant) because the migration is a
     /// one-shot: encoding `3` as `THRESHOLD_PRE + 2` or similar would
     /// invite the "what if the pre-state changes" failure mode the script
@@ -51,22 +52,29 @@ contract MigrateMultisigThreshold is Script {
 
     /// @notice Human-readable name embedded in the emitted Tx Builder
     /// JSON's `meta.name`. Visible to signers in the Safe Tx Builder UI.
-    string internal constant BUNDLE_NAME = "RAI-296 ST0x Safe threshold 1->3";
+    string internal constant BUNDLE_NAME = "ST0x Safe threshold 1->3";
 
     /// @notice Output path (relative to the project root) for the Tx
     /// Builder JSON artifact. Picked up by the multisig-artifact GH
-    /// workflow so PRs that touch RAI-296 expose the bundle as an
-    /// artifact for review.
-    string internal constant ARTIFACT_PATH = "out/rai-296-threshold-migration.json";
+    /// workflow so PRs that touch the migration code expose the bundle
+    /// as an artifact for review.
+    string internal constant ARTIFACT_PATH = "out/safe-threshold-migration.json";
 
-    /// @notice Dry-run the RAI-296 migration: pre-flight every invariant,
-    /// simulate the post-state, emit the Tx Builder JSON artifact, and
-    /// log the canonical SafeTxHash. Does not broadcast anything — the
-    /// inner call is gated behind the Safe's own signature verification
-    /// in production and we explicitly simulate via `vm.prank`.
+    /// @notice Dry-run the threshold migration: pre-flight every invariant
+    /// via `assertAllChecks`, simulate the post-state, emit the Tx Builder
+    /// JSON artifact, and log the canonical SafeTxHash. Does not broadcast
+    /// anything — the inner call is gated behind the Safe's own signature
+    /// verification in production and we explicitly simulate via
+    /// `vm.prank`.
     function run() external {
         IGnosisSafe safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
-        _preFlight(safe);
+        // Pre-flight: every immutable invariant plus the pinned 4-owner
+        // roster plus the pre-migration threshold of 1. Reverts with the
+        // relevant typed error from the underlying library on first
+        // mismatch.
+        LibSafeInvariants.assertAllChecks(
+            safe, LibProdSafes.expectedOwners(), LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION
+        );
 
         // Build the single-tx bundle: a self-call to `changeThreshold(3)`.
         SafeTx memory txn = SafeTx({
@@ -82,12 +90,16 @@ contract MigrateMultisigThreshold is Script {
         uint256 nonce = safe.nonce();
         bytes32 safeTxHash = LibSafeOps.computeSafeTxHashViaSafe(safe, txn, nonce);
 
-        // Simulate the inner call and re-assert post-state. This is the
-        // load-bearing dry-run: if anything about the Safe rejects the
+        // Simulate the inner call and re-assert post-state via the same
+        // bundle the pre-flight uses, only differing on the expected
+        // threshold argument. If anything about the Safe rejects the
         // changeThreshold(3) call in production, it would also reject it
         // here (modulo the signature check, which `vm.prank` bypasses).
+        // The bundle re-check guards against a `changeThreshold`
+        // implementation that secretly mutates the owner roster, modules,
+        // or fallback handler as a side effect.
         LibSafeOps.simulateSelfCall(safe, txn.data);
-        _postState(safe);
+        LibSafeInvariants.assertAllChecks(safe, LibProdSafes.expectedOwners(), TARGET_THRESHOLD);
 
         // Emit the Tx Builder JSON artifact and write it under `out/`.
         SafeTx[] memory txs = new SafeTx[](1);
@@ -105,14 +117,19 @@ contract MigrateMultisigThreshold is Script {
         console2.log("Nonce:", nonce);
     }
 
-    /// @notice Re-runs the RAI-296 pre-flight and asserts that a
-    /// pre-emitted Tx Builder JSON at `jsonPath` matches what the live
+    /// @notice Re-runs the threshold migration pre-flight and asserts that
+    /// a pre-emitted Tx Builder JSON at `jsonPath` matches what the live
     /// pre-flight would emit. Used by signers to confirm an artifact's
     /// integrity before signing.
     /// @param jsonPath Filesystem path to the Tx Builder JSON to verify.
     function verify(string calldata jsonPath) external view {
         IGnosisSafe safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
-        _preFlight(safe);
+        // Same pre-flight bundle as `run()`. If the live state has drifted
+        // since the artifact was authored, the typed error bubbles before
+        // we even open the file.
+        LibSafeInvariants.assertAllChecks(
+            safe, LibProdSafes.expectedOwners(), LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION
+        );
 
         (uint256 parsedChainId, address parsedSafe, SafeTx[] memory parsedTxs) = LibSafeOps.parseTxBuilderJson(jsonPath);
 
@@ -139,30 +156,5 @@ contract MigrateMultisigThreshold is Script {
         bytes32 liveHash = LibSafeOps.computeSafeTxHashViaSafe(safe, expected, safe.nonce());
         bytes32 artifactHash = LibSafeOps.computeSafeTxHashViaSafe(safe, parsedTxs[0], safe.nonce());
         if (liveHash != artifactHash) revert VerifyMismatch("safeTxHash");
-    }
-
-    /// @notice Run the full pre-flight: Safe structural invariants, the
-    /// pinned 4-owner roster, the pre-RAI-296 threshold of 1, and uniform
-    /// vault ownership. Reverts with the relevant typed error from the
-    /// underlying library on first mismatch.
-    /// @param safe The Safe to validate.
-    function _preFlight(IGnosisSafe safe) internal view {
-        LibSafeInvariants.assertBaseSafeInvariants(safe);
-        LibSafeInvariants.assertOwnerSet(safe, LibProdSafes.expectedOwners());
-        LibSafeInvariants.assertThreshold(safe, LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_RAI296);
-        LibTokenOwnership.assertUniformOwnership(address(safe));
-    }
-
-    /// @notice Assert the post-simulation state: threshold is now
-    /// `TARGET_THRESHOLD`, owners are unchanged, and the base Safe
-    /// invariants still hold (codehash, singleton, version, modules,
-    /// guard, fallback handler). The owner-set re-check guards against a
-    /// `changeThreshold` implementation that secretly mutates the owner
-    /// roster as a side effect.
-    /// @param safe The Safe to validate post-simulation.
-    function _postState(IGnosisSafe safe) internal view {
-        LibSafeInvariants.assertThreshold(safe, TARGET_THRESHOLD);
-        LibSafeInvariants.assertOwnerSet(safe, LibProdSafes.expectedOwners());
-        LibSafeInvariants.assertBaseSafeInvariants(safe);
     }
 }

--- a/script/MigrateMultisigThreshold.s.sol
+++ b/script/MigrateMultisigThreshold.s.sol
@@ -28,7 +28,7 @@ error VerifyExpectedSingleTx(uint256 actualCount);
 /// @title MigrateMultisigThreshold
 /// @notice Forge script that authors the ST0x token-owner Safe's
 /// multisig threshold migration (1-of-4 -> 3-of-4). Performs an
-/// exhaustive on-chain pre-flight via `LibSafeInvariants.assertAllChecks`
+/// exhaustive on-chain pre-flight via `LibSafeInvariants.assertAll`
 /// (proxy codehash, singleton + bytecode, version, modules, guard,
 /// fallback handler, uniform vault ownership, expected owner set,
 /// expected threshold), simulates the post-state, emits a Safe Tx
@@ -42,6 +42,12 @@ error VerifyExpectedSingleTx(uint256 actualCount);
 ///   artifact, and asserts the parsed artifact matches what the live
 ///   pre-flight would emit. Used by signers (or CI) to confirm an
 ///   artifact wasn't tampered with between authoring and signing.
+///
+/// Pre-flight uses the no-arg `assertAll(safe)` overload, which defaults
+/// the expected threshold and owner set to the `LibProdSafes`-pinned
+/// current truth. Post-state uses the full-args overload to override
+/// the threshold with the deliberately-changed `TARGET_THRESHOLD`
+/// while keeping the owner set pinned.
 contract MigrateMultisigThreshold is Script {
     /// @notice Target signature threshold post-migration. Hardcoded literal
     /// (not derived from any constant) because the migration is a
@@ -61,7 +67,7 @@ contract MigrateMultisigThreshold is Script {
     string internal constant ARTIFACT_PATH = "out/safe-threshold-migration.json";
 
     /// @notice Dry-run the threshold migration: pre-flight every invariant
-    /// via `assertAllChecks`, simulate the post-state, emit the Tx Builder
+    /// via `assertAll`, simulate the post-state, emit the Tx Builder
     /// JSON artifact, and log the canonical SafeTxHash. Does not broadcast
     /// anything — the inner call is gated behind the Safe's own signature
     /// verification in production and we explicitly simulate via
@@ -69,12 +75,10 @@ contract MigrateMultisigThreshold is Script {
     function run() external {
         IGnosisSafe safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
         // Pre-flight: every immutable invariant plus the pinned 4-owner
-        // roster plus the pre-migration threshold of 1. Reverts with the
-        // relevant typed error from the underlying library on first
-        // mismatch.
-        LibSafeInvariants.assertAllChecks(
-            safe, LibProdSafes.expectedOwners(), LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION
-        );
+        // roster plus the pinned current threshold. Defaults from
+        // `LibProdSafes` (no-arg overload). Reverts with the relevant
+        // typed error from the underlying library on first mismatch.
+        LibSafeInvariants.assertAll(safe);
 
         // Build the single-tx bundle: a self-call to `changeThreshold(3)`.
         SafeTx memory txn = SafeTx({
@@ -90,16 +94,17 @@ contract MigrateMultisigThreshold is Script {
         uint256 nonce = safe.nonce();
         bytes32 safeTxHash = LibSafeOps.computeSafeTxHashViaSafe(safe, txn, nonce);
 
-        // Simulate the inner call and re-assert post-state via the same
-        // bundle the pre-flight uses, only differing on the expected
-        // threshold argument. If anything about the Safe rejects the
+        // Simulate the inner call and re-assert post-state via the
+        // full-args bundle. Overrides only the threshold (the
+        // deliberately-changed value) while keeping the owner set on its
+        // pinned current truth. If anything about the Safe rejects the
         // changeThreshold(3) call in production, it would also reject it
         // here (modulo the signature check, which `vm.prank` bypasses).
         // The bundle re-check guards against a `changeThreshold`
         // implementation that secretly mutates the owner roster, modules,
         // or fallback handler as a side effect.
         LibSafeOps.simulateSelfCall(safe, txn.data);
-        LibSafeInvariants.assertAllChecks(safe, LibProdSafes.expectedOwners(), TARGET_THRESHOLD);
+        LibSafeInvariants.assertAll(safe, TARGET_THRESHOLD, LibProdSafes.expectedOwners());
 
         // Emit the Tx Builder JSON artifact and write it under `out/`.
         SafeTx[] memory txs = new SafeTx[](1);
@@ -127,9 +132,7 @@ contract MigrateMultisigThreshold is Script {
         // Same pre-flight bundle as `run()`. If the live state has drifted
         // since the artifact was authored, the typed error bubbles before
         // we even open the file.
-        LibSafeInvariants.assertAllChecks(
-            safe, LibProdSafes.expectedOwners(), LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD_PRE_MIGRATION
-        );
+        LibSafeInvariants.assertAll(safe);
 
         (uint256 parsedChainId, address parsedSafe, SafeTx[] memory parsedTxs) = LibSafeOps.parseTxBuilderJson(jsonPath);
 

--- a/test/script/MigrateMultisigThresholdTest.t.sol
+++ b/test/script/MigrateMultisigThresholdTest.t.sol
@@ -16,10 +16,10 @@ import {LibTokenOwnership, IOwnable, ReceiptVaultOwnerMismatch} from "../../src/
 import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
 
 /// @title MigrateMultisigThresholdTest
-/// @notice End-to-end fork tests for the RAI-296 migration script.
-/// Covers the happy-path `run()` dry-run, inverted preconditions (each
-/// pre-flight invariant is exercised by mocking a single drift in
-/// isolation), and the `run()` → `verify()` chain (i.e. `verify` accepts
+/// @notice End-to-end fork tests for the multisig threshold migration
+/// script. Covers the happy-path `run()` dry-run, inverted preconditions
+/// (each pre-flight invariant is exercised by mocking a single drift in
+/// isolation), and the `run()` -> `verify()` chain (i.e. `verify` accepts
 /// what `run` emits).
 contract MigrateMultisigThresholdTest is Test {
     /// @notice The script under test, deployed fresh per fork.
@@ -45,12 +45,12 @@ contract MigrateMultisigThresholdTest is Test {
 
         // The artifact path the script writes to is project-relative,
         // resolved against `vm.projectRoot()`.
-        string memory artifactPath = string.concat(vm.projectRoot(), "/out/rai-296-threshold-migration.json");
+        string memory artifactPath = string.concat(vm.projectRoot(), "/out/safe-threshold-migration.json");
         string memory json = vm.readFile(artifactPath);
 
         // Smoke-check the JSON shape.
         string memory bundleName = vm.parseJsonString(json, ".meta.name");
-        assertEq(bundleName, "RAI-296 ST0x Safe threshold 1->3", "meta.name pinned");
+        assertEq(bundleName, "ST0x Safe threshold 1->3", "meta.name pinned");
         bool hasFirstTx = vm.keyExistsJson(json, ".transactions[0].to");
         bool hasSecondTx = vm.keyExistsJson(json, ".transactions[1].to");
         assertTrue(hasFirstTx, "first transaction present");
@@ -69,7 +69,7 @@ contract MigrateMultisigThresholdTest is Test {
         // the same pre-migration threshold it would see in production.
         uint256 snapshot = vm.snapshotState();
         script.run();
-        string memory artifactPath = string.concat(vm.projectRoot(), "/out/rai-296-threshold-migration.json");
+        string memory artifactPath = string.concat(vm.projectRoot(), "/out/safe-threshold-migration.json");
         vm.revertToState(snapshot);
         script.verify(artifactPath);
     }
@@ -118,8 +118,9 @@ contract MigrateMultisigThresholdTest is Test {
         txs[0] = txn;
         // Emit a bundle that claims to be for a different chain id by
         // bypassing the live `block.chainid` and passing `block.chainid + 1`.
-        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid + 1, "rai-296-wrong-chain", txs);
-        string memory path = string.concat(vm.projectRoot(), "/out/rai-296-verify-wrong-chain.json");
+        string memory json =
+            LibSafeOps.emitTxBuilderJson(address(safe), block.chainid + 1, "safe-verify-wrong-chain", txs);
+        string memory path = string.concat(vm.projectRoot(), "/out/safe-verify-wrong-chain.json");
         vm.writeFile(path, json);
 
         vm.expectRevert(abi.encodeWithSelector(VerifyMismatch.selector, "chainId"));
@@ -136,8 +137,8 @@ contract MigrateMultisigThresholdTest is Test {
         });
         SafeTx[] memory txs = new SafeTx[](1);
         txs[0] = txn;
-        string memory json = LibSafeOps.emitTxBuilderJson(impostor, block.chainid, "rai-296-wrong-safe", txs);
-        string memory path = string.concat(vm.projectRoot(), "/out/rai-296-verify-wrong-safe.json");
+        string memory json = LibSafeOps.emitTxBuilderJson(impostor, block.chainid, "safe-verify-wrong-safe", txs);
+        string memory path = string.concat(vm.projectRoot(), "/out/safe-verify-wrong-safe.json");
         vm.writeFile(path, json);
 
         vm.expectRevert(abi.encodeWithSelector(VerifyMismatch.selector, "safeAddress"));
@@ -153,8 +154,9 @@ contract MigrateMultisigThresholdTest is Test {
         });
         SafeTx[] memory txs = new SafeTx[](1);
         txs[0] = txn;
-        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, "rai-296-wrong-threshold", txs);
-        string memory path = string.concat(vm.projectRoot(), "/out/rai-296-verify-wrong-threshold.json");
+        string memory json =
+            LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, "safe-verify-wrong-threshold", txs);
+        string memory path = string.concat(vm.projectRoot(), "/out/safe-verify-wrong-threshold.json");
         vm.writeFile(path, json);
 
         vm.expectRevert(abi.encodeWithSelector(VerifyMismatch.selector, "data"));

--- a/test/script/MigrateMultisigThresholdTest.t.sol
+++ b/test/script/MigrateMultisigThresholdTest.t.sol
@@ -44,7 +44,10 @@ contract MigrateMultisigThresholdTest is Test {
 
     /// @notice `run()` dry-run completes against the live pre-state,
     /// writes the artifact, and the artifact has the expected single-tx
-    /// shape.
+    /// shape. The final fork state must show the threshold back at the
+    /// pinned pre-migration value — this is the n+1 reversibility check's
+    /// observable side effect: the script ends with the safe rolled back,
+    /// proving the new state is exitable.
     function testRunCompletesAndWritesArtifact() external {
         selectBaseFork();
         script.run();
@@ -61,6 +64,18 @@ contract MigrateMultisigThresholdTest is Test {
         bool hasSecondTx = vm.keyExistsJson(json, ".transactions[1].to");
         assertTrue(hasFirstTx, "first transaction present");
         assertFalse(hasSecondTx, "exactly one transaction emitted");
+
+        // After `run()` the n+1 reversibility check has rolled the
+        // threshold back to its pre-migration value. Asserting the final
+        // fork state matches the pinned pre-migration threshold is the
+        // observable evidence that the reversal path executed
+        // successfully — without it we'd be relying solely on the absence
+        // of an internal revert.
+        assertEq(
+            safe.getThreshold(),
+            LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD,
+            "n+1 reversibility check rolled threshold back to pre-migration value"
+        );
     }
 
     /// @notice `verify()` accepts the artifact emitted by `run()`. This

--- a/test/script/MigrateMultisigThresholdTest.t.sol
+++ b/test/script/MigrateMultisigThresholdTest.t.sol
@@ -11,8 +11,13 @@ import {
 import {IGnosisSafe} from "../../src/interface/IGnosisSafe.sol";
 import {LibProdSafes} from "../../src/lib/LibProdSafes.sol";
 import {LibSafeOps, SafeTx} from "../../src/lib/LibSafeOps.sol";
-import {LibSafeInvariants, SafeThresholdMismatch} from "../../src/lib/LibSafeInvariants.sol";
-import {LibTokenOwnership, IOwnable, ReceiptVaultOwnerMismatch} from "../../src/lib/LibTokenOwnership.sol";
+import {
+    LibSafeInvariants,
+    IOwnable,
+    SafeThresholdMismatch,
+    ReceiptVaultOwnerMismatch
+} from "../../src/lib/LibSafeInvariants.sol";
+import {LibProdTokensBase} from "../../src/lib/LibProdTokensBase.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
 
 /// @title MigrateMultisigThresholdTest
@@ -29,7 +34,8 @@ contract MigrateMultisigThresholdTest is Test {
     IGnosisSafe internal safe;
 
     /// @notice Selects the Base fork at chain head — deliberately
-    /// unpinned. Same precedent as `LibProdSafes.t.sol::selectBaseFork`.
+    /// unpinned. Same precedent as
+    /// `StoxProdV2.t.sol::testProdDeployBaseV2`.
     function selectBaseFork() internal {
         vm.createSelectFork(LibRainDeploy.BASE);
         script = new MigrateMultisigThreshold();
@@ -66,7 +72,7 @@ contract MigrateMultisigThresholdTest is Test {
         // `run()` simulates the inner call via `vm.prank`, which mutates
         // the Safe's threshold on the active fork. Snapshot first so we
         // can roll the fork back to the pre-run state and `verify()` sees
-        // the same pre-migration threshold it would see in production.
+        // the same pinned current threshold it would see in production.
         uint256 snapshot = vm.snapshotState();
         script.run();
         string memory artifactPath = string.concat(vm.projectRoot(), "/out/safe-threshold-migration.json");
@@ -96,7 +102,10 @@ contract MigrateMultisigThresholdTest is Test {
     function testRunRejectsVaultOwnershipDrift() external {
         selectBaseFork();
         address rogueOwner = address(0xBADC0DE);
-        address victim = LibTokenOwnership.ST0X_RECEIPT_VAULT_NVDA;
+        // Victim address sourced from `LibProdTokensBase` — the canonical
+        // list of production receipt vaults. Any vault from the list
+        // would do; MSTR is the first entry.
+        address victim = LibProdTokensBase.MSTR_RECEIPT_VAULT;
         vm.mockCall(victim, abi.encodeWithSelector(IOwnable.owner.selector), abi.encode(rogueOwner));
 
         vm.expectRevert(abi.encodeWithSelector(ReceiptVaultOwnerMismatch.selector, victim, address(safe), rogueOwner));

--- a/test/script/MigrateMultisigThresholdTest.t.sol
+++ b/test/script/MigrateMultisigThresholdTest.t.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {
+    MigrateMultisigThreshold,
+    VerifyMismatch,
+    VerifyExpectedSingleTx
+} from "../../script/MigrateMultisigThreshold.s.sol";
+import {IGnosisSafe} from "../../src/interface/IGnosisSafe.sol";
+import {LibProdSafes} from "../../src/lib/LibProdSafes.sol";
+import {LibSafeOps, SafeTx} from "../../src/lib/LibSafeOps.sol";
+import {LibSafeInvariants, SafeThresholdMismatch} from "../../src/lib/LibSafeInvariants.sol";
+import {LibTokenOwnership, IOwnable, ReceiptVaultOwnerMismatch} from "../../src/lib/LibTokenOwnership.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+
+/// @title MigrateMultisigThresholdTest
+/// @notice End-to-end fork tests for the RAI-296 migration script.
+/// Covers the happy-path `run()` dry-run, inverted preconditions (each
+/// pre-flight invariant is exercised by mocking a single drift in
+/// isolation), and the `run()` → `verify()` chain (i.e. `verify` accepts
+/// what `run` emits).
+contract MigrateMultisigThresholdTest is Test {
+    /// @notice The script under test, deployed fresh per fork.
+    MigrateMultisigThreshold internal script;
+
+    /// @notice Live Safe handle.
+    IGnosisSafe internal safe;
+
+    /// @notice Selects the Base fork at chain head — deliberately
+    /// unpinned. Same precedent as `LibProdSafes.t.sol::selectBaseFork`.
+    function selectBaseFork() internal {
+        vm.createSelectFork(LibRainDeploy.BASE);
+        script = new MigrateMultisigThreshold();
+        safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
+    }
+
+    /// @notice `run()` dry-run completes against the live pre-state,
+    /// writes the artifact, and the artifact has the expected single-tx
+    /// shape.
+    function testRunCompletesAndWritesArtifact() external {
+        selectBaseFork();
+        script.run();
+
+        // The artifact path the script writes to is project-relative,
+        // resolved against `vm.projectRoot()`.
+        string memory artifactPath = string.concat(vm.projectRoot(), "/out/rai-296-threshold-migration.json");
+        string memory json = vm.readFile(artifactPath);
+
+        // Smoke-check the JSON shape.
+        string memory bundleName = vm.parseJsonString(json, ".meta.name");
+        assertEq(bundleName, "RAI-296 ST0x Safe threshold 1->3", "meta.name pinned");
+        bool hasFirstTx = vm.keyExistsJson(json, ".transactions[0].to");
+        bool hasSecondTx = vm.keyExistsJson(json, ".transactions[1].to");
+        assertTrue(hasFirstTx, "first transaction present");
+        assertFalse(hasSecondTx, "exactly one transaction emitted");
+    }
+
+    /// @notice `verify()` accepts the artifact emitted by `run()`. This
+    /// is the load-bearing round-trip property — a signer should be able
+    /// to take the artifact, run `verify` against the same fork, and get
+    /// silent success.
+    function testVerifyAcceptsRunArtifact() external {
+        selectBaseFork();
+        // `run()` simulates the inner call via `vm.prank`, which mutates
+        // the Safe's threshold on the active fork. Snapshot first so we
+        // can roll the fork back to the pre-run state and `verify()` sees
+        // the same pre-migration threshold it would see in production.
+        uint256 snapshot = vm.snapshotState();
+        script.run();
+        string memory artifactPath = string.concat(vm.projectRoot(), "/out/rai-296-threshold-migration.json");
+        vm.revertToState(snapshot);
+        script.verify(artifactPath);
+    }
+
+    /// @notice Inverted: the pre-flight rejects a drifted threshold. If
+    /// the Safe's threshold already moved off `1` (e.g. someone else ran
+    /// a migration first), `run()` must trip the threshold invariant
+    /// rather than emitting a stale artifact.
+    function testRunRejectsAlreadyMigratedThreshold() external {
+        selectBaseFork();
+        // Mock the Safe's threshold to `3` to simulate post-migration
+        // pre-state; the pre-flight should reject this.
+        vm.mockCall(address(safe), abi.encodeWithSelector(IGnosisSafe.getThreshold.selector), abi.encode(uint256(3)));
+
+        vm.expectRevert(abi.encodeWithSelector(SafeThresholdMismatch.selector, address(safe), uint256(1), uint256(3)));
+        script.run();
+    }
+
+    /// @notice Inverted: the pre-flight rejects vault-ownership drift.
+    /// If even one receipt vault has its `owner()` pointing somewhere
+    /// other than the Safe, the migration must abort before producing an
+    /// artifact (the migration would otherwise lock the wrong Safe into
+    /// 3-of-4 without controlling the vaults).
+    function testRunRejectsVaultOwnershipDrift() external {
+        selectBaseFork();
+        address rogueOwner = address(0xBADC0DE);
+        address victim = LibTokenOwnership.ST0X_RECEIPT_VAULT_NVDA;
+        vm.mockCall(victim, abi.encodeWithSelector(IOwnable.owner.selector), abi.encode(rogueOwner));
+
+        vm.expectRevert(abi.encodeWithSelector(ReceiptVaultOwnerMismatch.selector, victim, address(safe), rogueOwner));
+        script.run();
+    }
+
+    /// @notice Inverted: `verify()` rejects an artifact with a wrong
+    /// `chainId`. We forge a minimal JSON with a bogus chain id and
+    /// assert the typed `VerifyMismatch("chainId")` revert.
+    function testVerifyRejectsWrongChainId() external {
+        selectBaseFork();
+        // Build a minimal-shape Tx Builder JSON with a deliberately-wrong
+        // chainId. Tx Builder schema serialises `chainId` as a decimal
+        // string.
+        SafeTx memory txn = SafeTx({
+            to: address(safe), value: 0, data: abi.encodeCall(IGnosisSafe.changeThreshold, (uint256(3))), operation: 0
+        });
+        SafeTx[] memory txs = new SafeTx[](1);
+        txs[0] = txn;
+        // Emit a bundle that claims to be for a different chain id by
+        // bypassing the live `block.chainid` and passing `block.chainid + 1`.
+        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid + 1, "rai-296-wrong-chain", txs);
+        string memory path = string.concat(vm.projectRoot(), "/out/rai-296-verify-wrong-chain.json");
+        vm.writeFile(path, json);
+
+        vm.expectRevert(abi.encodeWithSelector(VerifyMismatch.selector, "chainId"));
+        script.verify(path);
+    }
+
+    /// @notice Inverted: `verify()` rejects an artifact whose first tx
+    /// targets a different Safe.
+    function testVerifyRejectsWrongSafeAddress() external {
+        selectBaseFork();
+        address impostor = address(0xCAFEBABE);
+        SafeTx memory txn = SafeTx({
+            to: impostor, value: 0, data: abi.encodeCall(IGnosisSafe.changeThreshold, (uint256(3))), operation: 0
+        });
+        SafeTx[] memory txs = new SafeTx[](1);
+        txs[0] = txn;
+        string memory json = LibSafeOps.emitTxBuilderJson(impostor, block.chainid, "rai-296-wrong-safe", txs);
+        string memory path = string.concat(vm.projectRoot(), "/out/rai-296-verify-wrong-safe.json");
+        vm.writeFile(path, json);
+
+        vm.expectRevert(abi.encodeWithSelector(VerifyMismatch.selector, "safeAddress"));
+        script.verify(path);
+    }
+
+    /// @notice Inverted: `verify()` rejects an artifact whose tx
+    /// calldata encodes a different threshold.
+    function testVerifyRejectsWrongThresholdData() external {
+        selectBaseFork();
+        SafeTx memory txn = SafeTx({
+            to: address(safe), value: 0, data: abi.encodeCall(IGnosisSafe.changeThreshold, (uint256(4))), operation: 0
+        });
+        SafeTx[] memory txs = new SafeTx[](1);
+        txs[0] = txn;
+        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, "rai-296-wrong-threshold", txs);
+        string memory path = string.concat(vm.projectRoot(), "/out/rai-296-verify-wrong-threshold.json");
+        vm.writeFile(path, json);
+
+        vm.expectRevert(abi.encodeWithSelector(VerifyMismatch.selector, "data"));
+        script.verify(path);
+    }
+}

--- a/test/script/MigrateMultisigThresholdTest.t.sol
+++ b/test/script/MigrateMultisigThresholdTest.t.sol
@@ -18,7 +18,7 @@ import {
     ReceiptVaultOwnerMismatch
 } from "../../src/lib/LibSafeInvariants.sol";
 import {LibProdTokensBase} from "../../src/lib/LibProdTokensBase.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 
 /// @title MigrateMultisigThresholdTest
 /// @notice End-to-end fork tests for the multisig threshold migration


### PR DESCRIPTION
## Summary

Adds `script/MigrateMultisigThreshold.s.sol`: an authored Forge script for the ST0x token-owner Safe's threshold migration (1-of-4 → 3-of-4). Two entrypoints:

- `run()` — exhaustive on-chain pre-flight via the no-arg `LibSafeInvariants.assertAll(safe)` overload (defaults from `LibProdSafes`: proxy codehash, singleton + bytecode, version, modules, guard, fallback handler, uniform vault ownership, expected owner set, pinned current threshold). Then simulates `changeThreshold(3)` via `vm.prank`, re-runs the bundle via the full-args `assertAll(safe, TARGET_THRESHOLD, expectedOwners)` overload to override the threshold with the deliberately-changed value (owners stay on the current-truth pin), emits the Safe Tx Builder JSON artifact to `out/safe-threshold-migration.json`, and logs the canonical `SafeTxHash` between explicit BEGIN/END markers. **Final post-state step**: `LibSafeOps.simulateNPlus1Reversal(safe, oldThreshold, TARGET_THRESHOLD)` — see below.
- `verify(jsonPath)` — re-runs the pre-flight via `assertAll(safe)`, parses an existing artifact, and asserts the parsed artifact matches what the live pre-flight would emit (per-field `VerifyMismatch` errors pinpoint drift; `safeTxHash` cross-check catches stale artifacts after a nonce bump).

End-to-end fork tests cover the happy-path `run`, each inverted precondition, and the `run` → `verify` round-trip.

## n+1 reversibility check

Per DevOps convention every critical state change ships with the proof that it isn't terminal — DM's framing: "ppl put things in a state that cant be moved out of". The migration script's final post-state step is now `LibSafeOps.simulateNPlus1Reversal(safe, STOX_TOKEN_OWNER_SAFE_THRESHOLD, TARGET_THRESHOLD)`, which:

1. Builds the inverse `changeThreshold(STOX_TOKEN_OWNER_SAFE_THRESHOLD)` as a follow-up tx.
2. Pre-approves the follow-up hash from `TARGET_THRESHOLD` owners via `vm.prank(owner) + safe.approveHash(hash)`.
3. Calls `execTransaction` with only `TARGET_THRESHOLD - 1` packed signatures; asserts the call reverts with `GS020` (Safe v1.4.1's "Signatures data too short") — proving the threshold gate enforces.
4. Calls `execTransaction` with all `TARGET_THRESHOLD` packed signatures; asserts success and that the threshold rolls back to `STOX_TOKEN_OWNER_SAFE_THRESHOLD` — proving the new state is exitable and the real `checkSignatures` path works end-to-end (no mocks, no owner-slot overwrites; only the source of the approval is the cheatcode prank).

Sequenced **after** the JSON emission so the artifact reflects the forward migration. The reversal exists only as a fork-local simulation and never reaches the signers. Generalises via `LibSafeOps` to other operational scripts.

## Call shape

Mirrors `StoxProdV2Test::checkAllV2OnChain` — a no-arg overload for the pinned current truth, a full-args overload for deliberate overrides. Pre-flight defaults to the no-arg version; only the post-state assertion (which intentionally changes the threshold) uses the full-args overload.

## Files

- `script/MigrateMultisigThreshold.s.sol` — the script. Now ends with the `simulateNPlus1Reversal` call.
- `test/script/MigrateMultisigThresholdTest.t.sol` — end-to-end fork tests. `testRunCompletesAndWritesArtifact` now also asserts the post-`run()` fork state has the threshold back at the pinned pre-migration value, giving the n+1 reversal observable evidence in the test. Vault-ownership inverted test imports `IOwnable` / `ReceiptVaultOwnerMismatch` from `LibSafeInvariants` (folded in from the now-deleted `LibTokenOwnership`) and sources the victim address from `LibProdTokensBase.MSTR_RECEIPT_VAULT`.
- `README.md` — operational workflow section under "Operational scripts → Worked example: the multisig threshold migration", with dry-run + verify commands.
- `.github/workflows/multisig-artifact.yaml` — runs the dry-run on `workflow_dispatch` (maintainer-triggered, for producing the bundle the signers actually use) and on `pull_request` events that touch the migration code or any of its direct dependencies, uploading `out/*.json` as a build artifact.

## Stack

- Parent: [#191](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/191) (`feat/lib-safe-ops`) — also gains the `simulateNPlus1Reversal` helper + its inverted tests.
- Next: [#194](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/194) (`feat/rai-296-post-migration-pin`, DRAFT) — the post-execution drift detector.

## Test plan

- [x] `forge test --match-contract MigrateMultisigThresholdTest` — 7/7 passing (now includes the post-`run()` threshold restoration assertion).
- [x] `rainix-sol-static` — slither 0 findings, fmt clean.
- [x] `rainix-sol-legal` — REUSE compliant.
- [x] Full `rainix-sol-test` — 594 passing (pre-existing ignored failures only).
- [ ] On merge, manually trigger the `multisig-artifact` workflow via `workflow_dispatch` against this branch's HEAD to produce the bundle signers will load into the Safe Tx Builder UI.
