### PR TITLE
ci: drop deprecated soldeer-generate-cmd input

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -16,21 +16,16 @@ jobs:
       id-token: write
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
-      soldeer-package: st0x-deploy
       # `foundry.toml` version is the NEXT (in-development) release (see #244). On
-      # merge, publish that version, bump to the next, and regenerate the deploy
-      # libs so the bump commit is born clean. BuildPointers writes the `<tag>/`
-      # snapshot and regenerates the deploy libs from all snapshots in one run.
-      # The reusable runs this inside its own pinned rainix sol-shell, so the
-      # command is bare (no nested `nix develop`, which would also reintroduce a
-      # rate-limited unpinned `github:rainlanguage/rainix#` flake ref). The reusable
-      # runs this on a fresh checkout with NO soldeer deps installed, and
-      # BuildPointers COMPILES the contracts, so `forge soldeer install` must run
-      # first (else the compile fails resolving `dependencies/...`). BuildPointers
-      # then emits unindented Solidity, so `forge fmt` normalizes it — matching the
-      # `git-clean` workflow's install → regenerate → format check, so the
-      # born-green bump commit stays clean.
-      soldeer-generate-cmd: forge soldeer install && forge script ./script/BuildPointers.sol && forge fmt
+      # merge, publish that version and bump to the next — the bump no longer
+      # generates artifacts (rainix#267). A version's deploy-pin snapshot is built
+      # by the PR that changes the bytecode: run
+      # `forge script ./script/BuildPointers.sol` (after `forge soldeer install`)
+      # and commit the new `src/generated/<tag>/` snapshot + regenerated deploy
+      # libs. The LibProdDeploy fork/deploy tests fail if a snapshot is stale, and
+      # the rainix append-only check (rainix#268) rejects any change to a snapshot
+      # already on main, so snapshots stay frozen once merged.
+      soldeer-package: st0x-deploy
     # Secrets are passed explicitly (not `inherit`), mirroring this repo's other
     # cross-org rainix callers (e.g. rainix-sol.yaml). Only SOLDEER_API_TOKEN is
     # required for the publish; the rest are optional and fall back cleanly when


### PR DESCRIPTION
Companion cleanup to rainlanguage/rainix#267 (autopublish version bump no longer pre-generates artifacts) and rainlanguage/rainix#268 (append-only snapshot enforcement).

`soldeer-generate-cmd` is now a no-op input, so this drops it. Nothing enforcing is lost:
- A version's `src/generated/<tag>/` snapshot is built by the PR that changes the bytecode (run `forge script ./script/BuildPointers.sol` and commit it + the regenerated deploy libs).
- The `LibProdDeploy` deploy/fork tests already fail if a committed snapshot is stale vs the current bytecode.
- The rainix append-only check rejects any change to a snapshot already on main.

Updated the stale comment to describe the current flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package release workflow to use the streamlined Soldeer deployment configuration.
  * Removed the automated package-generation and formatting commands from the release process.
  * Clarified inline guidance for handling deploy-pin snapshots in NEXT releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->