### PR TITLE
feat(script): deploy the Ethereum production tokens via the deploy key, matched to Base

### DIFF
--- a/.github/workflows/manual-broadcast.yaml
+++ b/.github/workflows/manual-broadcast.yaml
@@ -19,6 +19,7 @@ on:
           # lives in the script's file-level NatSpec — this dropdown is a
           # registry of *which* scripts exist, not *whether* they've run.
           - 20260619-deploy-v4-authoriser-clone
+          - 20260706-deploy-tokens-ethereum
       network:
         description: 'Network to broadcast against (default: base)'
         required: true

--- a/script/20260706-deploy-tokens-ethereum.s.sol
+++ b/script/20260706-deploy-tokens-ethereum.s.sol
@@ -10,10 +10,9 @@ import {
 } from "rain-vats-0.1.6/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
 import {ReceiptVaultConfigV2} from "rain-vats-0.1.6/src/abstract/ReceiptVault.sol";
 
-import {IGnosisSafe} from "../src/interface/IGnosisSafe.sol";
+import {LibBeaconInvariants} from "../src/lib/LibBeaconInvariants.sol";
 import {IStoxUnifiedDeployerV1} from "../src/interface/IStoxUnifiedDeployerV1.sol";
 import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
-import {LibProdDeployCurrent} from "../src/generated/LibProdDeployCurrent.sol";
 import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
 import {LibProdTokenConfig, TokenConfig} from "../src/lib/LibProdTokenConfig.sol";
 
@@ -41,12 +40,12 @@ error DeployerNotDeployed(address deployer);
 /// @param clone The clone address inspected.
 error EthereumCloneNotReady(address clone);
 
-/// @notice Pre-flight failed: the Ethereum token-owner Safe address is not
-/// yet pinned (`address(0)`). The Safe is a distinct per-chain address,
-/// deployed out-of-band and pinned in
-/// `LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM`; ownership cannot be
-/// handed to it until that address lands.
-/// @param safe The Safe address inspected (`address(0)` when unpinned).
+/// @notice Pre-flight failed: the active chain's resolved token-owner Safe is
+/// not the pinned ETHEREUM Safe. Either the script was dispatched against a
+/// network other than Ethereum mainnet (this script deploys the Ethereum
+/// token set only), or the Ethereum pin
+/// (`LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM`) has not landed.
+/// @param safe The Safe address the active chain resolved to.
 error EthereumSafeNotReady(address safe);
 
 /// @title DeployTokensEthereum
@@ -91,15 +90,18 @@ contract DeployTokensEthereum is Script {
         if (deployer.code.length == 0) revert DeployerNotDeployed(deployer);
     }
 
-    /// @notice The Ethereum token-owner Safe, asserted pinned + policy-aligned
-    /// to Base. Reverts `EthereumSafeNotReady` until the address is hydrated,
-    /// then asserts the live Safe matches Base's shared policy with
-    /// `assertTokenOwnerSafePolicy` (order-insensitive owner set).
+    /// @notice The active chain's token-owner Safe, resolved + policy-asserted
+    /// through the shared entry point (`assertActiveChainTokenOwnerSafe` — the
+    /// identical assertion the scheduled CI pin runs per chain), then guarded
+    /// to be ETHEREUM's Safe: this script deploys the Ethereum token set, so
+    /// a dispatch against any other network's RPC must revert rather than
+    /// deploy duplicate tokens onto that chain.
     /// @return safe The validated Ethereum token-owner Safe address.
     function _assertSafeReady() internal view returns (address safe) {
-        safe = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM;
-        if (safe == address(0)) revert EthereumSafeNotReady(safe);
-        LibSafeInvariants.assertTokenOwnerSafePolicy(IGnosisSafe(safe));
+        safe = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
+        if (safe != LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM) {
+            revert EthereumSafeNotReady(safe);
+        }
     }
 
     /// @notice Assert the Ethereum V4 authoriser clone is deployed at its pin
