### PR TITLE
ci: pass soldeer autopublish secrets explicitly (fix cross-org startup_failure)

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -8,4 +8,14 @@ jobs:
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
       soldeer-package: st0x-deploy
-    secrets: inherit
+    # Pass secrets EXPLICITLY, not `inherit`: GitHub disallows `secrets: inherit`
+    # when the reusable is owned by a different org (rainlanguage vs S01-Issuer),
+    # which fails the run at startup. Mirror this repo's other cross-org rainix
+    # callers (e.g. rainix-sol.yaml). Only SOLDEER_API_TOKEN is required for the
+    # publish; the rest are optional (empty -> the reusable's fallbacks: bot git
+    # identity, GITHUB_TOKEN push since main is unprotected).
+    secrets:
+      SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
+      PUBLISH_PRIVATE_KEY: ${{ secrets.PUBLISH_PRIVATE_KEY }}
+      CI_GIT_EMAIL: ${{ secrets.CI_GIT_EMAIL }}
+      CI_GIT_USER: ${{ secrets.CI_GIT_USER }}


### PR DESCRIPTION
Follow-up to #239. The first **Package Release** run (on the #239 merge, commit `1097885d0`) failed with **`startup_failure`** — the run never started.

## Cause

`secrets: inherit` is **not permitted when the reusable workflow is owned by a different organization**. `rainix-autopublish.yaml` lives in `rainlanguage/rainix`; this repo is `S01-Issuer/st0x.deploy` — a different org. raindex can use `inherit` only because it's *in* the rainlanguage org.

This repo's other cross-org rainix callers already pass secrets explicitly — e.g. `rainix-sol.yaml` passes `RPC_URL_*_FORK` by name — and the old (working) `publish-soldeer.yaml` passed `SOLDEER_API_TOKEN` explicitly too.

## Fix

Replace `secrets: inherit` with an explicit block:

- `SOLDEER_API_TOKEN` — required for the publish (already present in this repo; the old workflow used it).
- `PUBLISH_PRIVATE_KEY`, `CI_GIT_EMAIL`, `CI_GIT_USER` — optional; empty falls back cleanly (bot git identity; `GITHUB_TOKEN` push, which works because `main` is **not** branch-protected).
- `CACHIX_AUTH_TOKEN` is intentionally omitted — it's referenced but *not declared* in the reusable's `secrets:` block, so it can't be passed explicitly; nix runs fine without it (as `rainix-sol` already does here).

## On merge

The autopublish runs for real: content-gate current `main` vs published `st0x-deploy@0.1.1` → change → auto-publish **`st0x-deploy@0.1.2`** + tag `sol-v0.1.2` + GH release. I'll watch this run and diagnose (not fire-and-forget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)