### PR TITLE
RAI-789 feat(safe): swap LibProdSafes roster to the 6-signer post-rotation set

### DIFF
--- a/script/MigrateMultisigThreshold.s.sol
+++ b/script/MigrateMultisigThreshold.s.sol
@@ -27,7 +27,7 @@ error VerifyExpectedSingleTx(uint256 actualCount);
 
 /// @title MigrateMultisigThreshold
 /// @notice Forge script that authors the ST0x token-owner Safe's
-/// multisig threshold migration (1-of-4 -> 3-of-4). Performs an
+/// multisig threshold migration (1-of-6 -> 3-of-6 against the post-rotation roster). Performs an
 /// exhaustive on-chain pre-flight via `LibSafeInvariants.assertAll`
 /// (proxy codehash, singleton + bytecode, version, modules, guard,
 /// fallback handler, uniform vault ownership, expected owner set,
@@ -58,7 +58,7 @@ contract MigrateMultisigThreshold is Script {
 
     /// @notice Human-readable name embedded in the emitted Tx Builder
     /// JSON's `meta.name`. Visible to signers in the Safe Tx Builder UI.
-    string internal constant BUNDLE_NAME = "ST0x Safe threshold 1->3";
+    string internal constant BUNDLE_NAME = "ST0x Safe threshold 1->3 (post-rotation roster)";
 
     /// @notice Output path (relative to the project root) for the Tx
     /// Builder JSON artifact. Picked up by the multisig-artifact GH
@@ -74,7 +74,7 @@ contract MigrateMultisigThreshold is Script {
     /// `vm.prank`.
     function run() external {
         IGnosisSafe safe = IGnosisSafe(LibProdSafes.STOX_TOKEN_OWNER_SAFE);
-        // Pre-flight: every immutable invariant plus the pinned 4-owner
+        // Pre-flight: every immutable invariant plus the pinned 6-owner
         // roster plus the pinned current threshold. Defaults from
         // `LibProdSafes` (no-arg overload). Reverts with the relevant
         // typed error from the underlying library on first mismatch.

--- a/src/lib/LibProdSafes.sol
+++ b/src/lib/LibProdSafes.sol
@@ -5,14 +5,23 @@ pragma solidity ^0.8.25;
 /// @title LibProdSafes
 /// @notice Production Safe constants for the ST0x token-owner multisig on
 /// Base. Pinned addresses, codehashes, slot values, and the expected owner
-/// set (currently 4 owners) are derived from live on-chain state and the
-/// canonical Safe deployment manifest, then re-asserted from fork tests so
-/// that drift between this file and reality trips CI rather than slipping
-/// into a migration script.
-/// @dev Scope: the multisig threshold migration raises this Safe from
-/// 1-of-4 to 3-of-4. (Originally specced as 1-of-5 -> 3-of-5; the owner
-/// roster was reduced to four on 2026-05-18 via the `RemovedOwner` event
-/// at block 46156528, before the threshold migration was executed.)
+/// set (6 owners post-rotation) are derived from live on-chain state and
+/// the canonical Safe deployment manifest, then re-asserted from fork
+/// tests so that drift between this file and reality trips CI rather than
+/// slipping into a migration script.
+/// @dev Scope: this file pins the *post-rotation* roster (6 ST0x
+/// governance signers) and the threshold migration script targets 3-of-6
+/// against that roster. The owner rotation itself is done manually via
+/// the Safe UI under the current 1-of-N threshold (no rotation script
+/// needed — at threshold 1 a single signer can execute each
+/// `addOwnerWithThreshold` / `removeOwner` call via the Safe UI). Each
+/// pinned address was verified off-chain via a send-back ceremony before
+/// being committed here; the per-signer verification tracker is held
+/// privately. Until the manual roster swap finishes executing on-chain
+/// (i.e. all 6 listed addresses are present and the previous owners are
+/// removed), every script and fork test that asserts against
+/// `expectedOwners()` deliberately fails — the red CI is the explicit
+/// forcing function gating the threshold-raise script.
 /// @dev Sources:
 /// - Safe v1.4.1 L2 singleton & proxy: github.com/safe-global/safe-deployments
 ///   under `src/assets/v1.4.1/safe_l2.json` (chainId 8453 entry). Both the
@@ -65,8 +74,8 @@ library LibProdSafes {
     address constant SAFE_V1_4_1_COMPATIBILITY_FALLBACK_HANDLER = 0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99;
 
     /// @notice The Safe that owns every ST0x receipt vault on Base. Subject
-    /// of the threshold migration (1 -> 3, against the current 4-owner
-    /// roster).
+    /// of the threshold migration (1 -> 3, against the post-rotation
+    /// 6-owner roster).
     /// https://basescan.org/address/0xe70d821f3462A074E63b42D0aac6523faAe1D611
     address constant STOX_TOKEN_OWNER_SAFE = 0xe70d821f3462a074e63b42d0AaC6523faAe1d611;
 
@@ -77,25 +86,30 @@ library LibProdSafes {
     /// in the same PR that records the live post-execution state.
     uint256 constant STOX_TOKEN_OWNER_SAFE_THRESHOLD = 1;
 
-    /// @notice Owner #1 of `STOX_TOKEN_OWNER_SAFE`. Order matches
-    /// `getOwners()` (Safe-internal linked-list order).
-    address constant STOX_TOKEN_OWNER_SAFE_OWNER_1 = 0x19f95a84aa1C48A2c6a7B2d5de164331c86D030C;
+    /// @notice Owner #1 of `STOX_TOKEN_OWNER_SAFE`.
+    /// @dev Order matches `getOwners()` (Safe-internal linked-list order)
+    /// against the post-rotation roster: `getOwners()` returns owners
+    /// newest-first, so the last signer to be added via
+    /// `addOwnerWithThreshold` appears at slot 0. The owner rotation
+    /// itself is done manually via the Safe UI under the current 1-of-N
+    /// threshold (no rotation script); only the threshold raise is
+    /// scripted.
+    address constant STOX_TOKEN_OWNER_SAFE_OWNER_1 = 0x4746095B1Ea1A84446d34448f44e74D3d51f92F2;
 
-    /// @notice Owner #2 of `STOX_TOKEN_OWNER_SAFE`. Order matches
-    /// `getOwners()` (Safe-internal linked-list order).
-    address constant STOX_TOKEN_OWNER_SAFE_OWNER_2 = 0x8f6bF4A948Af2Fc74eE34982C4435a7C013D1A52;
+    /// @notice Owner #2 of `STOX_TOKEN_OWNER_SAFE`.
+    address constant STOX_TOKEN_OWNER_SAFE_OWNER_2 = 0xceC2cb8B8EE4000FFA3F8a7f8E0Fa0A3E3DAb72d;
 
-    /// @notice Owner #3 of `STOX_TOKEN_OWNER_SAFE`. Order matches
-    /// `getOwners()` (Safe-internal linked-list order). This slot previously
-    /// held the now-removed owner `0x691AcCd4...`; after the 2026-05-18
-    /// `RemovedOwner` event at block 46156528 the linked list shifted up
-    /// and what was owner #4 became owner #3.
-    address constant STOX_TOKEN_OWNER_SAFE_OWNER_3 = 0x91E2AF6Ee6bc5d0f7AA1644Bb94957932629d2DB;
+    /// @notice Owner #3 of `STOX_TOKEN_OWNER_SAFE`.
+    address constant STOX_TOKEN_OWNER_SAFE_OWNER_3 = 0x8D5901d8aE48101B59400235ad8614A2e0510466;
 
-    /// @notice Owner #4 of `STOX_TOKEN_OWNER_SAFE`. Order matches
-    /// `getOwners()` (Safe-internal linked-list order). Formerly owner #5
-    /// before the 2026-05-18 roster reduction.
-    address constant STOX_TOKEN_OWNER_SAFE_OWNER_4 = 0xBF8a5DE7BaAFaD46495217d467F43ae305cb900f;
+    /// @notice Owner #4 of `STOX_TOKEN_OWNER_SAFE`.
+    address constant STOX_TOKEN_OWNER_SAFE_OWNER_4 = 0xC1C89b7f5448F447d59f920456A9610f6b2544bC;
+
+    /// @notice Owner #5 of `STOX_TOKEN_OWNER_SAFE`.
+    address constant STOX_TOKEN_OWNER_SAFE_OWNER_5 = 0xAB92b327c97A6E7461cBd76E2a789E5e106FF87e;
+
+    /// @notice Owner #6 of `STOX_TOKEN_OWNER_SAFE`.
+    address constant STOX_TOKEN_OWNER_SAFE_OWNER_6 = 0x5CCd3cE683b66ff271DDB8915fF528b8fcFa23c2;
 
     /// @notice Returns the expected owner set for `STOX_TOKEN_OWNER_SAFE` in
     /// the exact order returned by `getOwners()` against an unpinned Base
@@ -105,14 +119,21 @@ library LibProdSafes {
     /// further drift). Provided as a helper because Solidity 0.8 cannot
     /// express a file-scope `constant address[]` and declaring the array
     /// as `immutable` is contract-scoped only.
-    /// @return The four owners of the ST0x token-owner Safe in
+    /// @dev Six entries post-rotation. The roster uses a mixed-vendor
+    /// hardware-wallet policy: the 3-of-6 threshold combined with the
+    /// vendor mix enforces that no single-vendor subset can reach quorum
+    /// on its own, so a single-vendor compromise cannot sign a tx without
+    /// recruiting a different-vendor signer.
+    /// @return The six owners of the ST0x token-owner Safe in
     /// `getOwners()` order.
     function expectedOwners() internal pure returns (address[] memory) {
-        address[] memory owners = new address[](4);
+        address[] memory owners = new address[](6);
         owners[0] = STOX_TOKEN_OWNER_SAFE_OWNER_1;
         owners[1] = STOX_TOKEN_OWNER_SAFE_OWNER_2;
         owners[2] = STOX_TOKEN_OWNER_SAFE_OWNER_3;
         owners[3] = STOX_TOKEN_OWNER_SAFE_OWNER_4;
+        owners[4] = STOX_TOKEN_OWNER_SAFE_OWNER_5;
+        owners[5] = STOX_TOKEN_OWNER_SAFE_OWNER_6;
         return owners;
     }
 }

--- a/test/script/MigrateMultisigThresholdTest.t.sol
+++ b/test/script/MigrateMultisigThresholdTest.t.sol
@@ -59,7 +59,7 @@ contract MigrateMultisigThresholdTest is Test {
 
         // Smoke-check the JSON shape.
         string memory bundleName = vm.parseJsonString(json, ".meta.name");
-        assertEq(bundleName, "ST0x Safe threshold 1->3", "meta.name pinned");
+        assertEq(bundleName, "ST0x Safe threshold 1->3 (post-rotation roster)", "meta.name pinned");
         bool hasFirstTx = vm.keyExistsJson(json, ".transactions[0].to");
         bool hasSecondTx = vm.keyExistsJson(json, ".transactions[1].to");
         assertTrue(hasFirstTx, "first transaction present");
@@ -113,7 +113,7 @@ contract MigrateMultisigThresholdTest is Test {
     /// If even one receipt vault has its `owner()` pointing somewhere
     /// other than the Safe, the migration must abort before producing an
     /// artifact (the migration would otherwise lock the wrong Safe into
-    /// 3-of-4 without controlling the vaults).
+    /// 3-of-6 without controlling the vaults).
     function testRunRejectsVaultOwnershipDrift() external {
         selectBaseFork();
         address rogueOwner = address(0xBADC0DE);

--- a/test/src/lib/LibSafeInvariants.t.sol
+++ b/test/src/lib/LibSafeInvariants.t.sol
@@ -221,14 +221,14 @@ contract LibSafeInvariantsTest is Test {
     }
 
     /// @notice Owner count drift trips `SafeOwnerCountMismatch`. The caller
-    /// passes a 3-entry array against the live 4-owner Safe.
+    /// passes a 3-entry array against the live 6-owner Safe.
     function testInvertedOwnerCountMismatch() external {
         selectBaseFork();
         address[] memory truncated = new address[](3);
         truncated[0] = LibProdSafes.STOX_TOKEN_OWNER_SAFE_OWNER_1;
         truncated[1] = LibProdSafes.STOX_TOKEN_OWNER_SAFE_OWNER_2;
         truncated[2] = LibProdSafes.STOX_TOKEN_OWNER_SAFE_OWNER_3;
-        vm.expectRevert(abi.encodeWithSelector(SafeOwnerCountMismatch.selector, address(safe), uint256(3), uint256(4)));
+        vm.expectRevert(abi.encodeWithSelector(SafeOwnerCountMismatch.selector, address(safe), uint256(3), uint256(6)));
         harness.callAssertOwnerSet(safe, truncated);
     }
 


### PR DESCRIPTION
## Summary

**DRAFT — blocked on the final owner-add ([slot-0 address](https://basescan.org/address/0x4746095B1Ea1A84446d34448f44e74D3d51f92F2) not yet present on the live Safe). Hydrated placeholders aren't yet matched 1:1 by `getOwners()`; the red CI is the explicit forcing function.**

Swaps the ST0x token-owner Safe owner-set pinned in `LibProdSafes` from the current 4-owner roster to the 6 verified post-rotation signer addresses. The merged threshold-migration script ([#193](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/193)) already targets `1 -> 3`, so this PR only changes the roster shape; `TARGET_THRESHOLD` itself is unchanged.

## Why a roster swap (and not a re-target)

The merged script already targets `TARGET_THRESHOLD = 3`. The 6-signer / 3-of-6 design just needs the lib to expose the new owner set so the script's pre-flight `assertAll(safe)` matches the post-swap Safe state. The script's signature path, n+1 reversibility check, and Tx Builder JSON emission don't change.

The owner roster swap itself isn't scripted — at the current threshold = 1, a single signer executes each `removeOwner` / `addOwnerWithThreshold(..., 1)` call via the Safe UI.

## Roster + ordering

6 verified addresses, committed in `getOwners()` linked-list order (Safe returns owners newest-first, so the last-added signer occupies slot 0). Identity/brand mapping is held privately off-PR. Aggregate policy: **mixed-vendor hardware-wallet split** — at 3-of-6 the vendor mix prevents any single-vendor subset from reaching quorum on its own, so a single-vendor compromise can't sign a tx without recruiting a different-vendor signer.

## Changes

- `src/lib/LibProdSafes.sol`:
  - `STOX_TOKEN_OWNER_SAFE_OWNER_1..6` hydrated with the 6 verified post-rotation signer addresses.
  - `expectedOwners()` returns a 6-element array.
  - File-level NatSpec rewritten to reflect the post-rotation framing + the off-chain send-back verification ceremony.
  - `STOX_TOKEN_OWNER_SAFE_THRESHOLD` stays `1` — current on-chain threshold at the moment the script runs.
- `script/MigrateMultisigThreshold.s.sol`:
  - Header NatSpec: `1-of-4 -> 3-of-4` → `1-of-6 -> 3-of-6 against the post-rotation roster`.
  - `BUNDLE_NAME`: `"ST0x Safe threshold 1->3"` → `"ST0x Safe threshold 1->3 (post-rotation roster)"` so signers can disambiguate this bundle from a pre-rotation-era one in their Tx Builder UI history.
  - One internal comment updated from "4-owner" to "6-owner".
  - `TARGET_THRESHOLD` unchanged.
- `test/script/MigrateMultisigThresholdTest.t.sol`:
  - Bundle-name pin updated.
  - One comment updated from `4-of-5` → `3-of-6`.

## Live state at the time this PR was authored

Current Safe state on Base (verified via `cast call`):

- `getOwners()` returns 5 owners (the 5 already-added new signers; the 6th lands at slot 0 once `addOwnerWithThreshold` runs for it).
- `getThreshold()` returns `1`.

Local fork tests against an unpinned Base head correctly trip `SafeOwnerCountMismatch(safe, 6, 5)` — lib pins 6, live has 5. This is the deliberately-red posture.

## Ops workflow once the final signer is added

1. **Add the remaining owner.** At threshold 1 the current signer executes one final `addOwnerWithThreshold(<slot-0 address>, 1)` via the Safe UI. After this, `getOwners()` returns all 6 addresses pinned here, in matching order.
2. **Mark this PR ready for review.** With all 6 owners live, `assertAll(safe)` passes; fork tests go green.
3. **Script run.** `forge script script/MigrateMultisigThreshold.s.sol` against a Base head fork — pre-flight `assertAll(safe)` passes, `simulateSelfCall` runs `changeThreshold(3)`, post-state `assertAll(safe, 3, expectedOwners())` validates. Emits `out/safe-threshold-migration.json`.
4. **Signer review + execution.** Each of the 6 new owners imports the Tx Builder JSON into the Safe UI, verifies the displayed `SafeTxHash` matches the script's logged value, signs. Any 3 valid sigs execute the threshold raise.
5. **Follow-up PR.** [#206](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/206) (stacked on this one) bumps `LibProdSafes.STOX_TOKEN_OWNER_SAFE_THRESHOLD` from `1` → `3` and merges as the post-execution state pin.

## Linked issue

[RAI-789](https://linear.app/makeitrain/issue/RAI-789) — the threshold-raise workstream. Blocked by [RAI-788](https://linear.app/makeitrain/issue/RAI-788) (the signer ceremony).

## Supersedes

Replaces [#204](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/204) (closed) — that PR had been amended through two intermediate plans and accumulated a misleading branch name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multisig owner configuration from 4-owner to 6-owner setup with new pinned addresses for owners 5 and 6.
  * Extended migration metadata to reference post-rotation roster configuration.

* **Documentation**
  * Updated library and script documentation to reflect 6-owner governance scope and 3-of-6 threshold target.

* **Tests**
  * Updated test fixtures and expectations to align with 6-owner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->