### PR TITLE
ci: soldeer autopublish via rainix-autopublish (unbreak publishing)

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,11 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    with:
+      soldeer-package: st0x-deploy
+    secrets: inherit

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,9 +1,0 @@
-name: Publish to Soldeer
-on:
-  push:
-    tags: ["v*"]
-jobs:
-  publish:
-    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
-    secrets:
-      SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,11 @@
+# Soldeer package identity. `rainix-autopublish` reads `version` here, content-
+# gates it against the latest published `st0x-deploy` revision on every push to
+# main, and auto-bumps + publishes on a real change — so this holds the LAST
+# published version, not a hand-edited target.
+[package]
+name = "st0x-deploy"
+version = "0.1.1"
+
 [profile.default]
 libs = ['dependencies']
 


### PR DESCRIPTION
## Why

The existing `publish-soldeer.yaml` triggers on `v*` tag push and calls `rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main` — **that reusable no longer exists in rainix** (only `rainix-autopublish.yaml` remains), so the workflow is dead. The `st0x-deploy` soldeer package is stuck at **0.1.1** (published 2026-05-20); the **0.1.2** orchestrator release (#222) and **0.1.3** corp-actions release (#224) advanced the internal `DEPLOY_TAG` but never reached soldeer, so downstream consumers can't pin the new deploy constants / frozen bytecode.

## How

Adopt the merge-driven autopublish model raindex uses (`rainix-autopublish.yaml`):

- **`.github/workflows/package-release.yaml`** — on push to `main`, calls `rainix-autopublish.yaml@main` with `soldeer-package: st0x-deploy`, `secrets: inherit`. The reusable content-gates the package (dry-run zip vs the latest published revision), and on a real change auto-bumps `foundry.toml [package].version`, publishes to soldeer, tags `sol-v<version>`, and cuts a GH release — **no manual tag**.
- **`foundry.toml`** — add a top-level `[package]` (`name = "st0x-deploy"`, `version = "0.1.1"` = last published) that the content-gate/auto-bump reads.
- **Remove** the dead tag-triggered `publish-soldeer.yaml`.

## Effect on merge

The content-gate compares current `main` against published `st0x-deploy@0.1.1`, sees the 0.1.2 + 0.1.3 changes, and auto-publishes **`st0x-deploy@0.1.2`** (patch bump), catching soldeer up with the on-chain deploy constants. Subsequent merges publish only on real content change.

Soldeer semver (`0.1.x`) is intentionally decoupled from the internal `DEPLOY_TAG` (`0_1_3`) — same as raindex's soldeer `0.1.13` vs its own deploy tags. st0x's deploy-constant pins are not self-referentially rewritten on publish, so there is no bump loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated release flow for package publishing on updates to the main branch.
  * Updated the package identity and version information to reflect the latest release.
* **Chores**
  * Removed the older tag-based publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->