### PR TITLE
fix(tests): beacon-ownership migration executed on Base — update test reality

### DIFF
--- a/src/lib/LibBeaconInvariants.sol
+++ b/src/lib/LibBeaconInvariants.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.25;
 
 import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {LibSafeInvariants} from "./LibSafeInvariants.sol";
 
 /// @notice Minimal `Ownable`-like surface used to read a beacon's owner.
 /// Every OpenZeppelin `UpgradeableBeacon` exposes `owner()`; this library
@@ -74,6 +75,21 @@ error BeaconImplNotDeployed(address beacon, address implementation);
 /// migration and the receipt vault upgrade reach into a library named for
 /// what it actually validates.
 library LibBeaconInvariants {
+    /// @notice The CURRENT owner of the three V1 production beacons on Base
+    /// — the single source of truth for "who owns the prod beacons today".
+    /// Every consumer that means "the current beacon owner" (post-state
+    /// asserts, upgrade pre-flights, `vm.prank` targets in fork tests)
+    /// reads this constant, so an ownership change is a one-line edit here
+    /// rather than a sweep of hardcoded call sites.
+    ///
+    /// The ST0x token-owner Safe since the `MigrateBeaconOwners` broadcast
+    /// executed on Base (2026-07); the deploy-time EOA before that. Sites
+    /// that deliberately mean the deploy-time initial owner (un-migrated
+    /// V4-generation beacons, the migration's reconstructed pre-state) use
+    /// `LibProdDeployV1.BEACON_INITIAL_OWNER` / the V4 lib's
+    /// `BEACON_INITIAL_OWNER` instead — do not conflate the two.
+    address internal constant PROD_BEACON_OWNER = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE;
+
     /// @notice Runtime codehash shared by every OpenZeppelin
     /// `UpgradeableBeacon` instance on Base. An `UpgradeableBeacon` keeps its
     /// implementation pointer and owner in storage rather than in code, so the

--- a/test/script/20260623-upgrade-receipt-vaults-to-v4.t.sol
+++ b/test/script/20260623-upgrade-receipt-vaults-to-v4.t.sol
@@ -8,6 +8,7 @@ import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
 import {IAuthorizableV1} from "rain-vats-0.1.6/src/interface/IAuthorizableV1.sol";
 
+import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
 import {LibTokenInvariants} from "../../src/lib/LibTokenInvariants.sol";
 import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
@@ -65,14 +66,19 @@ contract UpgradeReceiptVaultsToV4Test is Test {
     /// beacon to (placeholder Zoltu address until the patched build lands).
     address internal constant V4_IMPL = LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1;
 
-    /// @notice Fork Base and simulate PR #196 (transfer the receipt-vault
-    /// beacon from the deploy EOA to the Safe) so the script's beacon
-    /// pre-flight (`assertBeaconInvariants`, Safe-owned + at V1) passes and
-    /// `run()` reaches the V4 impl + clone checks.
+    /// @notice Fork Base at head. The beacon-ownership migration
+    /// (`MigrateBeaconOwners.s.sol`) EXECUTED on Base in 2026-07, so the
+    /// live receipt-vault beacon is already Safe-owned — the script's
+    /// beacon pre-flight (`assertBeaconInvariants`, Safe-owned + at V1)
+    /// passes against real chain state with no simulation, and `run()`
+    /// reaches the V4 impl + clone checks.
     function _forkAndMigrateBeaconOwnership() internal {
         vm.createSelectFork(LibRainDeploy.BASE);
-        vm.prank(LibProdDeployV1.BEACON_INITIAL_OWNER);
-        Ownable(BEACON).transferOwnership(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
+        assertEq(
+            Ownable(BEACON).owner(),
+            LibBeaconInvariants.PROD_BEACON_OWNER,
+            "live beacon not Safe-owned - migration state regressed?"
+        );
     }
 
     /// @notice `run()` pre-flight reverts `V4ImplementationNotDeployed` when
@@ -141,7 +147,7 @@ contract UpgradeReceiptVaultsToV4Test is Test {
             "src/concrete/StoxCorporateActionsFacet.sol:StoxCorporateActionsFacet",
             LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_1
         );
-        vm.prank(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
+        vm.prank(LibBeaconInvariants.PROD_BEACON_OWNER);
         IUpgradeableBeacon(BEACON).upgradeTo(V4_IMPL);
 
         UpgradeReceiptVaultsToV4Harness harness = new UpgradeReceiptVaultsToV4Harness();

--- a/test/script/MigrateBeaconOwnersTest.t.sol
+++ b/test/script/MigrateBeaconOwnersTest.t.sol
@@ -9,21 +9,29 @@ import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
 import {IGnosisSafe} from "../../src/interface/IGnosisSafe.sol";
 import {LibProdDeployV1} from "../../src/lib/LibProdDeployV1.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
-import {BeaconOwnerMismatch} from "../../src/lib/LibBeaconInvariants.sol";
+import {LibBeaconInvariants, BeaconOwnerMismatch} from "../../src/lib/LibBeaconInvariants.sol";
 import {MigrateBeaconOwnersHarness} from "./MigrateBeaconOwnersHarness.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 
 /// @title MigrateBeaconOwnersTest
-/// @notice End-to-end fork tests for the beacon-ownership migration. Because
-/// the migration broadcasts from the rainlang.eth EOA (which owns the
-/// beacons), the test simulates the broadcast's effect by pranking the EOA
-/// to perform the `transferOwnership` calls, exercising the same pre-flight,
-/// post-state, and n+1 reversibility steps the script runs.
+/// @notice End-to-end fork tests for the beacon-ownership migration
+/// (EXECUTED on Base, 2026-07 — every V1 beacon is now Safe-owned live).
+/// The migration walk is still exercised in full: the pre-migration
+/// EOA-owned state is reconstructed deterministically via `vm.store` on the
+/// beacons' OZ `Ownable` owner slot (slot 0), so the coverage no longer
+/// depends on the live chain being in the pre-execution state. The live
+/// post-state (Safe-owned, real transfers) is asserted by
+/// `testLivePostStateSafeOwned` and by the `BeaconOwnerMigrationPinTest`
+/// migration-window cron invariant.
 /// @dev Uses an unpinned Base head fork (same precedent as
 /// `MigrateMultisigThresholdTest`): any drift in the live beacon state
 /// surfaces on the next CI run rather than being frozen against a stale
 /// snapshot.
 contract MigrateBeaconOwnersTest is Test {
+    /// @notice OZ `Ownable` stores `_owner` in slot 0 on the
+    /// `UpgradeableBeacon`.
+    bytes32 internal constant OWNABLE_OWNER_SLOT = bytes32(0);
+
     /// @notice Live Safe handle, reset per fork.
     IGnosisSafe internal safe;
 
@@ -51,20 +59,46 @@ contract MigrateBeaconOwnersTest is Test {
         harness = new MigrateBeaconOwnersHarness();
     }
 
-    /// @notice Simulate the migration's on-chain effect: prank the EOA owner
-    /// and transfer each beacon to the Safe. Models exactly what
-    /// `MigrateBeaconOwners.run()`'s broadcast block does.
-    function simulateTransfers() internal {
+    /// @notice Reconstruct the pre-migration state on the fork: write the
+    /// rainlang.eth EOA back into each beacon's `Ownable` owner slot. The
+    /// migration executed on Base in 2026-07, so the live fork starts
+    /// Safe-owned; the walk tests rewind ownership deterministically
+    /// instead of depending on live pre-execution state.
+    function rewindToEoaOwned() internal {
         for (uint256 i = 0; i < beaconList.length; i++) {
-            vm.prank(LibProdDeployV1.BEACON_INITIAL_OWNER);
-            Ownable(beaconList[i]).transferOwnership(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
+            vm.store(beaconList[i], OWNABLE_OWNER_SLOT, bytes32(uint256(uint160(LibProdDeployV1.BEACON_INITIAL_OWNER))));
+            assertEq(Ownable(beaconList[i]).owner(), LibProdDeployV1.BEACON_INITIAL_OWNER, "rewind failed: owner slot");
         }
     }
 
-    /// @notice Pre-flight passes against the live EOA-owned state for all
-    /// three beacons. This is the gate `run()` runs before broadcasting.
+    /// @notice Simulate the migration's on-chain effect: prank the EOA owner
+    /// and transfer each beacon to the Safe. Models exactly what
+    /// `MigrateBeaconOwners.run()`'s broadcast block did.
+    function simulateTransfers() internal {
+        for (uint256 i = 0; i < beaconList.length; i++) {
+            vm.prank(LibProdDeployV1.BEACON_INITIAL_OWNER);
+            Ownable(beaconList[i]).transferOwnership(LibBeaconInvariants.PROD_BEACON_OWNER);
+        }
+    }
+
+    /// @notice LIVE post-state: every beacon on Base head is Safe-owned with
+    /// its implementation unchanged — the executed migration's outcome,
+    /// asserted against the real chain with no state reconstruction.
+    function testLivePostStateSafeOwned() external {
+        selectBaseFork();
+        for (uint256 i = 0; i < beaconList.length; i++) {
+            harness.callAssertBeaconInvariants(beaconList[i], LibBeaconInvariants.PROD_BEACON_OWNER, implList[i]);
+            assertEq(Ownable(beaconList[i]).owner(), LibBeaconInvariants.PROD_BEACON_OWNER, "beacon Safe-owned");
+            assertEq(IBeacon(beaconList[i]).implementation(), implList[i], "implementation unchanged by migration");
+        }
+    }
+
+    /// @notice Pre-flight passes against the (reconstructed) EOA-owned state
+    /// for all three beacons. This is the gate `run()` ran before
+    /// broadcasting.
     function testPreflightPassesAgainstEoaOwnedState() external {
         selectBaseFork();
+        rewindToEoaOwned();
         for (uint256 i = 0; i < beaconList.length; i++) {
             // No revert == invariant holds.
             harness.callAssertBeaconInvariants(beaconList[i], LibProdDeployV1.BEACON_INITIAL_OWNER, implList[i]);
@@ -73,9 +107,11 @@ contract MigrateBeaconOwnersTest is Test {
 
     /// @notice Full migration walk: pre-flight (EOA) passes, transfers
     /// applied, post-state (Safe) passes, n+1 reversibility passes for every
-    /// beacon. This is the happy-path mirror of `MigrateBeaconOwners.run()`.
+    /// beacon. This is the happy-path mirror of `MigrateBeaconOwners.run()`,
+    /// replayed from the reconstructed pre-state.
     function testFullMigrationWalk() external {
         selectBaseFork();
+        rewindToEoaOwned();
 
         // Pre-flight: every beacon EOA-owned.
         for (uint256 i = 0; i < beaconList.length; i++) {
@@ -87,8 +123,8 @@ contract MigrateBeaconOwnersTest is Test {
 
         // Post-state: every beacon now Safe-owned, implementations unchanged.
         for (uint256 i = 0; i < beaconList.length; i++) {
-            harness.callAssertBeaconInvariants(beaconList[i], LibSafeInvariants.STOX_TOKEN_OWNER_SAFE, implList[i]);
-            assertEq(Ownable(beaconList[i]).owner(), LibSafeInvariants.STOX_TOKEN_OWNER_SAFE, "beacon now Safe-owned");
+            harness.callAssertBeaconInvariants(beaconList[i], LibBeaconInvariants.PROD_BEACON_OWNER, implList[i]);
+            assertEq(Ownable(beaconList[i]).owner(), LibBeaconInvariants.PROD_BEACON_OWNER, "beacon now Safe-owned");
             assertEq(IBeacon(beaconList[i]).implementation(), implList[i], "implementation unchanged by transfer");
         }
 
@@ -103,44 +139,45 @@ contract MigrateBeaconOwnersTest is Test {
             // implementation and is still Safe-owned.
             assertEq(IBeacon(beaconList[i]).implementation(), implList[i], "implementation preserved through n+1");
             assertEq(
-                Ownable(beaconList[i]).owner(), LibSafeInvariants.STOX_TOKEN_OWNER_SAFE, "still Safe-owned after n+1"
+                Ownable(beaconList[i]).owner(), LibBeaconInvariants.PROD_BEACON_OWNER, "still Safe-owned after n+1"
             );
         }
     }
 
-    /// @notice Inverted: the pre-flight rejects a wrong expected owner. The
-    /// live beacon is EOA-owned; asserting it should be Safe-owned (before the
-    /// transfer) trips `BeaconOwnerMismatch` with the actual EOA owner. This
-    /// is the property that makes the post-state assertion meaningful — it
-    /// would catch a transfer that silently failed.
+    /// @notice Inverted: the pre-flight rejects a wrong expected owner. From
+    /// the reconstructed EOA-owned state, asserting the beacon should be
+    /// Safe-owned trips `BeaconOwnerMismatch` with the actual EOA owner.
+    /// This is the property that makes the post-state assertion meaningful —
+    /// it would catch a transfer that silently failed.
     function testInvertedWrongExpectedOwnerReverts() external {
         selectBaseFork();
+        rewindToEoaOwned();
         address beacon = beaconList[0];
         vm.expectRevert(
             abi.encodeWithSelector(
                 BeaconOwnerMismatch.selector,
                 beacon,
-                LibSafeInvariants.STOX_TOKEN_OWNER_SAFE,
+                LibBeaconInvariants.PROD_BEACON_OWNER,
                 LibProdDeployV1.BEACON_INITIAL_OWNER
             )
         );
-        harness.callAssertBeaconInvariants(beacon, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE, implList[0]);
+        harness.callAssertBeaconInvariants(beacon, LibBeaconInvariants.PROD_BEACON_OWNER, implList[0]);
     }
 
-    /// @notice Inverted: after the transfers land, asserting the OLD EOA owner
-    /// trips `BeaconOwnerMismatch` reporting the Safe as the actual owner.
-    /// Confirms the post-state assertion is sensitive to the ownership flip in
-    /// both directions.
+    /// @notice Inverted: with the migration landed (live state), asserting
+    /// the OLD EOA owner trips `BeaconOwnerMismatch` reporting the Safe as
+    /// the actual owner. Confirms the post-state assertion is sensitive to
+    /// the ownership flip in both directions — and doubles as the dispatch
+    /// gate: a re-run of the script's pre-flight now reverts here.
     function testInvertedStaleEoaOwnerRevertsPostTransfer() external {
         selectBaseFork();
-        simulateTransfers();
         address beacon = beaconList[0];
         vm.expectRevert(
             abi.encodeWithSelector(
                 BeaconOwnerMismatch.selector,
                 beacon,
                 LibProdDeployV1.BEACON_INITIAL_OWNER,
-                LibSafeInvariants.STOX_TOKEN_OWNER_SAFE
+                LibBeaconInvariants.PROD_BEACON_OWNER
             )
         );
         harness.callAssertBeaconInvariants(beacon, LibProdDeployV1.BEACON_INITIAL_OWNER, implList[0]);

--- a/test/src/concrete/deploy/BeaconOwnerMigrationPin.t.sol
+++ b/test/src/concrete/deploy/BeaconOwnerMigrationPin.t.sol
@@ -5,6 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
+import {LibBeaconInvariants} from "../../../../src/lib/LibBeaconInvariants.sol";
 import {LibMigrationInvariant} from "../../../../src/lib/LibMigrationInvariant.sol";
 import {LibProdDeployV1} from "../../../../src/lib/LibProdDeployV1.sol";
 import {LibSafeInvariants} from "../../../../src/lib/LibSafeInvariants.sol";
@@ -44,7 +45,7 @@ contract BeaconOwnerMigrationPinTest is Test {
             label,
             Ownable(beacon).owner(),
             LibProdDeployV1.BEACON_INITIAL_OWNER,
-            LibSafeInvariants.STOX_TOKEN_OWNER_SAFE,
+            LibBeaconInvariants.PROD_BEACON_OWNER,
             BEACON_OWNER_MIGRATION_DEADLINE
         );
     }

--- a/test/src/concrete/upgrade/V3UpgradeShadowFork.t.sol
+++ b/test/src/concrete/upgrade/V3UpgradeShadowFork.t.sol
@@ -10,6 +10,7 @@ import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensio
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 import {LibProdDeployV1} from "../../../../src/lib/LibProdDeployV1.sol";
 import {LibProdDeployV4} from "../../../../src/generated/LibProdDeployV4.sol";
+import {LibBeaconInvariants} from "../../../../src/lib/LibBeaconInvariants.sol";
 import {LibSafeInvariants} from "../../../../src/lib/LibSafeInvariants.sol";
 import {LibAuthoriserInvariants} from "../../../../src/lib/LibAuthoriserInvariants.sol";
 import {LibTokenInvariants} from "../../../../src/lib/LibTokenInvariants.sol";
@@ -94,12 +95,16 @@ contract V3UpgradeShadowForkTest is Test {
             LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_1
         );
 
-        // 2. Simulate PR-A: transfer the beacon from the EOA to the Safe.
-        vm.prank(LibProdDeployV1.BEACON_INITIAL_OWNER);
-        Ownable(BEACON).transferOwnership(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
+        // 2. The beacon-ownership migration EXECUTED on Base (2026-07):
+        //    the live beacon is already Safe-owned, no simulation needed.
+        assertEq(
+            Ownable(BEACON).owner(),
+            LibBeaconInvariants.PROD_BEACON_OWNER,
+            "live beacon not Safe-owned - migration state regressed?"
+        );
 
         // 3. Apply the upgrade: the Safe points the beacon at the V3 impl.
-        vm.prank(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);
+        vm.prank(LibBeaconInvariants.PROD_BEACON_OWNER);
         IUpgradeableBeacon(BEACON).upgradeTo(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1);
     }
 
@@ -113,7 +118,7 @@ contract V3UpgradeShadowForkTest is Test {
     /// Safe-owned, points at the V3 implementation, and the live receipt vault
     /// is still behind this beacon.
     function testForkIsInUpgradedState() external view {
-        assertEq(Ownable(BEACON).owner(), LibSafeInvariants.STOX_TOKEN_OWNER_SAFE, "beacon Safe-owned");
+        assertEq(Ownable(BEACON).owner(), LibBeaconInvariants.PROD_BEACON_OWNER, "beacon Safe-owned");
         assertEq(IBeacon(BEACON).implementation(), LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1, "beacon at V3 impl");
         assertEq(beaconOf(LIVE_RECEIPT_VAULT), BEACON, "live vault behind the upgraded beacon");
     }

--- a/test/src/lib/LibBeaconInvariants.t.sol
+++ b/test/src/lib/LibBeaconInvariants.t.sol
@@ -88,7 +88,10 @@ contract LibBeaconInvariantsTest is Test {
     /// @notice `assertBeaconInvariants` trips `BeaconImplementationMismatch`
     /// when the beacon's `implementation()` differs from the expected
     /// implementation. Simulated by mocking `implementation()` on the live
-    /// receipt vault beacon to a rogue address.
+    /// receipt vault beacon to a rogue address. The expected owner is the
+    /// Safe — the live owner since the beacon-ownership migration executed
+    /// (2026-07) — so the owner check passes and the revert is specifically
+    /// the implementation gate.
     function testInvertedBeaconImplementationMismatch() external {
         selectBaseFork();
         address beacon = LibProdDeployV1.STOX_RECEIPT_VAULT_BEACON_V1;
@@ -103,7 +106,7 @@ contract LibBeaconInvariantsTest is Test {
             )
         );
         harness.callAssertBeaconInvariants(
-            beacon, LibProdDeployV1.BEACON_INITIAL_OWNER, LibProdDeployV1.STOX_RECEIPT_VAULT_IMPLEMENTATION
+            beacon, LibBeaconInvariants.PROD_BEACON_OWNER, LibProdDeployV1.STOX_RECEIPT_VAULT_IMPLEMENTATION
         );
     }
 }


### PR DESCRIPTION
## Summary

`MigrateBeaconOwners.s.sol` has **executed on Base** (2026-07): all three V1 production beacons now report the ST0x token-owner Safe as `owner()` at live head. Every test that depended on the live *pre*-migration state (pranking rainlang.eth to `transferOwnership`) started failing with `OwnableUnauthorizedAccount` / `BeaconOwnerMismatch` on head-fork runs — 10 failures on main's test job.

## Changes

- **`MigrateBeaconOwnersTest`** — the migration-walk coverage is preserved permanently by reconstructing the pre-state deterministically: `vm.store` writes the EOA back into each beacon's OZ `Ownable` owner slot (slot 0) before the walk. New `testLivePostStateSafeOwned` asserts the executed migration's outcome against the real chain. `testInvertedStaleEoaOwnerRevertsPostTransfer` now runs against live state directly — doubling as the dispatch-gate check (a re-run of the script's pre-flight reverts).
- **`20260623-upgrade-receipt-vaults-to-v4.t.sol`** — `_forkAndMigrateBeaconOwnership` no longer simulates the transfer; it asserts the live Safe-owned state (regression tripwire if ownership ever moves back).
- **`V3UpgradeShadowFork.t.sol`** — same change in `setUp`.
- **`LibBeaconInvariants.t.sol`** — `testInvertedBeaconImplementationMismatch` passes the Safe as expected owner so the owner gate passes against live state and the revert isolates the implementation check.

This is the "collapse the migration-window when next touching the file" pattern from `docs/OPERATIONAL_SCRIPTS.md` applied to the beacon migration: the `BeaconOwnerMigrationPinTest` cron invariant rode through the transition automatically; only the tests hard-wired to the pre-state needed the rewind treatment.

## Stack

`main → this PR → #252 (V4 authoriser clone address pin)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated migration and upgrade scenarios to assert beacon ownership using the live Base fork state.
  * Added deterministic handling of the pre-migration EOA-owned beacon via state rewind/reconstruction, and aligned post-migration expectations to Safe-owned production beacons.
  * Switched upgrade call impersonation and regression checks to target the correct beacon owner, and adjusted revert expectations accordingly.
  * Improved invariant tests so implementation-mismatch failures are evaluated independently of ownership checks.  
* **Internal Improvements**
  * Introduced a shared constant for the current production beacon owner used by invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Centralized: `LibBeaconInvariants.PROD_BEACON_OWNER`

"Who owns the prod V1 beacons today" is now a single constant in the beacon-domain lib (`PROD_BEACON_OWNER = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE`) instead of `STOX_TOKEN_OWNER_SAFE` hardcoded at every call site. All 16 owner-semantic sites (post-state asserts, upgrade pre-flights, `vm.prank` owner targets) read it — a future ownership change is a one-line lib edit, not an error-prone sweep. Sites that deliberately mean the deploy-time initial owner (un-migrated V4-gen beacons, the reconstructed pre-migration state) keep `BEACON_INITIAL_OWNER`; the constant's NatSpec spells out the distinction.
