### PR TITLE
RAI-789 test(safe-rotation): post-execution threshold pin (1 → 3)

### DIFF
--- a/src/lib/LibProdSafes.sol
+++ b/src/lib/LibProdSafes.sol
@@ -79,11 +79,14 @@ library LibProdSafes {
     address constant STOX_TOKEN_OWNER_SAFE = 0xe70d821f3462a074e63b42d0AaC6523faAe1d611;
 
     /// @notice The current expected threshold for `STOX_TOKEN_OWNER_SAFE`.
-    /// Updated by the threshold-migration PR family once live execution
-    /// lands: scripts and the post-migration pin both treat this constant
-    /// as the canonical current truth, so the value bumps from `1` to `3`
-    /// in the same PR that records the live post-execution state.
-    uint256 constant STOX_TOKEN_OWNER_SAFE_THRESHOLD = 1;
+    /// Bumped from `1` to `3` to record the live post-execution state of
+    /// the threshold migration against the post-rotation 6-signer roster.
+    /// From this PR onward, the no-arg `LibSafeInvariants.assertAll(safe)`
+    /// overload (which defaults its expected threshold to this constant)
+    /// is the canonical drift detector for the Safe's current threshold;
+    /// any further change to the threshold should land in a new PR that
+    /// updates this constant in lockstep with live execution.
+    uint256 constant STOX_TOKEN_OWNER_SAFE_THRESHOLD = 3;
 
     /// @notice Owner #1 of `STOX_TOKEN_OWNER_SAFE`. **PLACEHOLDER**
     /// (`address(0)`) until the post-rotation roster is published and each


### PR DESCRIPTION
## Summary

**DRAFT — blocked on the Safe Tx Builder bundle from [#204](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/204) being signed and executed on Base.**

Bumps `LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD` from `1` to `3` to record the live post-execution state of the threshold migration (6-signer post-rotation roster, mixed-vendor hardware-wallet policy, 3-of-6 threshold). One-line lib change; the rest of the lib (6 owner-address placeholders, supporting NatSpec, etc.) lives in the parent PR [#204](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/204).

## Why it's separate from [#204](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/204)

Two distinct on-chain states the lib needs to pin at two different moments:

- **At script run time** (the state [#204](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/204) pins): post manual roster swap, pre threshold raise — 6 new owners + threshold `1`. This is what the script's pre-flight `assertAll(safe)` validates against.
- **Post-execution** (the state this PR pins): post Safe Tx Builder bundle landed on Base — 6 new owners + threshold `3`. This is what every future `assertAll(safe)` call should validate against.

Merging this PR before the bundle executes would trip every `assertAll`-based test (live threshold `1` ≠ lib-pinned `3`). Same "fails-until-live-execution" forcing-function pattern used elsewhere in the V4 stack.

## Stack

[#204](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/204) (retarget script + 6-owner placeholders) → **this PR** (post-execution threshold pin).

## Linked issue

[RAI-789](https://linear.app/makeitrain/issue/RAI-789) — the threshold-raise workstream. This PR is the final checklist item in RAI-789 (the post-execution lib pin), and RAI-789 itself is blocked by [RAI-788](https://linear.app/makeitrain/issue/RAI-788) (the signer ceremony).

## Test plan

- [ ] After the [#204](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/204) bundle has executed on Base, run `forge test --match-contract StoxProdV2Test` against an unpinned Base head fork. With this PR's threshold bump applied, `assertAll(safe)` passes silently — the live Safe is now at 3-of-6 against the post-rotation roster.
