### PR TITLE
fix(deploy): unbreak main compile — rename stale authoriser constants after #222

### DIFF
--- a/script/20260619-deploy-v4-authoriser-clone.s.sol
+++ b/script/20260619-deploy-v4-authoriser-clone.s.sol
@@ -31,7 +31,7 @@ error V4ImplNotDeployed(address impl);
 /// non-canonical contract is squatting the address or that the Zoltu
 /// deploy emitted different bytecode than the lib expects.
 /// @param impl The V4 impl address inspected.
-/// @param expected The pinned codehash (`STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_CODEHASH_RAIN_VATS_0_1_6`).
+/// @param expected The pinned codehash (`STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_CODEHASH_0_1_1`).
 /// @param actual The codehash observed at `impl`.
 error V4ImplCodehashMismatch(address impl, bytes32 expected, bytes32 actual);
 
@@ -289,7 +289,7 @@ contract DeployV4AuthoriserClone is Script {
         // if it isn't there or has the wrong code, the clone would
         // either fail to initialize or initialize against attacker
         // code.
-        address v4Impl = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6;
+        address v4Impl = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1;
         assertV4ImplDeployed(v4Impl);
 
         // Pre-flight: the canonical CloneFactory is deployed with the
@@ -494,7 +494,7 @@ contract DeployV4AuthoriserClone is Script {
     /// @param parsedTo The `transactions[0].to` reported by the parser.
     /// @param parsedTxs The parsed transactions array (length == 1).
     function verifyDeployBundle(IGnosisSafe safe, address parsedTo, SafeTx[] memory parsedTxs) internal view {
-        address v4Impl = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6;
+        address v4Impl = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1;
         assertV4ImplDeployed(v4Impl);
 
         address factoryAddr = LibCloneFactoryDeploy.CLONE_FACTORY_DEPLOYED_ADDRESS;
@@ -607,7 +607,7 @@ contract DeployV4AuthoriserClone is Script {
     function assertV4ImplDeployed(address impl) internal view {
         if (impl.code.length == 0) revert V4ImplNotDeployed(impl);
         bytes32 actual = impl.codehash;
-        bytes32 expected = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_CODEHASH_RAIN_VATS_0_1_6;
+        bytes32 expected = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_CODEHASH_0_1_1;
         if (actual != expected) revert V4ImplCodehashMismatch(impl, expected, actual);
     }
 

--- a/test/script/20260619-deploy-v4-authoriser-clone.t.sol
+++ b/test/script/20260619-deploy-v4-authoriser-clone.t.sol
@@ -85,7 +85,7 @@ contract DeployV4AuthoriserCloneTest is Test {
         safe = IGnosisSafe(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
         StoxOffchainAssetReceiptVaultAuthorizerV1 impl = new StoxOffchainAssetReceiptVaultAuthorizerV1();
         v4ImplRuntime = address(impl).code;
-        vm.etch(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6, v4ImplRuntime);
+        vm.etch(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1, v4ImplRuntime);
     }
 
     /// @notice `run()` dry-run completes against the live pre-state, writes
@@ -192,7 +192,7 @@ contract DeployV4AuthoriserCloneTest is Test {
         // the fork's state slot and the revert may or may not preserve
         // it depending on whether the snapshot captured it; etching
         // again is idempotent).
-        vm.etch(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6, v4ImplRuntime);
+        vm.etch(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1, v4ImplRuntime);
         script.verify(artifactPath);
     }
 
@@ -226,7 +226,7 @@ contract DeployV4AuthoriserCloneTest is Test {
     /// code at the pin so `impl.code.length == 0` trips first.
     function testRunRejectsMissingV4Impl() external {
         selectBaseFork();
-        address implAddr = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6;
+        address implAddr = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1;
         vm.etch(implAddr, new bytes(0));
         vm.expectRevert(abi.encodeWithSelector(V4ImplNotDeployed.selector, implAddr));
         script.run();
@@ -238,10 +238,10 @@ contract DeployV4AuthoriserCloneTest is Test {
     /// not the canonical bytecode.
     function testRunRejectsV4ImplCodehashDrift() external {
         selectBaseFork();
-        address implAddr = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6;
+        address implAddr = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1;
         bytes memory stub = hex"60005260206000F3";
         vm.etch(implAddr, stub);
-        bytes32 expectedHash = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_CODEHASH_RAIN_VATS_0_1_6;
+        bytes32 expectedHash = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_CODEHASH_0_1_1;
         bytes32 actualHash = keccak256(stub);
         vm.expectRevert(abi.encodeWithSelector(V4ImplCodehashMismatch.selector, implAddr, expectedHash, actualHash));
         script.run();
@@ -564,7 +564,7 @@ contract DeployV4AuthoriserCloneTest is Test {
     /// @notice The canonical deploy-bundle calldata:
     /// `clone(v4Impl, abi.encode(Config(Safe)))` against the CloneFactory.
     function _expectedDeployData() internal view returns (bytes memory) {
-        address v4Impl = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6;
+        address v4Impl = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1;
         bytes memory initData = abi.encode(OffchainAssetReceiptVaultAuthorizerV1Config({initialAdmin: address(safe)}));
         return abi.encodeCall(ICloneableFactoryV2.clone, (v4Impl, initData));
     }

--- a/test/script/AuthoriserCloneAuthorization.t.sol
+++ b/test/script/AuthoriserCloneAuthorization.t.sol
@@ -42,7 +42,7 @@ contract AuthoriserCloneAuthorizationTest is Test {
         safe = IGnosisSafe(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
 
         StoxOffchainAssetReceiptVaultAuthorizerV1 impl = new StoxOffchainAssetReceiptVaultAuthorizerV1();
-        vm.etch(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6, address(impl).code);
+        vm.etch(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1, address(impl).code);
 
         TestableDeployV4AuthoriserClone testable = new TestableDeployV4AuthoriserClone();
         testable.run();
@@ -159,7 +159,7 @@ contract AuthoriserCloneAuthorizationTest is Test {
         vm.createSelectFork(LibRainDeploy.BASE);
         safe = IGnosisSafe(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
         StoxOffchainAssetReceiptVaultAuthorizerV1 impl = new StoxOffchainAssetReceiptVaultAuthorizerV1();
-        address v4Impl = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6;
+        address v4Impl = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1;
         vm.etch(v4Impl, address(impl).code);
         address factory = LibCloneFactoryDeploy.CLONE_FACTORY_DEPLOYED_ADDRESS;
 

--- a/test/script/GrantsBundleSafeTxHash.t.sol
+++ b/test/script/GrantsBundleSafeTxHash.t.sol
@@ -33,7 +33,7 @@ contract GrantsBundleSafeTxHashTest is Test {
         safe = IGnosisSafe(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
 
         StoxOffchainAssetReceiptVaultAuthorizerV1 impl = new StoxOffchainAssetReceiptVaultAuthorizerV1();
-        vm.etch(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6, address(impl).code);
+        vm.etch(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_0_1_1, address(impl).code);
 
         TestableDeployV4AuthoriserClone testable = new TestableDeployV4AuthoriserClone();
         testable.run();


### PR DESCRIPTION
## Red `main`

Merging #222 broke `main`'s compile. #222 renamed the deploy constants from the rain.vats-version suffix (`_RAIN_VATS_0_1_6`) to the st0x-deploy release-tag suffix (`_0_1_1`). Four authoriser-clone script/test files — added to main in parallel, so absent from #222's branch — still reference the old names:

- `script/20260619-deploy-v4-authoriser-clone.s.sol`
- `test/script/20260619-deploy-v4-authoriser-clone.t.sol`
- `test/script/AuthoriserCloneAuthorization.t.sol`
- `test/script/GrantsBundleSafeTxHash.t.sol`

Both sides were green individually; the merge exposed it:
`Member "STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_RAIN_VATS_0_1_6" not found ... in type(library LibProdDeployV4)`.

## Fix

Rename the references `_RAIN_VATS_0_1_6` → `_0_1_1` (the same rename #222 applied in the lib). It resolves to the **same address/codehash** the old name pinned — **no logic or bytecode change**. Build compiles clean; the touched local script tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
