### PR TITLE
RAI-794 chore(deploy): post-Bundle-1 V4 authoriser clone-pin (placeholder)

### DIFF
--- a/src/lib/LibProdDeployV4.sol
+++ b/src/lib/LibProdDeployV4.sol
@@ -126,6 +126,16 @@ library LibProdDeployV4 {
     /// post-deploy edit hand-writes the real literal in place of
     /// `address(0)` here.
     ///
+    /// @dev Hydration of this constant + `STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH`
+    /// below happens in the post-Bundle-1 clone-pin PR. That PR is the
+    /// "pin before modify" gate between the clone-deploy script's
+    /// `run()` (Bundle 1) and its `mirrorGrants()` (Bundle 2): until the
+    /// pin lands, `mirrorGrants()` reverts with `V4AuthoriserCloneNotPinned()`
+    /// in pre-flight, so a grant-mirror bundle cannot be authored against
+    /// an arbitrary contract. See `docs/OPERATIONAL_SCRIPTS.md` §
+    /// "Pin before modify" for the full rationale and the field-by-field
+    /// hydration checklist.
+    ///
     /// Lives in this lib (the deploy artifacts pin) rather than in
     /// `LibAuthoriserInvariants` because it's a deploy target, not a
     /// current-state invariant. Post-swap, `LibAuthoriserInvariants.STOX_PROD_AUTHORISER`


### PR DESCRIPTION
## Summary

**PLACEHOLDER** — held empty until [#242](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/242)'s clone-deploy broadcast has executed on Base. The diff lands at that point with the literal clone address + EIP-1167 codehash.

## Purpose

Pins \`LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE\` from \`address(0)\` → the actual V4 clone address authored by [#242](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/242)'s \`run()\` broadcast, and \`LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH\` from \`bytes32(0)\` → the computed EIP-1167 minimal-proxy runtime codehash.

## Why this exists as its own PR (and not in [#242](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/242) or [#197](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/197))

The \"pin before modify\" pattern — the lib pin is the routing primitive [#197](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/197)'s script consumes:

- [#197](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/197)'s upgrade script reads the clone address from \`LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE\` — **no \`address\` parameter**, so a fat-finger in a workflow dispatch cannot route the swap bundle to an arbitrary contract. The lib pin is the only path to telling the script which clone to swap onto.
- Until this PR merges, [#197](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/197)'s \`run()\` reverts with \`V4AuthoriserCloneNotPinned()\` in pre-flight. That is the explicit forcing function gating the upgrade.
- [#242](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/242) cannot land the address either: the clone is deployed via \`CloneFactory.clone(impl, data)\`, which uses non-deterministic \`Clones.clone\` (address depends on the factory's nonce at execution). The pin can only be written **after** [#242](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/242)'s broadcast lands on Base.

This is orthogonal to the [\`LibMigrationInvariant\`](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/233) test pattern: migration-invariant lets invariant *tests* cover both live-chain states across a deadline; pin-before-modify is about the lib *constant* the operational script routes against. Both apply here.

## Filling this PR in

Once [#242](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/242)'s \`run()\` has broadcast on Base:

1. Read the \`Clone:\` line from the \`==== V4 AUTHORISER CLONE DEPLOYED ====\` block in the \`forge script --broadcast\` output. That's the clone address.
2. Read the \`CloneCodehash:\` line from the same block. That's the EIP-1167 minimal-proxy codehash.
3. Update \`src/lib/LibProdDeployV4.sol\`:
   \`\`\`diff
   -    address constant STOX_PROD_AUTHORISER_V4_CLONE = address(0);
   +    address constant STOX_PROD_AUTHORISER_V4_CLONE = address(<live clone address>);

   -    bytes32 constant STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH = bytes32(0);
   +    bytes32 constant STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH = <computed codehash>;
   \`\`\`
4. Push to this branch. [#197](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/197)'s upgrade pre-flight now finds a real clone at the pinned address and no longer trips \`V4AuthoriserCloneNotPinned\`.
5. Review the diff against on-chain — the clone address must match the address in the broadcast receipt, the codehash must match \`extcodehash(<clone>)\` queried via \`cast call\`.
6. Merge → mark ready to dispatch [#197](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/197).

## Stack position

\`\`\`
main
  → #233 (LibMigrationInvariant lib + beacon-owner pin)
  → #242 (EOA-broadcast clone deploy)
  → THIS PR (clone-pin hydration; held empty until #242's broadcast lands)
  → #197 (V4 upgrade + swap + post-swap state pin)
\`\`\`