### PR TITLE
ci: grant Package Release the write permissions autopublish needs

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -5,15 +5,22 @@ on:
       - main
 jobs:
   release:
+    # rainix-autopublish's job requests contents: write (to push the version-
+    # bump commit + tag) and id-token: write. This repo's default workflow-token
+    # permission is read-only, so without granting these here the reusable's
+    # request exceeds the caller and the run fails at startup. Grant exactly the
+    # scopes the reusable needs, per workflow, rather than flipping the whole
+    # repo default to write.
+    permissions:
+      contents: write
+      id-token: write
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
       soldeer-package: st0x-deploy
-    # Pass secrets EXPLICITLY, not `inherit`: GitHub disallows `secrets: inherit`
-    # when the reusable is owned by a different org (rainlanguage vs S01-Issuer),
-    # which fails the run at startup. Mirror this repo's other cross-org rainix
-    # callers (e.g. rainix-sol.yaml). Only SOLDEER_API_TOKEN is required for the
-    # publish; the rest are optional (empty -> the reusable's fallbacks: bot git
-    # identity, GITHUB_TOKEN push since main is unprotected).
+    # Secrets are passed explicitly (not `inherit`), mirroring this repo's other
+    # cross-org rainix callers (e.g. rainix-sol.yaml). Only SOLDEER_API_TOKEN is
+    # required for the publish; the rest are optional and fall back cleanly when
+    # empty (bot git identity; GITHUB_TOKEN push, since main is unprotected).
     secrets:
       SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
       PUBLISH_PRIVATE_KEY: ${{ secrets.PUBLISH_PRIVATE_KEY }}


### PR DESCRIPTION
Follow-up to #239 / #240. Both Package Release runs so far failed with **`startup_failure` and zero jobs**, and #240's `secrets` fix didn't help because **that wasn't the cause**.

## Real root cause

`rainix-autopublish`'s `release` job declares `permissions: { contents: write, id-token: write }` (it pushes the version-bump commit + tag and cuts a GH release). This repo's **default workflow-token permission is read-only**:

```
$ gh api repos/S01-Issuer/st0x.deploy/actions/permissions/workflow
{ "default_workflow_permissions": "read", ... }        # raindex = "write"
```

When the caller's token is read-only, a reusable requesting `write` **exceeds** what the caller can grant, so the run fails at startup before any job. raindex succeeds with the identical reusable only because its repo default is `write`.

## Fix

Grant exactly the scopes the reusable needs on the caller job:

```yaml
jobs:
  release:
    permissions:
      contents: write
      id-token: write
    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
```

This keeps the repo's **read-only default intact** (least privilege) rather than flipping the whole repo to `write` like raindex. `allowed_actions` is already `all`, so no other policy blocks it.

## On merge

The autopublish should finally run for real: content-gate current `main` vs published `st0x-deploy@0.1.1` → change → publish **`st0x-deploy@0.1.2`** + tag `sol-v0.1.2` + GH release. I'll watch this run and diagnose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)