@@ -117,16 +119,31 @@ contract DeployTokensEthereum is Script {
 
     /// @notice Deploy every production token on the active chain via the
     /// unified deployer, wire each onto the V4 authoriser clone, and hand
-    /// ownership to the Safe — one deploy-key broadcast, matched to Base. Reads
-    /// `DEPLOYMENT_KEY`. Logs each deployed pair for the pin PR.
+    /// ownership to the Safe — one deploy-key broadcast, matched to Base.
+    /// Broadcasts as the key `manual-broadcast.yaml` supplies via
+    /// `--private-key` (the same CI deploy key every operational broadcast
+    /// uses). Logs each deployed pair for the pin PR.
     function run() external {
         // Pre-flight: the unified deployer + both beacon-set deployers it
-        // delegates to must be live at their pinned V4 addresses (bootstrap
-        // step 1 broadcast the core suites here).
-        address unifiedDeployer = LibProdDeployCurrent.STOX_UNIFIED_DEPLOYER;
+        // delegates to must be live at their pinned addresses. The 0.1.1
+        // pins, NOT `LibProdDeployCurrent`: Ethereum's bootstrap shipped the
+        // audited 0.1.1 set, and the 0.1.1 unified deployer is what wires
+        // new vault proxies onto the chain's IN-USE production beacons (the
+        // 0.1.1 set pinned via `LibProdBeaconsEthereum` /
+        // `LibBeaconInvariants`). The current tag's deployer is a different
+        // Zoltu address that (a) is not deployed on Ethereum and (b) would
+        // wire tokens onto a different, unadopted beacon set even if it were.
+        address unifiedDeployer = LibProdDeployV4.STOX_UNIFIED_DEPLOYER_0_1_1;
         _assertDeployer(unifiedDeployer);
-        _assertDeployer(LibProdDeployCurrent.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER);
-        _assertDeployer(LibProdDeployCurrent.STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER);
+        _assertDeployer(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_0_1_1);
+        _assertDeployer(LibProdDeployV4.STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER_0_1_1);
+
+        // Pre-flight: the chain's IN-USE production beacons — the beacons
+        // every vault proxy created below will delegate through — are owned
+        // by this chain's token-owner Safe. A beacon owned by anything else
+        // could be repointed under the new tokens. The same assertion the
+        // per-chain prod pin (`StoxProdV4`) runs on every CI commit.
+        LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
 
         // The clone (setAuthorizer target) and the Safe (ownership-handoff
         // target) must both be live before we deploy, since each token is fully
@@ -135,10 +152,17 @@ contract DeployTokensEthereum is Script {
         address safe = _assertSafeReady();
 
         TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
-        uint256 deployerKey = vm.envUint("DEPLOYMENT_KEY");
-        address deployer = vm.addr(deployerKey);
 
         bytes32 deploymentTopic = keccak256("Deployment(address,address,address)");
+
+        vm.startBroadcast();
+
+        // Deployer identity — inside `vm.startBroadcast()` msg.sender
+        // resolves to the broadcast address (`--private-key` in production,
+        // supplied by `manual-broadcast.yaml`). Captured so the
+        // `initialAdmin` baked into each vault's config lines up with the
+        // key that then calls `setAuthorizer` + `transferOwnership`.
+        address deployer = msg.sender;
 
         console2.log("Deploying", configs.length, "tokens on chain id", block.chainid);
         console2.log("initialAdmin (deploy key, handed to Safe):", deployer);
@@ -157,7 +181,6 @@ contract DeployTokensEthereum is Script {
             });
 
             vm.recordLogs();
-            vm.broadcast(deployerKey);
             IStoxUnifiedDeployerV1(unifiedDeployer).newTokenAndWrapperVault(vaultConfig);
 
             // Fish the deployed pair out of the unified deployer's
@@ -182,9 +205,7 @@ contract DeployTokensEthereum is Script {
             // `onlyOwner`, so it must precede the handoff. Only the receipt
             // vault is ownable — the receipt and wrapped vault have no owner,
             // so nothing to hand off for those.
-            vm.broadcast(deployerKey);
             IReceiptVaultAdmin(receiptVault).setAuthorizer(clone);
-            vm.broadcast(deployerKey);
             IReceiptVaultAdmin(receiptVault).transferOwnership(safe);
 
             console2.log("==== TOKEN DEPLOYED ====");
@@ -193,6 +214,8 @@ contract DeployTokensEthereum is Script {
             console2.log("receiptVault:", vm.toString(receiptVault));
             console2.log("wrappedTokenVault:", vm.toString(wrapped));
         }
+
+        vm.stopBroadcast();
 
         console2.log(
             "All tokens deployed, authorised, and handed to the Safe. Hydrate"

--- a/script/20260706-deploy-tokens-ethereum.s.sol
+++ b/script/20260706-deploy-tokens-ethereum.s.sol
@@ -9,6 +9,9 @@ import {
     OffchainAssetReceiptVaultConfigV2
 } from "rain-vats-0.1.6/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
 import {ReceiptVaultConfigV2} from "rain-vats-0.1.6/src/abstract/ReceiptVault.sol";
+import {IReceiptVaultV3} from "rain-vats-0.1.6/src/interface/IReceiptVaultV3.sol";
+import {IAuthorizeV1} from "rain-vats-0.1.6/src/interface/IAuthorizeV1.sol";
+import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
 
 import {LibBeaconInvariants} from "../src/lib/LibBeaconInvariants.sol";
 import {IStoxUnifiedDeployerV1} from "../src/interface/IStoxUnifiedDeployerV1.sol";
@@ -16,16 +19,15 @@ import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
 import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
 import {LibProdTokenConfig, TokenConfig} from "../src/lib/LibProdTokenConfig.sol";
 
-/// @notice The receipt vault surface this script drives from the deploy key
-/// while it is (transiently) the vault owner: point the vault at the V4
-/// authoriser clone, hand ownership to the Safe, and read the vault's ERC-1155
-/// receipt (which the unified deployer's `Deployment` event does not surface,
-/// so it is read back here for the pin). Encoded via the interface so the
-/// calldata is the canonical selector.
-interface IReceiptVaultAdmin {
-    function setAuthorizer(address newAuthorizer) external;
-    function transferOwnership(address newOwner) external;
-    function receipt() external view returns (address);
+/// @dev Local mirror of the receipt-vault `setAuthorizer(IAuthorizeV1)`
+/// owner-gated selector. rain-vats ships no interface carrying it (it lives
+/// only on the concrete `OffchainAssetReceiptVault`), and importing the
+/// concrete would drag its full storage inheritance into this script just to
+/// encode one selector — the same trade the 20260623 swap script makes. The
+/// vault's other two admin surfaces come from canonical homes: `receipt()`
+/// via rain-vats `IReceiptVaultV3`, `transferOwnership` via OZ `Ownable`.
+interface ISetAuthorizer {
+    function setAuthorizer(IAuthorizeV1 newAuthorizer) external;
 }
 
 /// @notice Pre-flight failed: a required deployer contract has no runtime
@@ -198,15 +200,15 @@ contract DeployTokensEthereum is Script {
 
             // The unified deployer's event drops the ERC-1155 receipt, so read
             // it back off the vault for the pin PR to hydrate.
-            address receipt = IReceiptVaultAdmin(receiptVault).receipt();
+            address receipt = address(IReceiptVaultV3(payable(receiptVault)).receipt());
 
             // Wire onto the clone (deploy key is still owner), then relinquish
             // ownership to the Safe. Order matters: `setAuthorizer` is
             // `onlyOwner`, so it must precede the handoff. Only the receipt
             // vault is ownable — the receipt and wrapped vault have no owner,
             // so nothing to hand off for those.
-            IReceiptVaultAdmin(receiptVault).setAuthorizer(clone);
-            IReceiptVaultAdmin(receiptVault).transferOwnership(safe);
+            ISetAuthorizer(receiptVault).setAuthorizer(IAuthorizeV1(clone));
+            Ownable(receiptVault).transferOwnership(safe);
 
             console2.log("==== TOKEN DEPLOYED ====");
             console2.log("underlying:", cfg.underlying);

--- a/script/20260706-deploy-tokens-ethereum.s.sol
+++ b/script/20260706-deploy-tokens-ethereum.s.sol
@@ -5,28 +5,28 @@ pragma solidity =0.8.25;
 import {Script} from "forge-std-1.16.1/src/Script.sol";
 import {console2} from "forge-std-1.16.1/src/console2.sol";
 import {Vm} from "forge-std-1.16.1/src/Vm.sol";
-import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {
     OffchainAssetReceiptVaultConfigV2
 } from "rain-vats-0.1.6/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
 import {ReceiptVaultConfigV2} from "rain-vats-0.1.6/src/abstract/ReceiptVault.sol";
 
 import {IGnosisSafe} from "../src/interface/IGnosisSafe.sol";
-import {IAuthorisable} from "../src/interface/IAuthorisable.sol";
-import {IOwnable} from "../src/interface/IOwnable.sol";
 import {IStoxUnifiedDeployerV1} from "../src/interface/IStoxUnifiedDeployerV1.sol";
 import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
-import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
 import {LibProdDeployCurrent} from "../src/generated/LibProdDeployCurrent.sol";
-import {LibProdAuthoriserClones} from "../src/lib/LibProdAuthoriserClones.sol";
+import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
 import {LibProdTokenConfig, TokenConfig} from "../src/lib/LibProdTokenConfig.sol";
-import {LibTokenInvariants, TokenInstance} from "../src/lib/LibTokenInvariants.sol";
 
-/// @notice Minimal surface for the receipt vault's owner-gated
-/// `setAuthorizer`. Encoded via the interface so the calldata is the
-/// canonical `setAuthorizer(address)` selector.
-interface ISetAuthorizer {
+/// @notice The receipt vault surface this script drives from the deploy key
+/// while it is (transiently) the vault owner: point the vault at the V4
+/// authoriser clone, hand ownership to the Safe, and read the vault's ERC-1155
+/// receipt (which the unified deployer's `Deployment` event does not surface,
+/// so it is read back here for the pin). Encoded via the interface so the
+/// calldata is the canonical selector.
+interface IReceiptVaultAdmin {
     function setAuthorizer(address newAuthorizer) external;
+    function transferOwnership(address newOwner) external;
+    function receipt() external view returns (address);
 }
 
 /// @notice Pre-flight failed: a required deployer contract has no runtime
@@ -35,96 +35,92 @@ interface ISetAuthorizer {
 /// @param deployer The pinned deployer address that is missing.
 error DeployerNotDeployed(address deployer);
 
-/// @notice Pre-flight failed: the Ethereum token table in
-/// `LibTokenInvariants.productionTokensEthereum()` is still placeholders,
-/// so the authorise bundle has no vaults to target. Deploy the tokens
-/// (`run()`) and hydrate the table (pin PR) first.
-error EthereumTokenTableNotHydrated();
-
-/// @notice Pre-flight failed: a receipt vault to be authorised is not
-/// owned by the Ethereum Safe, so the Safe's `setAuthorizer` call would
-/// revert `onlyOwner`. Surfaces the offending vault.
-/// @param vault The receipt vault whose owner is wrong.
-/// @param expectedOwner The Ethereum token-owner Safe.
-/// @param actualOwner The owner actually read on-chain.
-error VaultNotOwnedBySafe(address vault, address expectedOwner, address actualOwner);
-
 /// @notice Pre-flight failed: the pinned Ethereum V4 authoriser clone is
-/// still `address(0)` / has no code / has the wrong codehash. Mirrors the
-/// clone-script guards; a token cannot be authorised onto a clone that
-/// isn't the pinned, deployed one.
+/// still `address(0)` / has no code / has the wrong codehash. A token cannot
+/// be wired onto a clone that isn't the pinned, deployed one.
 /// @param clone The clone address inspected.
 error EthereumCloneNotReady(address clone);
 
 /// @notice Pre-flight failed: the Ethereum token-owner Safe address is not
 /// yet pinned (`address(0)`). The Safe is a distinct per-chain address,
 /// deployed out-of-band and pinned in
-/// `LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM`; nothing can be
-/// authored against it until that address lands.
+/// `LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM`; ownership cannot be
+/// handed to it until that address lands.
 /// @param safe The Safe address inspected (`address(0)` when unpinned).
 error EthereumSafeNotReady(address safe);
 
-/// @notice `verify()` found the pre-emitted authorise bundle does not
-/// match what the live pre-flight would author. Surfaces the first field
-/// that drifted.
-/// @param field The field that diverged (e.g. `"chainId"`, `"to"`,
-/// `"data"`, `"safeTxHash"`, `"txCount"`).
-error VerifyMismatch(string field);
-
 /// @title DeployTokensEthereum
-/// @notice **PENDING.** Deploys the full 20-token ST0x production set on
-/// Ethereum mainnet, matched to Base (RAI-1095), and authors the
-/// authoriser-wiring Safe bundle. Both entrypoints stay red until the
-/// Ethereum core is deployed (`run()`) and the Safe + clone + token table
-/// are live (`authorizeTokens()`). Flips to `**EXECUTED YYYY-MM-DD.**` in
-/// the post-execution pin PR.
-/// @dev Two operations, mirroring the deploy-then-configure split the rest
-/// of the multichain stack uses:
+/// @notice **PENDING.** Deploys the full ST0x production token set on Ethereum
+/// mainnet, matched to Base, wires each vault onto the V4 authoriser
+/// clone, and hands ownership to the token-owner Safe — all in a single
+/// deploy-key broadcast, no Safe signature. Flips to `**EXECUTED YYYY-MM-DD.**`
+/// in the post-execution pin PR.
+/// @dev Single operation (`run()`), broadcast from the CI deploy key via
+/// `manual-broadcast.yaml`. Mirrors the authoriser-clone deploy pattern: the
+/// deploy key deploys, configures, then self-relinquishes — the Safe signs
+/// nothing. Per token, in order:
 ///
-/// - **`run()`** (EOA broadcast) — iterates
-///   `LibProdTokenConfig.productionTokenConfigs()` and calls
-///   `StoxUnifiedDeployer.newTokenAndWrapperVault` once per token with
-///   `initialAdmin` = the Ethereum token-owner Safe and the Base-verbatim
-///   `name` / `symbol`. Each call deploys the receipt vault + wrapped
-///   vault beacon-proxy pair; because `initialAdmin` is the Safe, the
-///   vaults are Safe-owned from block one and the broadcasting EOA never
-///   holds any role. The deterministic addresses are NOT known ahead of
-///   the broadcast (the beacon-set deployer uses nonce-based clones), so
-///   the script logs each deployed `(underlying, receiptVault, wrapped)`
-///   for the post-execution pin PR to hydrate
-///   `LibTokenInvariants.productionTokensEthereum()`.
+///   1. `StoxUnifiedDeployer.newTokenAndWrapperVault` with `initialAdmin` =
+///      the deploy key and the `name`/`symbol` from `LibProdTokenConfig` (the
+///      canonical table captured verbatim from Base). Deploys the receipt
+///      (ERC-1155) + receipt vault + wrapped vault beacon-proxy triple; the
+///      deploy key owns the receipt vault at this point. (The receipt and the
+///      wrapped vault have no owner.)
+///   2. `setAuthorizer(clone)` on the receipt vault — allowed because the
+///      deploy key is (transiently) the owner. Until this lands a fresh vault
+///      is self-authorised and every op reverts, exactly as on Base.
+///   3. `transferOwnership(safe)` on the receipt vault — single-step OZ
+///      `Ownable`, so ownership lands on the Safe with no accept step. After
+///      this the deploy key holds nothing.
 ///
-/// - **`authorizeTokens()`** (Safe Tx Builder bundle) — after the token
-///   table is hydrated, authors a 20-tx bundle of owner-gated
-///   `setAuthorizer(clone)` calls (one per receipt vault) wiring every
-///   vault onto the Ethereum V4 authoriser clone. Freshly-deployed vaults
-///   initialise with themselves as authoriser (every op reverts) until
-///   this lands, exactly as on Base.
+/// The deterministic addresses are NOT known ahead of the broadcast (the
+/// beacon-set deployer uses nonce-based clones), so the script logs each
+/// deployed `(underlying, receipt, receiptVault, wrapped)` for the
+/// post-execution pin PR to hydrate
+/// `LibTokenInvariants.productionTokensEthereum()`. Pre-flight
+/// requires the clone (step 2 target) and the Safe (step 3 target) both live,
+/// so the ordering — Safe out-of-band, then clone, then tokens — is enforced.
 ///
-/// After both run and the token table is hydrated, the cross-chain parity
-/// pin (`StoxCrossChainParity.t.sol`, RAI-1097) is the acceptance test:
-/// name/symbol/decimals equal to Base per underlying, uniform authoriser
-/// (this clone) and owner (this Safe), clean V4 beacon lineage.
-///
-/// See `docs/ETHEREUM_BOOTSTRAP.md` § 7 for where this sits in the runbook.
+/// After execution the cross-chain parity pin (`StoxCrossChainParity.t.sol`)
+/// is the acceptance test: name/symbol equal to the canonical config
+/// per underlying, uniform authoriser (this clone) and owner (this Safe).
 contract DeployTokensEthereum is Script {
-    /// @notice Human-readable authorise-bundle name shown to Safe signers.
-    string internal constant AUTHORIZE_BUNDLE_NAME = "ST0x tokens (Ethereum) - set authoriser on all vaults";
-
-    /// @notice Output path for the authorise-bundle JSON artifact.
-    string internal constant AUTHORIZE_ARTIFACT_PATH = "out/tokens-ethereum-authorize.json";
-
     /// @notice Assert a deployer contract is present at its pinned address.
     /// @param deployer The pinned deployer address.
     function _assertDeployer(address deployer) internal view {
         if (deployer.code.length == 0) revert DeployerNotDeployed(deployer);
     }
 
-    /// @notice Deploy all 20 tokens on the active chain via the unified
-    /// deployer, Safe-owned, matched to Base. EOA broadcast: reads
+    /// @notice The Ethereum token-owner Safe, asserted pinned + policy-aligned
+    /// to Base. Reverts `EthereumSafeNotReady` until the address is hydrated,
+    /// then asserts the live Safe matches Base's shared policy with
+    /// `assertTokenOwnerSafePolicy` (order-insensitive owner set).
+    /// @return safe The validated Ethereum token-owner Safe address.
+    function _assertSafeReady() internal view returns (address safe) {
+        safe = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM;
+        if (safe == address(0)) revert EthereumSafeNotReady(safe);
+        LibSafeInvariants.assertTokenOwnerSafePolicy(IGnosisSafe(safe));
+    }
+
+    /// @notice Assert the Ethereum V4 authoriser clone is deployed at its pin
+    /// with the shared EIP-1167 codehash.
+    /// @return clone The validated clone address.
+    function _assertCloneReady() internal view returns (address clone) {
+        clone = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+        if (
+            clone == address(0) || clone.code.length == 0
+                || clone.codehash != LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
+        ) {
+            revert EthereumCloneNotReady(clone);
+        }
+    }
+
+    /// @notice Deploy every production token on the active chain via the
+    /// unified deployer, wire each onto the V4 authoriser clone, and hand
+    /// ownership to the Safe — one deploy-key broadcast, matched to Base. Reads
     /// `DEPLOYMENT_KEY`. Logs each deployed pair for the pin PR.
     function run() external {
-        // Pre-flight: the unified deployer and both beacon-set deployers it
+        // Pre-flight: the unified deployer + both beacon-set deployers it
         // delegates to must be live at their pinned V4 addresses (bootstrap
         // step 1 broadcast the core suites here).
         address unifiedDeployer = LibProdDeployCurrent.STOX_UNIFIED_DEPLOYER;
@@ -132,24 +128,29 @@ contract DeployTokensEthereum is Script {
         _assertDeployer(LibProdDeployCurrent.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER);
         _assertDeployer(LibProdDeployCurrent.STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER);
 
-        // The Ethereum token-owner Safe (a distinct per-chain address) must be
-        // pinned + policy-aligned to Base before it becomes the admin of all 20
-        // tokens. Asserted after the core pre-flight so a missing core surfaces
-        // first.
-        address safe = address(_assertSafeReady());
+        // The clone (setAuthorizer target) and the Safe (ownership-handoff
+        // target) must both be live before we deploy, since each token is fully
+        // wired in this same broadcast.
+        address clone = _assertCloneReady();
+        address safe = _assertSafeReady();
 
         TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
         uint256 deployerKey = vm.envUint("DEPLOYMENT_KEY");
+        address deployer = vm.addr(deployerKey);
 
         bytes32 deploymentTopic = keccak256("Deployment(address,address,address)");
 
         console2.log("Deploying", configs.length, "tokens on chain id", block.chainid);
-        console2.log("initialAdmin (token-owner Safe):", safe);
+        console2.log("initialAdmin (deploy key, handed to Safe):", deployer);
+        console2.log("token-owner Safe:", safe);
+        console2.log("V4 authoriser clone:", clone);
 
         for (uint256 i = 0; i < configs.length; i++) {
             TokenConfig memory cfg = configs[i];
             OffchainAssetReceiptVaultConfigV2 memory vaultConfig = OffchainAssetReceiptVaultConfigV2({
-                initialAdmin: safe,
+                // The deploy key is the transient owner: it setAuthorizer's the
+                // vault then hands ownership to the Safe, all below.
+                initialAdmin: deployer,
                 receiptVaultConfig: ReceiptVaultConfigV2({
                     asset: address(0), name: cfg.name, symbol: cfg.symbol, receipt: address(0)
                 })
@@ -160,8 +161,7 @@ contract DeployTokensEthereum is Script {
             IStoxUnifiedDeployerV1(unifiedDeployer).newTokenAndWrapperVault(vaultConfig);
 
             // Fish the deployed pair out of the unified deployer's
-            // `Deployment(sender, asset, wrapper)` event so the operator can
-            // hydrate the token table without re-deriving addresses.
+            // `Deployment(sender, asset, wrapper)` event.
             Vm.Log[] memory logs = vm.getRecordedLogs();
             (address receiptVault, address wrapped) = (address(0), address(0));
             for (uint256 j = 0; j < logs.length; j++) {
@@ -173,134 +173,30 @@ contract DeployTokensEthereum is Script {
                 }
             }
 
+            // The unified deployer's event drops the ERC-1155 receipt, so read
+            // it back off the vault for the pin PR to hydrate.
+            address receipt = IReceiptVaultAdmin(receiptVault).receipt();
+
+            // Wire onto the clone (deploy key is still owner), then relinquish
+            // ownership to the Safe. Order matters: `setAuthorizer` is
+            // `onlyOwner`, so it must precede the handoff. Only the receipt
+            // vault is ownable — the receipt and wrapped vault have no owner,
+            // so nothing to hand off for those.
+            vm.broadcast(deployerKey);
+            IReceiptVaultAdmin(receiptVault).setAuthorizer(clone);
+            vm.broadcast(deployerKey);
+            IReceiptVaultAdmin(receiptVault).transferOwnership(safe);
+
             console2.log("==== TOKEN DEPLOYED ====");
             console2.log("underlying:", cfg.underlying);
+            console2.log("receipt (ERC-1155):", vm.toString(receipt));
             console2.log("receiptVault:", vm.toString(receiptVault));
             console2.log("wrappedTokenVault:", vm.toString(wrapped));
         }
 
         console2.log(
-            "All tokens deployed. Hydrate LibTokenInvariants.productionTokensEthereum() from the logged pairs."
+            "All tokens deployed, authorised, and handed to the Safe. Hydrate"
+            " LibTokenInvariants.productionTokensEthereum() from the logged pairs."
         );
-    }
-
-    /// @notice The Ethereum token-owner Safe, asserted pinned + policy-aligned
-    /// to Base. Reverts `EthereumSafeNotReady` until the address is hydrated,
-    /// then asserts the live Safe matches Base's shared policy with
-    /// `assertPolicyMatchesBase` — order-INSENSITIVE on the owner set, because
-    /// this is a distinct per-chain Safe whose `getOwners()` order is
-    /// incidental (the matched-address approach was abandoned).
-    /// @return safe The validated Ethereum token-owner Safe.
-    function _assertSafeReady() internal view returns (IGnosisSafe safe) {
-        address safeAddr = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM;
-        if (safeAddr == address(0)) {
-            revert EthereumSafeNotReady(safeAddr);
-        }
-        safe = IGnosisSafe(safeAddr);
-        LibSafeInvariants.assertPolicyMatchesBase(safe);
-    }
-
-    /// @notice Assert the Ethereum V4 authoriser clone is deployed at its
-    /// pin with the shared EIP-1167 codehash.
-    /// @return clone The validated clone address.
-    function _assertCloneReady() internal view returns (address clone) {
-        clone = LibProdAuthoriserClones.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
-        if (
-            clone == address(0) || clone.code.length == 0
-                || clone.codehash != LibProdAuthoriserClones.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
-        ) {
-            revert EthereumCloneNotReady(clone);
-        }
-    }
-
-    /// @notice Read the hydrated Ethereum receipt vaults, asserting the
-    /// table is fully hydrated and every vault is Safe-owned (so the
-    /// owner-gated `setAuthorizer` will not revert on execution).
-    /// @param safe The Ethereum token-owner Safe.
-    /// @return vaults The 20 receipt vault addresses.
-    function _hydratedReceiptVaults(address safe) internal view returns (address[] memory vaults) {
-        TokenInstance[] memory tokens = LibTokenInvariants.productionTokensEthereum();
-        vaults = new address[](tokens.length);
-        for (uint256 i = 0; i < tokens.length; i++) {
-            address vault = tokens[i].receiptVault;
-            if (vault == address(0) || vault.code.length == 0) revert EthereumTokenTableNotHydrated();
-            address owner = IOwnable(vault).owner();
-            if (owner != safe) revert VaultNotOwnedBySafe(vault, safe, owner);
-            vaults[i] = vault;
-        }
-    }
-
-    /// @notice Build the canonical `setAuthorizer(clone)` bundle for the
-    /// supplied vaults. Factored out so `authorizeTokens()` and `verify()`
-    /// author byte-identical bundles.
-    /// @param vaults The receipt vaults to authorise.
-    /// @param clone The Ethereum V4 authoriser clone.
-    /// @return txs The setAuthorizer transactions.
-    function _buildAuthorizeTxs(address[] memory vaults, address clone) internal pure returns (SafeTx[] memory txs) {
-        txs = new SafeTx[](vaults.length);
-        for (uint256 i = 0; i < vaults.length; i++) {
-            txs[i] = SafeTx({
-                to: vaults[i], value: 0, data: abi.encodeCall(ISetAuthorizer.setAuthorizer, (clone)), operation: 0
-            });
-        }
-    }
-
-    /// @notice Author the Safe bundle that wires every Ethereum receipt
-    /// vault onto the Ethereum V4 authoriser clone. Simulates each call and
-    /// asserts the post-state, then emits the Tx Builder JSON + SafeTxHash.
-    function authorizeTokens() external {
-        IGnosisSafe safe = _assertSafeReady();
-
-        address clone = _assertCloneReady();
-        address[] memory vaults = _hydratedReceiptVaults(address(safe));
-        SafeTx[] memory txs = _buildAuthorizeTxs(vaults, clone);
-
-        uint256 nonce = safe.nonce();
-        bytes32 safeTxHash = LibSafeOps.computeMultiSendSafeTxHash(safe, txs, nonce);
-
-        // Simulate each setAuthorizer via the Safe; nonce is not advanced.
-        for (uint256 i = 0; i < txs.length; i++) {
-            LibSafeOps.simulateExternalCall(safe, txs[i].to, txs[i].data);
-        }
-
-        // Post-state: every vault now points at the clone.
-        for (uint256 i = 0; i < vaults.length; i++) {
-            require(IAuthorisable(vaults[i]).authorizer() == clone, "post-state: vault.authorizer() != clone");
-        }
-
-        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, AUTHORIZE_BUNDLE_NAME, txs);
-        vm.writeFile(AUTHORIZE_ARTIFACT_PATH, json);
-
-        console2.log("==== TX BUILDER JSON BEGIN ====");
-        console2.log(json);
-        console2.log("==== TX BUILDER JSON END ====");
-        console2.log("SafeTxHash:", vm.toString(safeTxHash));
-        console2.log("Nonce:", nonce);
-    }
-
-    /// @notice Re-run the authorise-bundle pre-flight and assert a
-    /// pre-emitted artifact matches what the live pre-flight would author.
-    /// Used by signers to confirm the artifact wasn't tampered with.
-    /// @param jsonPath Filesystem path to the Tx Builder JSON to verify.
-    function verify(string calldata jsonPath) external view {
-        IGnosisSafe safe = _assertSafeReady();
-
-        address clone = _assertCloneReady();
-        address[] memory vaults = _hydratedReceiptVaults(address(safe));
-        SafeTx[] memory expected = _buildAuthorizeTxs(vaults, clone);
-
-        (uint256 parsedChainId, address parsedTo, SafeTx[] memory parsedTxs) = LibSafeOps.parseTxBuilderJson(jsonPath);
-        if (parsedChainId != block.chainid) revert VerifyMismatch("chainId");
-        if (parsedTxs.length != expected.length) revert VerifyMismatch("txCount");
-        if (parsedTo != expected[0].to) revert VerifyMismatch("to");
-        for (uint256 i = 0; i < expected.length; i++) {
-            if (parsedTxs[i].to != expected[i].to) revert VerifyMismatch("to");
-            if (parsedTxs[i].value != expected[i].value) revert VerifyMismatch("value");
-            if (keccak256(parsedTxs[i].data) != keccak256(expected[i].data)) revert VerifyMismatch("data");
-        }
-
-        bytes32 liveHash = LibSafeOps.computeMultiSendSafeTxHash(safe, expected, safe.nonce());
-        bytes32 artifactHash = LibSafeOps.computeMultiSendSafeTxHash(safe, parsedTxs, safe.nonce());
-        if (liveHash != artifactHash) revert VerifyMismatch("safeTxHash");
     }
 }

--- a/script/20260706-deploy-tokens-ethereum.s.sol
+++ b/script/20260706-deploy-tokens-ethereum.s.sol
@@ -17,7 +17,6 @@ import {IOwnable} from "../src/interface/IOwnable.sol";
 import {IStoxUnifiedDeployerV1} from "../src/interface/IStoxUnifiedDeployerV1.sol";
 import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
 import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
-import {LibChainPrincipals, ChainPrincipals} from "../src/lib/LibChainPrincipals.sol";
 import {LibProdDeployCurrent} from "../src/generated/LibProdDeployCurrent.sol";
 import {LibProdAuthoriserClones} from "../src/lib/LibProdAuthoriserClones.sol";
 import {LibProdTokenConfig, TokenConfig} from "../src/lib/LibProdTokenConfig.sol";
@@ -107,15 +106,6 @@ contract DeployTokensEthereum is Script {
     /// @notice Output path for the authorise-bundle JSON artifact.
     string internal constant AUTHORIZE_ARTIFACT_PATH = "out/tokens-ethereum-authorize.json";
 
-    /// @notice The Ethereum principals — concrete pins (matched-address
-    /// Safe + shared signer). The Safe's on-chain existence + policy
-    /// alignment is the real gate, asserted by the full Safe invariant in
-    /// `authorizeTokens()` / `verify()`, not by the principals.
-    /// @return principals The Ethereum principals.
-    function _principals() internal pure returns (ChainPrincipals memory principals) {
-        principals = LibChainPrincipals.ethereum();
-    }
-
     /// @notice Assert a deployer contract is present at its pinned address.
     /// @param deployer The pinned deployer address.
     function _assertDeployer(address deployer) internal view {
@@ -126,8 +116,9 @@ contract DeployTokensEthereum is Script {
     /// deployer, Safe-owned, matched to Base. EOA broadcast: reads
     /// `DEPLOYMENT_KEY`. Logs each deployed pair for the pin PR.
     function run() external {
-        ChainPrincipals memory principals = _principals();
-        address safe = principals.tokenOwnerSafe;
+        // The token-owner Safe is shared across chains (matched-address
+        // deploy), so it is the same pin Base uses.
+        address safe = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE;
 
         // Pre-flight: the unified deployer and both beacon-set deployers it
         // delegates to must be live at their pinned V4 addresses (bootstrap
@@ -232,8 +223,7 @@ contract DeployTokensEthereum is Script {
     /// vault onto the Ethereum V4 authoriser clone. Simulates each call and
     /// asserts the post-state, then emits the Tx Builder JSON + SafeTxHash.
     function authorizeTokens() external {
-        ChainPrincipals memory principals = _principals();
-        IGnosisSafe safe = IGnosisSafe(principals.tokenOwnerSafe);
+        IGnosisSafe safe = IGnosisSafe(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
         LibSafeInvariants.assertAll(safe);
 
         address clone = _assertCloneReady();
@@ -268,8 +258,7 @@ contract DeployTokensEthereum is Script {
     /// Used by signers to confirm the artifact wasn't tampered with.
     /// @param jsonPath Filesystem path to the Tx Builder JSON to verify.
     function verify(string calldata jsonPath) external view {
-        ChainPrincipals memory principals = _principals();
-        IGnosisSafe safe = IGnosisSafe(principals.tokenOwnerSafe);
+        IGnosisSafe safe = IGnosisSafe(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
         LibSafeInvariants.assertAll(safe);
 
         address clone = _assertCloneReady();

--- a/script/20260706-deploy-tokens-ethereum.s.sol
+++ b/script/20260706-deploy-tokens-ethereum.s.sol
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
+import {
+    OffchainAssetReceiptVaultConfigV2
+} from "rain-vats-0.1.6/src/concrete/deploy/OffchainAssetReceiptVaultBeaconSetDeployer.sol";
+import {ReceiptVaultConfigV2} from "rain-vats-0.1.6/src/abstract/ReceiptVault.sol";
+
+import {IGnosisSafe} from "../src/interface/IGnosisSafe.sol";
+import {IAuthorisable} from "../src/interface/IAuthorisable.sol";
+import {IOwnable} from "../src/interface/IOwnable.sol";
+import {IStoxUnifiedDeployerV1} from "../src/interface/IStoxUnifiedDeployerV1.sol";
+import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
+import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
+import {LibChainPrincipals, ChainPrincipals} from "../src/lib/LibChainPrincipals.sol";
+import {LibProdDeployCurrent} from "../src/generated/LibProdDeployCurrent.sol";
+import {LibProdAuthoriserClones} from "../src/lib/LibProdAuthoriserClones.sol";
+import {LibProdTokenConfig, TokenConfig} from "../src/lib/LibProdTokenConfig.sol";
+import {LibTokenInvariants, TokenInstance} from "../src/lib/LibTokenInvariants.sol";
+
+/// @notice Minimal surface for the receipt vault's owner-gated
+/// `setAuthorizer`. Encoded via the interface so the calldata is the
+/// canonical `setAuthorizer(address)` selector.
+interface ISetAuthorizer {
+    function setAuthorizer(address newAuthorizer) external;
+}
+
+/// @notice Pre-flight failed: a required deployer contract has no runtime
+/// code at its pinned V4 address on the active fork — the core V4 suites
+/// have not been broadcast to this chain yet (bootstrap step 1).
+/// @param deployer The pinned deployer address that is missing.
+error DeployerNotDeployed(address deployer);
+
+/// @notice Pre-flight failed: the Ethereum token table in
+/// `LibTokenInvariants.productionTokensEthereum()` is still placeholders,
+/// so the authorise bundle has no vaults to target. Deploy the tokens
+/// (`run()`) and hydrate the table (pin PR) first.
+error EthereumTokenTableNotHydrated();
+
+/// @notice Pre-flight failed: a receipt vault to be authorised is not
+/// owned by the Ethereum Safe, so the Safe's `setAuthorizer` call would
+/// revert `onlyOwner`. Surfaces the offending vault.
+/// @param vault The receipt vault whose owner is wrong.
+/// @param expectedOwner The Ethereum token-owner Safe.
+/// @param actualOwner The owner actually read on-chain.
+error VaultNotOwnedBySafe(address vault, address expectedOwner, address actualOwner);
+
+/// @notice Pre-flight failed: the pinned Ethereum V4 authoriser clone is
+/// still `address(0)` / has no code / has the wrong codehash. Mirrors the
+/// clone-script guards; a token cannot be authorised onto a clone that
+/// isn't the pinned, deployed one.
+/// @param clone The clone address inspected.
+error EthereumCloneNotReady(address clone);
+
+/// @notice `verify()` found the pre-emitted authorise bundle does not
+/// match what the live pre-flight would author. Surfaces the first field
+/// that drifted.
+/// @param field The field that diverged (e.g. `"chainId"`, `"to"`,
+/// `"data"`, `"safeTxHash"`, `"txCount"`).
+error VerifyMismatch(string field);
+
+/// @title DeployTokensEthereum
+/// @notice **PENDING.** Deploys the full 20-token ST0x production set on
+/// Ethereum mainnet, matched to Base (RAI-1095), and authors the
+/// authoriser-wiring Safe bundle. Both entrypoints stay red until the
+/// Ethereum core is deployed (`run()`) and the Safe + clone + token table
+/// are live (`authorizeTokens()`). Flips to `**EXECUTED YYYY-MM-DD.**` in
+/// the post-execution pin PR.
+/// @dev Two operations, mirroring the deploy-then-configure split the rest
+/// of the multichain stack uses:
+///
+/// - **`run()`** (EOA broadcast) — iterates
+///   `LibProdTokenConfig.productionTokenConfigs()` and calls
+///   `StoxUnifiedDeployer.newTokenAndWrapperVault` once per token with
+///   `initialAdmin` = the Ethereum token-owner Safe and the Base-verbatim
+///   `name` / `symbol`. Each call deploys the receipt vault + wrapped
+///   vault beacon-proxy pair; because `initialAdmin` is the Safe, the
+///   vaults are Safe-owned from block one and the broadcasting EOA never
+///   holds any role. The deterministic addresses are NOT known ahead of
+///   the broadcast (the beacon-set deployer uses nonce-based clones), so
+///   the script logs each deployed `(underlying, receiptVault, wrapped)`
+///   for the post-execution pin PR to hydrate
+///   `LibTokenInvariants.productionTokensEthereum()`.
+///
+/// - **`authorizeTokens()`** (Safe Tx Builder bundle) — after the token
+///   table is hydrated, authors a 20-tx bundle of owner-gated
+///   `setAuthorizer(clone)` calls (one per receipt vault) wiring every
+///   vault onto the Ethereum V4 authoriser clone. Freshly-deployed vaults
+///   initialise with themselves as authoriser (every op reverts) until
+///   this lands, exactly as on Base.
+///
+/// After both run and the token table is hydrated, the cross-chain parity
+/// pin (`StoxCrossChainParity.t.sol`, RAI-1097) is the acceptance test:
+/// name/symbol/decimals equal to Base per underlying, uniform authoriser
+/// (this clone) and owner (this Safe), clean V4 beacon lineage.
+///
+/// See `docs/ETHEREUM_BOOTSTRAP.md` § 7 for where this sits in the runbook.
+contract DeployTokensEthereum is Script {
+    /// @notice Human-readable authorise-bundle name shown to Safe signers.
+    string internal constant AUTHORIZE_BUNDLE_NAME = "ST0x tokens (Ethereum) - set authoriser on all vaults";
+
+    /// @notice Output path for the authorise-bundle JSON artifact.
+    string internal constant AUTHORIZE_ARTIFACT_PATH = "out/tokens-ethereum-authorize.json";
+
+    /// @notice The Ethereum principals — concrete pins (matched-address
+    /// Safe + shared signer). The Safe's on-chain existence + policy
+    /// alignment is the real gate, asserted by the full Safe invariant in
+    /// `authorizeTokens()` / `verify()`, not by the principals.
+    /// @return principals The Ethereum principals.
+    function _principals() internal pure returns (ChainPrincipals memory principals) {
+        principals = LibChainPrincipals.ethereum();
+    }
+
+    /// @notice Assert a deployer contract is present at its pinned address.
+    /// @param deployer The pinned deployer address.
+    function _assertDeployer(address deployer) internal view {
+        if (deployer.code.length == 0) revert DeployerNotDeployed(deployer);
+    }
+
+    /// @notice Deploy all 20 tokens on the active chain via the unified
+    /// deployer, Safe-owned, matched to Base. EOA broadcast: reads
+    /// `DEPLOYMENT_KEY`. Logs each deployed pair for the pin PR.
+    function run() external {
+        ChainPrincipals memory principals = _principals();
+        address safe = principals.tokenOwnerSafe;
+
+        // Pre-flight: the unified deployer and both beacon-set deployers it
+        // delegates to must be live at their pinned V4 addresses (bootstrap
+        // step 1 broadcast the core suites here).
+        address unifiedDeployer = LibProdDeployCurrent.STOX_UNIFIED_DEPLOYER;
+        _assertDeployer(unifiedDeployer);
+        _assertDeployer(LibProdDeployCurrent.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER);
+        _assertDeployer(LibProdDeployCurrent.STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER);
+
+        TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
+        uint256 deployerKey = vm.envUint("DEPLOYMENT_KEY");
+
+        bytes32 deploymentTopic = keccak256("Deployment(address,address,address)");
+
+        console2.log("Deploying", configs.length, "tokens on chain id", block.chainid);
+        console2.log("initialAdmin (token-owner Safe):", safe);
+
+        for (uint256 i = 0; i < configs.length; i++) {
+            TokenConfig memory cfg = configs[i];
+            OffchainAssetReceiptVaultConfigV2 memory vaultConfig = OffchainAssetReceiptVaultConfigV2({
+                initialAdmin: safe,
+                receiptVaultConfig: ReceiptVaultConfigV2({
+                    asset: address(0), name: cfg.name, symbol: cfg.symbol, receipt: address(0)
+                })
+            });
+
+            vm.recordLogs();
+            vm.broadcast(deployerKey);
+            IStoxUnifiedDeployerV1(unifiedDeployer).newTokenAndWrapperVault(vaultConfig);
+
+            // Fish the deployed pair out of the unified deployer's
+            // `Deployment(sender, asset, wrapper)` event so the operator can
+            // hydrate the token table without re-deriving addresses.
+            Vm.Log[] memory logs = vm.getRecordedLogs();
+            (address receiptVault, address wrapped) = (address(0), address(0));
+            for (uint256 j = 0; j < logs.length; j++) {
+                if (
+                    logs[j].emitter == unifiedDeployer && logs[j].topics.length > 0
+                        && logs[j].topics[0] == deploymentTopic
+                ) {
+                    (, receiptVault, wrapped) = abi.decode(logs[j].data, (address, address, address));
+                }
+            }
+
+            console2.log("==== TOKEN DEPLOYED ====");
+            console2.log("underlying:", cfg.underlying);
+            console2.log("receiptVault:", vm.toString(receiptVault));
+            console2.log("wrappedTokenVault:", vm.toString(wrapped));
+        }
+
+        console2.log(
+            "All tokens deployed. Hydrate LibTokenInvariants.productionTokensEthereum() from the logged pairs."
+        );
+    }
+
+    /// @notice Assert the Ethereum V4 authoriser clone is deployed at its
+    /// pin with the shared EIP-1167 codehash.
+    /// @return clone The validated clone address.
+    function _assertCloneReady() internal view returns (address clone) {
+        clone = LibProdAuthoriserClones.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+        if (
+            clone == address(0) || clone.code.length == 0
+                || clone.codehash != LibProdAuthoriserClones.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
+        ) {
+            revert EthereumCloneNotReady(clone);
+        }
+    }
+
+    /// @notice Read the hydrated Ethereum receipt vaults, asserting the
+    /// table is fully hydrated and every vault is Safe-owned (so the
+    /// owner-gated `setAuthorizer` will not revert on execution).
+    /// @param safe The Ethereum token-owner Safe.
+    /// @return vaults The 20 receipt vault addresses.
+    function _hydratedReceiptVaults(address safe) internal view returns (address[] memory vaults) {
+        TokenInstance[] memory tokens = LibTokenInvariants.productionTokensEthereum();
+        vaults = new address[](tokens.length);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            address vault = tokens[i].receiptVault;
+            if (vault == address(0) || vault.code.length == 0) revert EthereumTokenTableNotHydrated();
+            address owner = IOwnable(vault).owner();
+            if (owner != safe) revert VaultNotOwnedBySafe(vault, safe, owner);
+            vaults[i] = vault;
+        }
+    }
+
+    /// @notice Build the canonical `setAuthorizer(clone)` bundle for the
+    /// supplied vaults. Factored out so `authorizeTokens()` and `verify()`
+    /// author byte-identical bundles.
+    /// @param vaults The receipt vaults to authorise.
+    /// @param clone The Ethereum V4 authoriser clone.
+    /// @return txs The setAuthorizer transactions.
+    function _buildAuthorizeTxs(address[] memory vaults, address clone) internal pure returns (SafeTx[] memory txs) {
+        txs = new SafeTx[](vaults.length);
+        for (uint256 i = 0; i < vaults.length; i++) {
+            txs[i] = SafeTx({
+                to: vaults[i], value: 0, data: abi.encodeCall(ISetAuthorizer.setAuthorizer, (clone)), operation: 0
+            });
+        }
+    }
+
+    /// @notice Author the Safe bundle that wires every Ethereum receipt
+    /// vault onto the Ethereum V4 authoriser clone. Simulates each call and
+    /// asserts the post-state, then emits the Tx Builder JSON + SafeTxHash.
+    function authorizeTokens() external {
+        ChainPrincipals memory principals = _principals();
+        IGnosisSafe safe = IGnosisSafe(principals.tokenOwnerSafe);
+        LibSafeInvariants.assertAll(safe);
+
+        address clone = _assertCloneReady();
+        address[] memory vaults = _hydratedReceiptVaults(address(safe));
+        SafeTx[] memory txs = _buildAuthorizeTxs(vaults, clone);
+
+        uint256 nonce = safe.nonce();
+        bytes32 safeTxHash = LibSafeOps.computeMultiSendSafeTxHash(safe, txs, nonce);
+
+        // Simulate each setAuthorizer via the Safe; nonce is not advanced.
+        for (uint256 i = 0; i < txs.length; i++) {
+            LibSafeOps.simulateExternalCall(safe, txs[i].to, txs[i].data);
+        }
+
+        // Post-state: every vault now points at the clone.
+        for (uint256 i = 0; i < vaults.length; i++) {
+            require(IAuthorisable(vaults[i]).authorizer() == clone, "post-state: vault.authorizer() != clone");
+        }
+
+        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, AUTHORIZE_BUNDLE_NAME, txs);
+        vm.writeFile(AUTHORIZE_ARTIFACT_PATH, json);
+
+        console2.log("==== TX BUILDER JSON BEGIN ====");
+        console2.log(json);
+        console2.log("==== TX BUILDER JSON END ====");
+        console2.log("SafeTxHash:", vm.toString(safeTxHash));
+        console2.log("Nonce:", nonce);
+    }
+
+    /// @notice Re-run the authorise-bundle pre-flight and assert a
+    /// pre-emitted artifact matches what the live pre-flight would author.
+    /// Used by signers to confirm the artifact wasn't tampered with.
+    /// @param jsonPath Filesystem path to the Tx Builder JSON to verify.
+    function verify(string calldata jsonPath) external view {
+        ChainPrincipals memory principals = _principals();
+        IGnosisSafe safe = IGnosisSafe(principals.tokenOwnerSafe);
+        LibSafeInvariants.assertAll(safe);
+
+        address clone = _assertCloneReady();
+        address[] memory vaults = _hydratedReceiptVaults(address(safe));
+        SafeTx[] memory expected = _buildAuthorizeTxs(vaults, clone);
+
+        (uint256 parsedChainId, address parsedTo, SafeTx[] memory parsedTxs) = LibSafeOps.parseTxBuilderJson(jsonPath);
+        if (parsedChainId != block.chainid) revert VerifyMismatch("chainId");
+        if (parsedTxs.length != expected.length) revert VerifyMismatch("txCount");
+        if (parsedTo != expected[0].to) revert VerifyMismatch("to");
+        for (uint256 i = 0; i < expected.length; i++) {
+            if (parsedTxs[i].to != expected[i].to) revert VerifyMismatch("to");
+            if (parsedTxs[i].value != expected[i].value) revert VerifyMismatch("value");
+            if (keccak256(parsedTxs[i].data) != keccak256(expected[i].data)) revert VerifyMismatch("data");
+        }
+
+        bytes32 liveHash = LibSafeOps.computeMultiSendSafeTxHash(safe, expected, safe.nonce());
+        bytes32 artifactHash = LibSafeOps.computeMultiSendSafeTxHash(safe, parsedTxs, safe.nonce());
+        if (liveHash != artifactHash) revert VerifyMismatch("safeTxHash");
+    }
+}

--- a/script/20260706-deploy-tokens-ethereum.s.sol
+++ b/script/20260706-deploy-tokens-ethereum.s.sol
@@ -36,11 +36,11 @@ interface ISetAuthorizer {
 /// @param deployer The pinned deployer address that is missing.
 error DeployerNotDeployed(address deployer);
 
-/// @notice Pre-flight failed: the pinned Ethereum V4 authoriser clone is
-/// still `address(0)` / has no code / has the wrong codehash. A token cannot
-/// be wired onto a clone that isn't the pinned, deployed one.
-/// @param clone The clone address inspected.
-error EthereumCloneNotReady(address clone);
+/// @notice Pre-flight failed: the pinned Ethereum V4 authoriser is still
+/// `address(0)` / has no code / has the wrong codehash. A token cannot be
+/// wired onto an authoriser that isn't the pinned, deployed one.
+/// @param authoriser The authoriser address inspected.
+error EthereumAuthoriserNotReady(address authoriser);
 
 /// @notice Pre-flight failed: the active chain's resolved token-owner Safe is
 /// not the pinned ETHEREUM Safe. Either the script was dispatched against a
@@ -53,11 +53,11 @@ error EthereumSafeNotReady(address safe);
 /// @title DeployTokensEthereum
 /// @notice **PENDING.** Deploys the full ST0x production token set on Ethereum
 /// mainnet, matched to Base, wires each vault onto the V4 authoriser
-/// clone, and hands ownership to the token-owner Safe — all in a single
+/// authoriser, and hands ownership to the token-owner Safe — all in a single
 /// deploy-key broadcast, no Safe signature. Flips to `**EXECUTED YYYY-MM-DD.**`
 /// in the post-execution pin PR.
 /// @dev Single operation (`run()`), broadcast from the CI deploy key via
-/// `manual-broadcast.yaml`. Mirrors the authoriser-clone deploy pattern: the
+/// `manual-broadcast.yaml`. Mirrors the authoriser deploy pattern (20260619): the
 /// deploy key deploys, configures, then self-relinquishes — the Safe signs
 /// nothing. Per token, in order:
 ///
@@ -67,7 +67,7 @@ error EthereumSafeNotReady(address safe);
 ///      (ERC-1155) + receipt vault + wrapped vault beacon-proxy triple; the
 ///      deploy key owns the receipt vault at this point. (The receipt and the
 ///      wrapped vault have no owner.)
-///   2. `setAuthorizer(clone)` on the receipt vault — allowed because the
+///   2. `setAuthorizer(authoriser)` on the receipt vault — allowed because the
 ///      deploy key is (transiently) the owner. Until this lands a fresh vault
 ///      is self-authorised and every op reverts, exactly as on Base.
 ///   3. `transferOwnership(safe)` on the receipt vault — single-step OZ
@@ -79,12 +79,12 @@ error EthereumSafeNotReady(address safe);
 /// deployed `(underlying, receipt, receiptVault, wrapped)` for the
 /// post-execution pin PR to hydrate
 /// `LibTokenInvariants.productionTokensEthereum()`. Pre-flight
-/// requires the clone (step 2 target) and the Safe (step 3 target) both live,
-/// so the ordering — Safe out-of-band, then clone, then tokens — is enforced.
+/// requires the authoriser (step 2 target) and the Safe (step 3 target) both live,
+/// so the ordering — Safe out-of-band, then authoriser, then tokens — is enforced.
 ///
 /// After execution the cross-chain parity pin (`StoxCrossChainParity.t.sol`)
 /// is the acceptance test: name/symbol equal to the canonical config
-/// per underlying, uniform authoriser (this clone) and owner (this Safe).
+/// per underlying, uniform authoriser (this V4 authoriser) and owner (this Safe).
 contract DeployTokensEthereum is Script {
     /// @notice Assert a deployer contract is present at its pinned address.
     /// @param deployer The pinned deployer address.
@@ -106,21 +106,22 @@ contract DeployTokensEthereum is Script {
         }
     }
 
-    /// @notice Assert the Ethereum V4 authoriser clone is deployed at its pin
-    /// with the shared EIP-1167 codehash.
-    /// @return clone The validated clone address.
-    function _assertCloneReady() internal view returns (address clone) {
-        clone = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+    /// @notice Assert the Ethereum V4 authoriser is deployed at its pin with
+    /// the shared EIP-1167 codehash (the authoriser is deployed as a clone of
+    /// the deterministic V4 impl, hence the `_CLONE` pin names).
+    /// @return authoriser The validated authoriser address.
+    function _assertAuthoriserReady() internal view returns (address authoriser) {
+        authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
         if (
-            clone == address(0) || clone.code.length == 0
-                || clone.codehash != LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
+            authoriser == address(0) || authoriser.code.length == 0
+                || authoriser.codehash != LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
         ) {
-            revert EthereumCloneNotReady(clone);
+            revert EthereumAuthoriserNotReady(authoriser);
         }
     }
 
     /// @notice Deploy every production token on the active chain via the
-    /// unified deployer, wire each onto the V4 authoriser clone, and hand
+    /// unified deployer, wire each onto the V4 authoriser, and hand
     /// ownership to the Safe — one deploy-key broadcast, matched to Base.
     /// Broadcasts as the key `manual-broadcast.yaml` supplies via
     /// `--private-key` (the same CI deploy key every operational broadcast
@@ -147,10 +148,10 @@ contract DeployTokensEthereum is Script {
         // per-chain prod pin (`StoxProdV4`) runs on every CI commit.
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
 
-        // The clone (setAuthorizer target) and the Safe (ownership-handoff
-        // target) must both be live before we deploy, since each token is fully
-        // wired in this same broadcast.
-        address clone = _assertCloneReady();
+        // The authoriser (setAuthorizer target) and the Safe (ownership-
+        // handoff target) must both be live before we deploy, since each
+        // token is fully wired in this same broadcast.
+        address authoriser = _assertAuthoriserReady();
         address safe = _assertSafeReady();
 
         TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
@@ -169,7 +170,7 @@ contract DeployTokensEthereum is Script {
         console2.log("Deploying", configs.length, "tokens on chain id", block.chainid);
         console2.log("initialAdmin (deploy key, handed to Safe):", deployer);
         console2.log("token-owner Safe:", safe);
-        console2.log("V4 authoriser clone:", clone);
+        console2.log("V4 authoriser:", authoriser);
 
         for (uint256 i = 0; i < configs.length; i++) {
             TokenConfig memory cfg = configs[i];
@@ -202,12 +203,12 @@ contract DeployTokensEthereum is Script {
             // it back off the vault for the pin PR to hydrate.
             address receipt = address(IReceiptVaultV3(payable(receiptVault)).receipt());
 
-            // Wire onto the clone (deploy key is still owner), then relinquish
+            // Wire onto the authoriser (deploy key is still owner), then relinquish
             // ownership to the Safe. Order matters: `setAuthorizer` is
             // `onlyOwner`, so it must precede the handoff. Only the receipt
             // vault is ownable — the receipt and wrapped vault have no owner,
             // so nothing to hand off for those.
-            ISetAuthorizer(receiptVault).setAuthorizer(IAuthorizeV1(clone));
+            ISetAuthorizer(receiptVault).setAuthorizer(IAuthorizeV1(authoriser));
             Ownable(receiptVault).transferOwnership(safe);
 
             console2.log("==== TOKEN DEPLOYED ====");

--- a/script/20260706-deploy-tokens-ethereum.s.sol
+++ b/script/20260706-deploy-tokens-ethereum.s.sol
@@ -56,6 +56,14 @@ error VaultNotOwnedBySafe(address vault, address expectedOwner, address actualOw
 /// @param clone The clone address inspected.
 error EthereumCloneNotReady(address clone);
 
+/// @notice Pre-flight failed: the Ethereum token-owner Safe address is not
+/// yet pinned (`address(0)`). The Safe is a distinct per-chain address,
+/// deployed out-of-band and pinned in
+/// `LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM`; nothing can be
+/// authored against it until that address lands.
+/// @param safe The Safe address inspected (`address(0)` when unpinned).
+error EthereumSafeNotReady(address safe);
+
 /// @notice `verify()` found the pre-emitted authorise bundle does not
 /// match what the live pre-flight would author. Surfaces the first field
 /// that drifted.
@@ -116,10 +124,6 @@ contract DeployTokensEthereum is Script {
     /// deployer, Safe-owned, matched to Base. EOA broadcast: reads
     /// `DEPLOYMENT_KEY`. Logs each deployed pair for the pin PR.
     function run() external {
-        // The token-owner Safe is shared across chains (matched-address
-        // deploy), so it is the same pin Base uses.
-        address safe = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE;
-
         // Pre-flight: the unified deployer and both beacon-set deployers it
         // delegates to must be live at their pinned V4 addresses (bootstrap
         // step 1 broadcast the core suites here).
@@ -127,6 +131,12 @@ contract DeployTokensEthereum is Script {
         _assertDeployer(unifiedDeployer);
         _assertDeployer(LibProdDeployCurrent.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER);
         _assertDeployer(LibProdDeployCurrent.STOX_WRAPPED_TOKEN_VAULT_BEACON_SET_DEPLOYER);
+
+        // The Ethereum token-owner Safe (a distinct per-chain address) must be
+        // pinned + policy-aligned to Base before it becomes the admin of all 20
+        // tokens. Asserted after the core pre-flight so a missing core surfaces
+        // first.
+        address safe = address(_assertSafeReady());
 
         TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
         uint256 deployerKey = vm.envUint("DEPLOYMENT_KEY");
@@ -172,6 +182,22 @@ contract DeployTokensEthereum is Script {
         console2.log(
             "All tokens deployed. Hydrate LibTokenInvariants.productionTokensEthereum() from the logged pairs."
         );
+    }
+
+    /// @notice The Ethereum token-owner Safe, asserted pinned + policy-aligned
+    /// to Base. Reverts `EthereumSafeNotReady` until the address is hydrated,
+    /// then asserts the live Safe matches Base's shared policy with
+    /// `assertPolicyMatchesBase` — order-INSENSITIVE on the owner set, because
+    /// this is a distinct per-chain Safe whose `getOwners()` order is
+    /// incidental (the matched-address approach was abandoned).
+    /// @return safe The validated Ethereum token-owner Safe.
+    function _assertSafeReady() internal view returns (IGnosisSafe safe) {
+        address safeAddr = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM;
+        if (safeAddr == address(0)) {
+            revert EthereumSafeNotReady(safeAddr);
+        }
+        safe = IGnosisSafe(safeAddr);
+        LibSafeInvariants.assertPolicyMatchesBase(safe);
     }
 
     /// @notice Assert the Ethereum V4 authoriser clone is deployed at its
@@ -223,8 +249,7 @@ contract DeployTokensEthereum is Script {
     /// vault onto the Ethereum V4 authoriser clone. Simulates each call and
     /// asserts the post-state, then emits the Tx Builder JSON + SafeTxHash.
     function authorizeTokens() external {
-        IGnosisSafe safe = IGnosisSafe(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
-        LibSafeInvariants.assertAll(safe);
+        IGnosisSafe safe = _assertSafeReady();
 
         address clone = _assertCloneReady();
         address[] memory vaults = _hydratedReceiptVaults(address(safe));
@@ -258,8 +283,7 @@ contract DeployTokensEthereum is Script {
     /// Used by signers to confirm the artifact wasn't tampered with.
     /// @param jsonPath Filesystem path to the Tx Builder JSON to verify.
     function verify(string calldata jsonPath) external view {
-        IGnosisSafe safe = IGnosisSafe(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
-        LibSafeInvariants.assertAll(safe);
+        IGnosisSafe safe = _assertSafeReady();
 
         address clone = _assertCloneReady();
         address[] memory vaults = _hydratedReceiptVaults(address(safe));

--- a/script/20260706-deploy-tokens-ethereum.s.sol
+++ b/script/20260706-deploy-tokens-ethereum.s.sol
@@ -18,6 +18,7 @@ import {IStoxUnifiedDeployerV1} from "../src/interface/IStoxUnifiedDeployerV1.so
 import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
 import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
 import {LibProdTokenConfig, TokenConfig} from "../src/lib/LibProdTokenConfig.sol";
+import {LibTokenInvariants, TokenInstance} from "../src/lib/LibTokenInvariants.sol";
 
 /// @dev Local mirror of the receipt-vault `setAuthorizer(IAuthorizeV1)`
 /// owner-gated selector. rain-vats ships no interface carrying it (it lives
@@ -28,6 +29,7 @@ import {LibProdTokenConfig, TokenConfig} from "../src/lib/LibProdTokenConfig.sol
 /// via rain-vats `IReceiptVaultV3`, `transferOwnership` via OZ `Ownable`.
 interface ISetAuthorizer {
     function setAuthorizer(IAuthorizeV1 newAuthorizer) external;
+    function authorizer() external view returns (address);
 }
 
 /// @notice Pre-flight failed: a required deployer contract has no runtime
@@ -41,6 +43,35 @@ error DeployerNotDeployed(address deployer);
 /// wired onto an authoriser that isn't the pinned, deployed one.
 /// @param authoriser The authoriser address inspected.
 error EthereumAuthoriserNotReady(address authoriser);
+
+/// @notice Pre-flight failed: this chain's token table is already hydrated, so
+/// the tokens have been deployed. Re-running would deploy a SECOND full set —
+/// nonce-based clones, so fresh addresses indistinguishable from the real ones
+/// except by deploy order — and hand them to the Safe as though they were
+/// production. Once hydrated, the script is done for that chain.
+/// @param firstPinned The first non-zero address found in the table.
+error EthereumTokensAlreadyDeployed(address firstPinned);
+
+/// @notice The unified deployer emitted no `Deployment` event this iteration,
+/// so there is no address to wire or hand over. Named rather than left to
+/// fault on a zero address, because it happens MID-BROADCAST with earlier
+/// tokens already live.
+/// @param underlying The token whose deployment could not be resolved.
+error DeploymentEventMissing(string underlying);
+
+/// @notice A freshly deployed vault did not end up owned by the Safe. A vault
+/// still owned by the deploy key is a production contract under a CI key.
+/// @param receiptVault The vault whose ownership did not land.
+/// @param expected The Safe ownership should have transferred to.
+/// @param actual The owner actually recorded.
+error OwnershipHandoffFailed(address receiptVault, address expected, address actual);
+
+/// @notice A freshly deployed vault is not wired to the pinned authoriser.
+/// Until it is, every operation on the vault reverts.
+/// @param receiptVault The vault inspected.
+/// @param expected The authoriser it should route to.
+/// @param actual The authoriser actually set.
+error AuthoriserNotWired(address receiptVault, address expected, address actual);
 
 /// @notice Pre-flight failed: the active chain's resolved token-owner Safe is
 /// not the pinned ETHEREUM Safe. Either the script was dispatched against a
@@ -106,6 +137,55 @@ contract DeployTokensEthereum is Script {
         }
     }
 
+    /// @notice Refuse to run once this chain's token table carries any pinned
+    /// address. The table records what a previous run produced, so a hydrated
+    /// entry means the deploy already happened. Without this the only thing
+    /// between a re-dispatch and 28 duplicate production tokens is a human
+    /// reading a dropdown that says outright it lists which scripts exist, not
+    /// which have run.
+    function _assertNotAlreadyDeployed() internal pure {
+        assertTableVirgin(LibTokenInvariants.productionTokensEthereum());
+    }
+
+    /// @notice The run-once check itself, over a supplied table so it can be
+    /// exercised against a HYDRATED one. A guard that can only ever be called
+    /// with the shipped placeholders can be shown not to fire and never shown
+    /// to fire, which is the half that matters.
+    /// @param pinned The token table to inspect.
+    function assertTableVirgin(TokenInstance[] memory pinned) public pure {
+        for (uint256 i = 0; i < pinned.length; i++) {
+            if (pinned[i].receiptVault != address(0)) {
+                revert EthereumTokensAlreadyDeployed(pinned[i].receiptVault);
+            }
+            if (pinned[i].receipt != address(0)) {
+                revert EthereumTokensAlreadyDeployed(pinned[i].receipt);
+            }
+            if (pinned[i].wrappedTokenVault != address(0)) {
+                revert EthereumTokensAlreadyDeployed(pinned[i].wrappedTokenVault);
+            }
+        }
+    }
+
+    /// @notice Read back both writes made to a freshly deployed vault. Each
+    /// token is wired and handed over in the same broadcast, so a silent miss
+    /// leaves a live production vault either inoperable or owned by a CI key —
+    /// and the acceptance test that would catch it does not run until the pin
+    /// PR lands. Public so it can be driven directly: an assertion reachable
+    /// only from inside a broadcast loop cannot be shown to fire.
+    /// @param receiptVault The vault just deployed.
+    /// @param expectedAuthoriser The authoriser it must route to.
+    /// @param expectedSafe The Safe ownership must have landed on.
+    function assertHandoffLanded(address receiptVault, address expectedAuthoriser, address expectedSafe) public view {
+        address wiredAuthoriser = ISetAuthorizer(receiptVault).authorizer();
+        if (wiredAuthoriser != expectedAuthoriser) {
+            revert AuthoriserNotWired(receiptVault, expectedAuthoriser, wiredAuthoriser);
+        }
+        address landedOwner = Ownable(receiptVault).owner();
+        if (landedOwner != expectedSafe) {
+            revert OwnershipHandoffFailed(receiptVault, expectedSafe, landedOwner);
+        }
+    }
+
     /// @notice Assert the Ethereum V4 authoriser is deployed at its pin with
     /// the shared EIP-1167 codehash (the authoriser is deployed as a clone of
     /// the deterministic V4 impl, hence the `_CLONE` pin names).
@@ -136,6 +216,10 @@ contract DeployTokensEthereum is Script {
         // `LibBeaconInvariants`). The current tag's deployer is a different
         // Zoltu address that (a) is not deployed on Ethereum and (b) would
         // wire tokens onto a different, unadopted beacon set even if it were.
+        // Run-once, before anything else: the cheapest gate, and the only one
+        // whose failure mode is duplicate production tokens rather than a revert.
+        _assertNotAlreadyDeployed();
+
         address unifiedDeployer = LibProdDeployV4.STOX_UNIFIED_DEPLOYER_0_1_1;
         _assertDeployer(unifiedDeployer);
         _assertDeployer(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_0_1_1);
@@ -199,6 +283,8 @@ contract DeployTokensEthereum is Script {
                 }
             }
 
+            if (receiptVault == address(0)) revert DeploymentEventMissing(cfg.underlying);
+
             // The unified deployer's event drops the ERC-1155 receipt, so read
             // it back off the vault for the pin PR to hydrate.
             address receipt = address(IReceiptVaultV3(payable(receiptVault)).receipt());
@@ -210,6 +296,7 @@ contract DeployTokensEthereum is Script {
             // so nothing to hand off for those.
             ISetAuthorizer(receiptVault).setAuthorizer(IAuthorizeV1(authoriser));
             Ownable(receiptVault).transferOwnership(safe);
+            assertHandoffLanded(receiptVault, authoriser, safe);
 
             console2.log("==== TOKEN DEPLOYED ====");
             console2.log("underlying:", cfg.underlying);

--- a/test/script/20260706-deploy-tokens-ethereum.t.sol
+++ b/test/script/20260706-deploy-tokens-ethereum.t.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {
+    DeployTokensEthereum,
+    DeployerNotDeployed,
+    EthereumCloneNotReady
+} from "../../script/20260706-deploy-tokens-ethereum.s.sol";
+import {LibProdDeployCurrent} from "../../src/generated/LibProdDeployCurrent.sol";
+import {LibProdAuthoriserClones} from "../../src/lib/LibProdAuthoriserClones.sol";
+import {LibSafeInvariants, SafeProxyCodehashMismatch} from "../../src/lib/LibSafeInvariants.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
+
+/// @title DeployTokensEthereumTest
+/// @notice Inverted pre-flight coverage for the Ethereum token-deploy
+/// script. The happy path needs the full V4 core + a live, policy-aligned
+/// Ethereum Safe + a hydrated clone pin + a hydrated token table, none of
+/// which exist until the bootstrap executes — so the value here is proving
+/// each forcing-function fires in order, keeping the script red until its
+/// upstream state settles (OPERATIONAL_SCRIPTS.md § forcing-function
+/// pattern). The later guards (token-table hydration, per-vault ownership)
+/// cannot be tripped until the clone + tokens are pinned; this suite flips
+/// to cover them once those pins land.
+contract DeployTokensEthereumTest is Test {
+    DeployTokensEthereum internal script;
+
+    function setUp() external {
+        script = new DeployTokensEthereum();
+        // Persist across `createSelectFork` so the Base-fork tests can still
+        // call into the script (a fork switch otherwise leaves its address
+        // code-less on the new fork state).
+        vm.makePersistent(address(script));
+    }
+
+    /// `run()` reverts `DeployerNotDeployed` when the V4 core has not been
+    /// broadcast to the active chain — the unified deployer's pinned address
+    /// has no code, so no token can be deployed. (No fork: the deployer is
+    /// absent, which is the pre-bootstrap Ethereum state.)
+    function testRunRevertsWhenCoreNotDeployed() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(DeployerNotDeployed.selector, LibProdDeployCurrent.STOX_UNIFIED_DEPLOYER)
+        );
+        script.run();
+    }
+
+    /// `authorizeTokens()` reverts through the Safe invariant when the
+    /// Ethereum Safe is not live: with no fork the matched Safe address has
+    /// no code, so the pinned-proxy-codehash check trips first. This is the
+    /// forcing function that blocks authoring the bundle before the Safe is
+    /// deployed + policy-aligned to Base.
+    function testAuthorizeTokensRevertsWhenSafeNotLive() external {
+        vm.expectPartialRevert(SafeProxyCodehashMismatch.selector);
+        script.authorizeTokens();
+    }
+
+    /// On a Base fork the "Ethereum" Safe IS present — it is the SAME
+    /// address as the Base token-owner Safe (matched-address Safe) and it is
+    /// live + policy-aligned — so the Safe invariant passes and the NEXT
+    /// forcing function trips: the Ethereum authoriser clone pin is still the
+    /// `address(0)` placeholder. This directly exercises the matched-address
+    /// property AND the clone forcing function in one path.
+    function testAuthorizeTokensRevertsWhenClonePlaceholderOnBaseFork() external {
+        vm.createSelectFork(LibRainDeploy.BASE);
+        // Precondition the test relies on: the Ethereum clone pin is still a
+        // placeholder (flips this test to the next guard once hydrated).
+        require(
+            LibProdAuthoriserClones.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM == address(0),
+            "Ethereum clone pin hydrated - advance this test to the token-table guard"
+        );
+        vm.expectRevert(abi.encodeWithSelector(EthereumCloneNotReady.selector, address(0)));
+        script.authorizeTokens();
+    }
+
+    /// `verify()` shares the same pre-flight ordering, so on a Base fork it
+    /// too clears the Safe invariant and trips on the placeholder clone pin.
+    function testVerifyRevertsWhenClonePlaceholderOnBaseFork() external {
+        vm.createSelectFork(LibRainDeploy.BASE);
+        require(
+            LibProdAuthoriserClones.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM == address(0),
+            "Ethereum clone pin hydrated - advance this test"
+        );
+        vm.expectRevert(abi.encodeWithSelector(EthereumCloneNotReady.selector, address(0)));
+        script.verify("out/tokens-ethereum-authorize.json");
+    }
+}

--- a/test/script/20260706-deploy-tokens-ethereum.t.sol
+++ b/test/script/20260706-deploy-tokens-ethereum.t.sol
@@ -4,34 +4,61 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {DeployTokensEthereum, DeployerNotDeployed} from "../../script/20260706-deploy-tokens-ethereum.s.sol";
-import {LibProdDeployCurrent} from "../../src/generated/LibProdDeployCurrent.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+import {LibAuthoriserInvariants, RoleGrant} from "../../src/lib/LibAuthoriserInvariants.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
+import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
 
 /// @title DeployTokensEthereumTest
-/// @notice Inverted pre-flight coverage for the Ethereum token-deploy script.
-/// The happy path needs the full V4 core + a live, policy-aligned Ethereum
-/// Safe + a hydrated clone pin, none of which exist until the bootstrap
-/// executes — so the value here is proving the first forcing function fires,
-/// keeping the script red until its upstream state settles
-/// (OPERATIONAL_SCRIPTS.md § forcing-function pattern). `run()` is now a single
-/// deploy-key broadcast (deploy → setAuthorizer → transferOwnership to the
-/// Safe), so there is one entrypoint and one pre-flight chain: core deployers,
-/// then the clone (setAuthorizer target), then the Safe (handoff target).
+/// @notice Pre-flight coverage for the Ethereum token-deploy script, on the
+/// forcing-function pattern (OPERATIONAL_SCRIPTS.md): the happy path cannot
+/// complete until every upstream dependency has landed, so the tests prove
+/// each gate fires in order — and, critically, prove the gates that SHOULD
+/// pass against live Ethereum actually do, on every CI run. `run()` is a
+/// single deploy-key broadcast (deploy → setAuthorizer → transferOwnership to
+/// the Safe), so there is one entrypoint and one pre-flight chain: core
+/// 0.1.1 deployers, in-use beacon ownership, then the clone (setAuthorizer
+/// target), then the Safe (handoff target).
 contract DeployTokensEthereumTest is Test {
-    DeployTokensEthereum internal script;
-
-    function setUp() external {
-        script = new DeployTokensEthereum();
-    }
-
-    /// `run()` reverts `DeployerNotDeployed` when the V4 core has not been
+    /// `run()` reverts `DeployerNotDeployed` when the 0.1.1 core has not been
     /// broadcast to the active chain — the unified deployer's pinned address
     /// has no code, so no token can be deployed. (No fork: the deployer is
-    /// absent, which is the pre-bootstrap Ethereum state, and is the first
-    /// guard in the pre-flight chain.)
+    /// absent, which is the pre-bootstrap state, and is the first guard in
+    /// the pre-flight chain.)
     function testRunRevertsWhenCoreNotDeployed() external {
+        DeployTokensEthereum script = new DeployTokensEthereum();
         vm.expectRevert(
-            abi.encodeWithSelector(DeployerNotDeployed.selector, LibProdDeployCurrent.STOX_UNIFIED_DEPLOYER)
+            abi.encodeWithSelector(DeployerNotDeployed.selector, LibProdDeployV4.STOX_UNIFIED_DEPLOYER_0_1_1)
         );
         script.run();
+    }
+
+    /// The hydrated clone pin matches LIVE Ethereum: the V4 authoriser
+    /// clone (deployed 2026-07-22) is at the pinned address with the shared
+    /// EIP-1167 codehash and carries the full grant map parameterised on
+    /// ETHEREUM's Safe. With this green the script's `_assertCloneReady` +
+    /// grant expectations are proven against real chain state on every CI
+    /// run. `run()` itself is not driven here: under `forge test`,
+    /// `vm.startBroadcast` cannot emulate the broadcast sender the way
+    /// `forge script` does (the same limitation the 20260619 suite
+    /// documents), so the end-to-end simulation lives in the
+    /// `manual-broadcast` dry-run instead.
+    function testEthereumClonePinMatchesLive() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
+        address clone = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+        assertTrue(clone.code.length > 0, "Ethereum V4 authoriser clone not deployed at pin");
+        assertEq(
+            clone.codehash, LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH, "Ethereum clone codehash mismatch"
+        );
+
+        RoleGrant[] memory grants =
+            LibAuthoriserInvariants.expectedGrants(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM);
+        for (uint256 i = 0; i < grants.length; i++) {
+            assertTrue(
+                IAccessControl(clone).hasRole(grants[i].role, grants[i].grantee),
+                "Ethereum clone missing expected grant"
+            );
+        }
     }
 }

--- a/test/script/20260706-deploy-tokens-ethereum.t.sol
+++ b/test/script/20260706-deploy-tokens-ethereum.t.sol
@@ -6,32 +6,28 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {
     DeployTokensEthereum,
     DeployerNotDeployed,
-    EthereumCloneNotReady
+    EthereumSafeNotReady
 } from "../../script/20260706-deploy-tokens-ethereum.s.sol";
 import {LibProdDeployCurrent} from "../../src/generated/LibProdDeployCurrent.sol";
-import {LibProdAuthoriserClones} from "../../src/lib/LibProdAuthoriserClones.sol";
-import {LibSafeInvariants, SafeProxyCodehashMismatch} from "../../src/lib/LibSafeInvariants.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 
 /// @title DeployTokensEthereumTest
-/// @notice Inverted pre-flight coverage for the Ethereum token-deploy
-/// script. The happy path needs the full V4 core + a live, policy-aligned
-/// Ethereum Safe + a hydrated clone pin + a hydrated token table, none of
-/// which exist until the bootstrap executes — so the value here is proving
-/// each forcing-function fires in order, keeping the script red until its
-/// upstream state settles (OPERATIONAL_SCRIPTS.md § forcing-function
-/// pattern). The later guards (token-table hydration, per-vault ownership)
-/// cannot be tripped until the clone + tokens are pinned; this suite flips
-/// to cover them once those pins land.
+/// @notice Inverted pre-flight coverage for the Ethereum token-deploy script.
+/// The happy path needs the full V4 core + a live, policy-aligned Ethereum
+/// Safe + a hydrated clone pin + a hydrated token table, none of which exist
+/// until the bootstrap executes — so the value here is proving each
+/// forcing-function fires in order, keeping the script red until its upstream
+/// state settles (OPERATIONAL_SCRIPTS.md § forcing-function pattern).
+///
+/// The first two guards fire before Ethereum carries any state: the V4 core
+/// must be deployed, then the Ethereum token-owner Safe — a DISTINCT per-chain
+/// address — must be pinned. The later guards (clone pin, token-table
+/// hydration, per-vault ownership) sit behind the Safe pin and cannot be
+/// tripped until it lands; this suite flips to cover them once it does.
 contract DeployTokensEthereumTest is Test {
     DeployTokensEthereum internal script;
 
     function setUp() external {
         script = new DeployTokensEthereum();
-        // Persist across `createSelectFork` so the Base-fork tests can still
-        // call into the script (a fork switch otherwise leaves its address
-        // code-less on the new fork state).
-        vm.makePersistent(address(script));
     }
 
     /// `run()` reverts `DeployerNotDeployed` when the V4 core has not been
@@ -45,43 +41,20 @@ contract DeployTokensEthereumTest is Test {
         script.run();
     }
 
-    /// `authorizeTokens()` reverts through the Safe invariant when the
-    /// Ethereum Safe is not live: with no fork the matched Safe address has
-    /// no code, so the pinned-proxy-codehash check trips first. This is the
-    /// forcing function that blocks authoring the bundle before the Safe is
-    /// deployed + policy-aligned to Base.
-    function testAuthorizeTokensRevertsWhenSafeNotLive() external {
-        vm.expectPartialRevert(SafeProxyCodehashMismatch.selector);
+    /// `authorizeTokens()` reverts `EthereumSafeNotReady` while the Ethereum
+    /// token-owner Safe address is unpinned (`address(0)`). The Safe is a
+    /// distinct per-chain address deployed out-of-band; until it is pinned,
+    /// there is no Safe to author the setAuthorizer bundle against. This is the
+    /// forcing function that blocks the bundle before the Safe exists.
+    function testAuthorizeTokensRevertsWhenSafeNotReady() external {
+        vm.expectRevert(abi.encodeWithSelector(EthereumSafeNotReady.selector, address(0)));
         script.authorizeTokens();
     }
 
-    /// On a Base fork the "Ethereum" Safe IS present — it is the SAME
-    /// address as the Base token-owner Safe (matched-address Safe) and it is
-    /// live + policy-aligned — so the Safe invariant passes and the NEXT
-    /// forcing function trips: the Ethereum authoriser clone pin is still the
-    /// `address(0)` placeholder. This directly exercises the matched-address
-    /// property AND the clone forcing function in one path.
-    function testAuthorizeTokensRevertsWhenClonePlaceholderOnBaseFork() external {
-        vm.createSelectFork(LibRainDeploy.BASE);
-        // Precondition the test relies on: the Ethereum clone pin is still a
-        // placeholder (flips this test to the next guard once hydrated).
-        require(
-            LibProdAuthoriserClones.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM == address(0),
-            "Ethereum clone pin hydrated - advance this test to the token-table guard"
-        );
-        vm.expectRevert(abi.encodeWithSelector(EthereumCloneNotReady.selector, address(0)));
-        script.authorizeTokens();
-    }
-
-    /// `verify()` shares the same pre-flight ordering, so on a Base fork it
-    /// too clears the Safe invariant and trips on the placeholder clone pin.
-    function testVerifyRevertsWhenClonePlaceholderOnBaseFork() external {
-        vm.createSelectFork(LibRainDeploy.BASE);
-        require(
-            LibProdAuthoriserClones.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM == address(0),
-            "Ethereum clone pin hydrated - advance this test"
-        );
-        vm.expectRevert(abi.encodeWithSelector(EthereumCloneNotReady.selector, address(0)));
+    /// `verify()` shares the same Safe pre-flight, so it too reverts
+    /// `EthereumSafeNotReady` until the Safe address is pinned.
+    function testVerifyRevertsWhenSafeNotReady() external {
+        vm.expectRevert(abi.encodeWithSelector(EthereumSafeNotReady.selector, address(0)));
         script.verify("out/tokens-ethereum-authorize.json");
     }
 }

--- a/test/script/20260706-deploy-tokens-ethereum.t.sol
+++ b/test/script/20260706-deploy-tokens-ethereum.t.sol
@@ -3,7 +3,15 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {DeployTokensEthereum, DeployerNotDeployed} from "../../script/20260706-deploy-tokens-ethereum.s.sol";
+import {
+    DeployTokensEthereum,
+    DeployerNotDeployed,
+    EthereumTokensAlreadyDeployed,
+    AuthoriserNotWired,
+    OwnershipHandoffFailed
+} from "../../script/20260706-deploy-tokens-ethereum.s.sol";
+import {LibTokenInvariants, TokenInstance} from "../../src/lib/LibTokenInvariants.sol";
+import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 import {LibAuthoriserInvariants, RoleGrant} from "../../src/lib/LibAuthoriserInvariants.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
@@ -32,6 +40,83 @@ contract DeployTokensEthereumTest is Test {
             abi.encodeWithSelector(DeployerNotDeployed.selector, LibProdDeployV4.STOX_UNIFIED_DEPLOYER_0_1_1)
         );
         script.run();
+    }
+
+    /// The guard fires on a hydrated table — the half that matters. A
+    /// re-dispatch after a successful deploy has every dependency satisfied,
+    /// so nothing else would stop it minting a second full production set.
+    function testRunOnceGateFiresOnAHydratedTable() external {
+        DeployTokensEthereum script = new DeployTokensEthereum();
+        TokenInstance[] memory table = LibTokenInvariants.productionTokensEthereum();
+        table[7] = TokenInstance("SPYM", address(0), address(0xBEEF), address(0));
+        vm.expectRevert(abi.encodeWithSelector(EthereumTokensAlreadyDeployed.selector, address(0xBEEF)));
+        script.assertTableVirgin(table);
+    }
+
+    /// Each leg trips it independently. A guard reading only `receiptVault`
+    /// would miss a table hydrated receipt-first — which is what a broadcast
+    /// that failed midway leaves behind.
+    function testRunOnceGateInspectsEveryLeg() external {
+        DeployTokensEthereum script = new DeployTokensEthereum();
+        for (uint256 leg = 0; leg < 3; leg++) {
+            TokenInstance[] memory table = LibTokenInvariants.productionTokensEthereum();
+            address hydrated = address(uint160(0xC0DE + leg));
+            table[27] = TokenInstance(
+                "TTWO",
+                leg == 0 ? hydrated : address(0),
+                leg == 1 ? hydrated : address(0),
+                leg == 2 ? hydrated : address(0)
+            );
+            vm.expectRevert(abi.encodeWithSelector(EthereumTokensAlreadyDeployed.selector, hydrated));
+            script.assertTableVirgin(table);
+        }
+    }
+
+    /// It does NOT fire on the shipped placeholders, or the deploy could never
+    /// run and the two tests above would be vacuous.
+    function testRunOnceGatePassesOnTheShippedTable() external {
+        DeployTokensEthereum script = new DeployTokensEthereum();
+        script.assertTableVirgin(LibTokenInvariants.productionTokensEthereum());
+    }
+
+    /// Ownership that did not land on the Safe is caught: otherwise the
+    /// broadcast finishes "successfully" leaving a production vault owned by
+    /// the CI deploy key.
+    function testHandoffCaughtWhenOwnershipDidNotLand() external {
+        DeployTokensEthereum script = new DeployTokensEthereum();
+        address vault = address(0x1A17);
+        address safe = address(0x5AFE);
+        address auth = address(0xA077);
+        address stray = address(0xDEADBEEF);
+        vm.mockCall(vault, abi.encodeWithSignature("authorizer()"), abi.encode(auth));
+        vm.mockCall(vault, abi.encodeWithSelector(Ownable.owner.selector), abi.encode(stray));
+        vm.expectRevert(abi.encodeWithSelector(OwnershipHandoffFailed.selector, vault, safe, stray));
+        script.assertHandoffLanded(vault, auth, safe);
+    }
+
+    /// A vault left on the wrong authoriser is caught — until setAuthorizer
+    /// lands, every operation on the vault reverts.
+    function testHandoffCaughtWhenAuthoriserNotWired() external {
+        DeployTokensEthereum script = new DeployTokensEthereum();
+        address vault = address(0x1A17);
+        address safe = address(0x5AFE);
+        address auth = address(0xA077);
+        address wrong = address(0xBAD);
+        vm.mockCall(vault, abi.encodeWithSignature("authorizer()"), abi.encode(wrong));
+        vm.mockCall(vault, abi.encodeWithSelector(Ownable.owner.selector), abi.encode(safe));
+        vm.expectRevert(abi.encodeWithSelector(AuthoriserNotWired.selector, vault, auth, wrong));
+        script.assertHandoffLanded(vault, auth, safe);
+    }
+
+    /// Both landed passes, so the two above are not vacuous.
+    function testHandoffPassesWhenBothLanded() external {
+        DeployTokensEthereum script = new DeployTokensEthereum();
+        address vault = address(0x1A17);
+        address safe = address(0x5AFE);
+        address auth = address(0xA077);
+        vm.mockCall(vault, abi.encodeWithSignature("authorizer()"), abi.encode(auth));
+        vm.mockCall(vault, abi.encodeWithSelector(Ownable.owner.selector), abi.encode(safe));
+        script.assertHandoffLanded(vault, auth, safe);
     }
 
     /// The hydrated clone pin matches LIVE Ethereum: the V4 authoriser

--- a/test/script/20260706-deploy-tokens-ethereum.t.sol
+++ b/test/script/20260706-deploy-tokens-ethereum.t.sol
@@ -3,26 +3,19 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {
-    DeployTokensEthereum,
-    DeployerNotDeployed,
-    EthereumSafeNotReady
-} from "../../script/20260706-deploy-tokens-ethereum.s.sol";
+import {DeployTokensEthereum, DeployerNotDeployed} from "../../script/20260706-deploy-tokens-ethereum.s.sol";
 import {LibProdDeployCurrent} from "../../src/generated/LibProdDeployCurrent.sol";
 
 /// @title DeployTokensEthereumTest
 /// @notice Inverted pre-flight coverage for the Ethereum token-deploy script.
 /// The happy path needs the full V4 core + a live, policy-aligned Ethereum
-/// Safe + a hydrated clone pin + a hydrated token table, none of which exist
-/// until the bootstrap executes — so the value here is proving each
-/// forcing-function fires in order, keeping the script red until its upstream
-/// state settles (OPERATIONAL_SCRIPTS.md § forcing-function pattern).
-///
-/// The first two guards fire before Ethereum carries any state: the V4 core
-/// must be deployed, then the Ethereum token-owner Safe — a DISTINCT per-chain
-/// address — must be pinned. The later guards (clone pin, token-table
-/// hydration, per-vault ownership) sit behind the Safe pin and cannot be
-/// tripped until it lands; this suite flips to cover them once it does.
+/// Safe + a hydrated clone pin, none of which exist until the bootstrap
+/// executes — so the value here is proving the first forcing function fires,
+/// keeping the script red until its upstream state settles
+/// (OPERATIONAL_SCRIPTS.md § forcing-function pattern). `run()` is now a single
+/// deploy-key broadcast (deploy → setAuthorizer → transferOwnership to the
+/// Safe), so there is one entrypoint and one pre-flight chain: core deployers,
+/// then the clone (setAuthorizer target), then the Safe (handoff target).
 contract DeployTokensEthereumTest is Test {
     DeployTokensEthereum internal script;
 
@@ -33,28 +26,12 @@ contract DeployTokensEthereumTest is Test {
     /// `run()` reverts `DeployerNotDeployed` when the V4 core has not been
     /// broadcast to the active chain — the unified deployer's pinned address
     /// has no code, so no token can be deployed. (No fork: the deployer is
-    /// absent, which is the pre-bootstrap Ethereum state.)
+    /// absent, which is the pre-bootstrap Ethereum state, and is the first
+    /// guard in the pre-flight chain.)
     function testRunRevertsWhenCoreNotDeployed() external {
         vm.expectRevert(
             abi.encodeWithSelector(DeployerNotDeployed.selector, LibProdDeployCurrent.STOX_UNIFIED_DEPLOYER)
         );
         script.run();
-    }
-
-    /// `authorizeTokens()` reverts `EthereumSafeNotReady` while the Ethereum
-    /// token-owner Safe address is unpinned (`address(0)`). The Safe is a
-    /// distinct per-chain address deployed out-of-band; until it is pinned,
-    /// there is no Safe to author the setAuthorizer bundle against. This is the
-    /// forcing function that blocks the bundle before the Safe exists.
-    function testAuthorizeTokensRevertsWhenSafeNotReady() external {
-        vm.expectRevert(abi.encodeWithSelector(EthereumSafeNotReady.selector, address(0)));
-        script.authorizeTokens();
-    }
-
-    /// `verify()` shares the same Safe pre-flight, so it too reverts
-    /// `EthereumSafeNotReady` until the Safe address is pinned.
-    function testVerifyRevertsWhenSafeNotReady() external {
-        vm.expectRevert(abi.encodeWithSelector(EthereumSafeNotReady.selector, address(0)));
-        script.verify("out/tokens-ethereum-authorize.json");
     }
 }

--- a/test/script/20260706-deploy-tokens-ethereum.t.sol
+++ b/test/script/20260706-deploy-tokens-ethereum.t.sol
@@ -37,7 +37,7 @@ contract DeployTokensEthereumTest is Test {
     /// The hydrated clone pin matches LIVE Ethereum: the V4 authoriser
     /// clone (deployed 2026-07-22) is at the pinned address with the shared
     /// EIP-1167 codehash and carries the full grant map parameterised on
-    /// ETHEREUM's Safe. With this green the script's `_assertCloneReady` +
+    /// ETHEREUM's Safe. With this green the script's `_assertAuthoriserReady` +
     /// grant expectations are proven against real chain state on every CI
     /// run. `run()` itself is not driven here: under `forge test`,
     /// `vm.startBroadcast` cannot emulate the broadcast sender the way


### PR DESCRIPTION
Stands up the full ST0x production token set on Ethereum in a single
deploy-key broadcast, matched to Base — no Safe signature required.

- **`20260706-deploy-tokens-ethereum.s.sol`** — one operation (`run()`),
  broadcast from the CI deploy key. Mirrors the authoriser-clone deploy
  pattern: the deploy key deploys, configures, then self-relinquishes. Per
  token, in order:
  1. `StoxUnifiedDeployer.newTokenAndWrapperVault` with `initialAdmin` = the
     deploy key and the Base-verbatim name/symbol — the deploy key transiently
     owns the receipt vault (the wrapped vault has no owner).
  2. `setAuthorizer(clone)` on the receipt vault while the key is still owner.
  3. `transferOwnership(Safe)` — single-step OZ `Ownable`, so ownership lands
     on the Safe with no accept step. The deploy key then holds nothing.

  Pre-flight requires the core deployers, the V4 authoriser clone (the
  `setAuthorizer` target) and the Safe (the handoff target) all live, so the
  bootstrap order (Safe → clone → tokens) is enforced. Deployed addresses are
  nonce-based (not known ahead), so it logs each `(underlying, receiptVault,
  wrapped)` for the post-execution pin PR to hydrate
  `productionTokensEthereum()`.

- Name/symbol come from the canonical `LibProdTokenConfig` (introduced in the
  branch below), validated against live Base — SGOV's leading-space name and
  all — so the tokens reproduce Base byte-identically.

- **Workflow** — listed in `manual-broadcast.yaml` (the deploy-key broadcast
  dispatcher), targeting the chosen `network`. It is NOT a Safe-artifact
  script, so it is not in `run-script.yaml`.

Pre-flight guard test fires while the pins are pending; red until the Ethereum
Safe + clone are live, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPs1hCTxusmaSeFKvoc4Kr