### PR TITLE
feat(script): V4 upgrade bundle covers all three V1 production beacons

### DIFF
--- a/script/20260623-upgrade-receipt-vaults-to-v4.s.sol
+++ b/script/20260623-upgrade-receipt-vaults-to-v4.s.sol
@@ -77,8 +77,10 @@ error VaultAuthoriserMismatchPostUpgrade(address vault, address expected, addres
 /// mirrored onto it. The ST0x token-owner Safe signs a single bundle
 /// that:
 ///
-///   1. Points the receipt-vault beacon at the V4 implementation
-///      (`LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1`).
+///   1. Points all three V1 production beacons (receipt, receipt vault,
+///      wrapped token vault) at their V4 implementations
+///      (`LibProdDeployV4.STOX_RECEIPT_0_1_1` /
+///      `STOX_RECEIPT_VAULT_0_1_1` / `STOX_WRAPPED_TOKEN_VAULT_0_1_1`).
 ///   2. Calls `setAuthorizer(LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE)`
 ///      on every production receipt vault.
 ///
@@ -103,12 +105,13 @@ error VaultAuthoriserMismatchPostUpgrade(address vault, address expected, addres
 ///    fails red today because `STOX_PROD_AUTHORISER_V4_CLONE` is still
 ///    `address(0)` — the forcing function blocking the upgrade until the clone
 ///    is deployed and pinned.
-/// 2. **Build** — a multi-tx bundle: one `upgradeTo(V4 impl)` call on the
-///    beacon, plus one `setAuthorizer(V4 clone)` call per production receipt
-///    vault (count = `LibTokenInvariants.productionReceiptVaults().length`,
+/// 2. **Build** — a multi-tx bundle: one `upgradeTo(V4 impl)` call per V1
+///    production beacon (receipt, receipt vault, wrapped token vault), plus
+///    one `setAuthorizer(V4 clone)` call per production receipt vault
+///    (count = `LibTokenInvariants.productionReceiptVaults().length`,
 ///    20 as of 2026-06-26; the bundle grows in lockstep as new vaults are
 ///    added to the lib). Compute the canonical `SafeTxHash` against the live
-///    nonce for the beacon-upgrade tx for signer cross-check.
+///    nonce for the first beacon-upgrade tx for signer cross-check.
 /// 3. **Simulate** — prank-route each bundle item as the Safe so post-state
 ///    assertions reflect the executed state.
 /// 4. **Post-state** —
@@ -124,16 +127,54 @@ error VaultAuthoriserMismatchPostUpgrade(address vault, address expected, addres
 ///    intrinsic — every vault is Safe-owned so the Safe can re-issue
 ///    `setAuthorizer(old clone)` symmetrically.
 contract UpgradeReceiptVaultsToV4 is Script {
-    /// @notice The receipt-vault beacon whose implementation is upgraded.
+    /// @notice The receipt-vault beacon — kept as a named constant because
+    /// several tests exercise its pre-flight paths specifically.
     address internal constant BEACON = LibProdDeployV1.STOX_RECEIPT_VAULT_BEACON_V1;
 
-    /// @notice The V1 implementation the beacon points at before the upgrade,
-    /// and the rollback target for the n+1 reversibility inverse op.
+    /// @notice The receipt-vault V1 implementation (rollback target).
     address internal constant V1_IMPL = LibProdDeployV1.STOX_RECEIPT_VAULT_IMPLEMENTATION;
 
-    /// @notice The V4 implementation the beacon is upgraded to — the audited
-    /// `0.1.1` receipt-vault build, deployed on Base at this pinned address.
+    /// @notice The receipt-vault V4 implementation — the audited `0.1.1`
+    /// build, deployed on Base at this pinned address.
     address internal constant V4_IMPL = LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1;
+
+    /// @notice The three V1 production beacons the bundle upgrades, in
+    /// receipt → receipt-vault → wrapped-token-vault order (same order as
+    /// `MigrateBeaconOwners`). Every live production token proxies through
+    /// these three, so upgrading them together keeps the receipt (ERC-1155),
+    /// receipt vault (ERC-20) and wrapped vault (ERC-4626) implementations
+    /// in lock-step — the receipt-vault V4 impl assumes the V4 receipt
+    /// behaviour and vice versa.
+    function beacons() internal pure returns (address[3] memory list) {
+        list[0] = LibProdDeployV1.STOX_RECEIPT_BEACON_V1;
+        list[1] = LibProdDeployV1.STOX_RECEIPT_VAULT_BEACON_V1;
+        list[2] = LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_V1;
+    }
+
+    /// @notice Each beacon's V1 implementation, index-aligned with
+    /// `beacons()`. Pre-flight expectation and the n+1 rollback target.
+    function v1Impls() internal pure returns (address[3] memory list) {
+        list[0] = LibProdDeployV1.STOX_RECEIPT_IMPLEMENTATION;
+        list[1] = LibProdDeployV1.STOX_RECEIPT_VAULT_IMPLEMENTATION;
+        list[2] = LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_IMPLEMENTATION;
+    }
+
+    /// @notice Each beacon's V4 implementation, index-aligned with
+    /// `beacons()` — the audited `0.1.1` builds pinned in the generated
+    /// deploy lib.
+    function v4Impls() internal pure returns (address[3] memory list) {
+        list[0] = LibProdDeployV4.STOX_RECEIPT_0_1_1;
+        list[1] = LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1;
+        list[2] = LibProdDeployV4.STOX_WRAPPED_TOKEN_VAULT_0_1_1;
+    }
+
+    /// @notice Each V4 implementation's pinned codehash, index-aligned with
+    /// `v4Impls()`.
+    function v4Codehashes() internal pure returns (bytes32[3] memory list) {
+        list[0] = LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_1;
+        list[1] = LibProdDeployV4.STOX_RECEIPT_VAULT_CODEHASH_0_1_1;
+        list[2] = LibProdDeployV4.STOX_WRAPPED_TOKEN_VAULT_CODEHASH_0_1_1;
+    }
 
     /// @notice The V4 authoriser clone that every production receipt vault is
     /// rewired onto. Placeholder until the clone is deployed.
@@ -161,10 +202,70 @@ contract UpgradeReceiptVaultsToV4 is Script {
 
         // Safe identity / config + token-side uniformity.
         LibSafeInvariants.assertAll(safe);
-        // Beacon is Safe-owned and still at V1.
-        LibBeaconInvariants.assertBeaconInvariants(BEACON, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE, V1_IMPL);
+        _preflightBeaconsAndImpls();
+        _preflightClone();
 
-        // V4 implementation pinned, deployed, audited codehash.
+        // --- Build the bundle --------------------------------------------
+
+        // Three beacon upgrades (receipt, receipt vault, wrapped token
+        // vault) + one setAuthorizer per production receipt vault.
+        SafeTx[] memory txs = _buildBundle(vaults);
+
+        // Capture the nonce before any simulation. `simulateExternalCall`
+        // does not advance the nonce, so the hash binds to the current Safe
+        // state.
+        uint256 nonce = safe.nonce();
+        bytes32 beaconSafeTxHash = LibSafeOps.computeSafeTxHashViaSafe(safe, txs[0], nonce);
+
+        // --- Simulate -----------------------------------------------------
+
+        for (uint256 i = 0; i < txs.length; i++) {
+            LibSafeOps.simulateExternalCall(safe, txs[i].to, txs[i].data);
+        }
+
+        // --- Post-state ---------------------------------------------------
+
+        _assertPostState(safe, vaults);
+
+        // --- Artifact -----------------------------------------------------
+
+        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, BUNDLE_NAME, txs);
+        vm.writeFile(ARTIFACT_PATH, json);
+
+        console2.log("==== TX BUILDER JSON BEGIN ====");
+        console2.log(json);
+        console2.log("==== TX BUILDER JSON END ====");
+        console2.log("Beacon-upgrade SafeTxHash:", vm.toString(beaconSafeTxHash));
+        console2.log("Nonce:", nonce);
+        console2.log("Bundle item count:", txs.length);
+
+        // --- n+1 reversibility -------------------------------------------
+
+        address[3] memory beaconList = beacons();
+        address[3] memory v1ImplList = v1Impls();
+        for (uint256 i = 0; i < beaconList.length; i++) {
+            bytes memory inverseData = abi.encodeCall(IUpgradeableBeacon.upgradeTo, (v1ImplList[i]));
+            LibSafeOps.simulateNPlus1(
+                safe, beaconList[i], inverseData, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD
+            );
+            require(
+                IBeacon(beaconList[i]).implementation() == v1ImplList[i],
+                "UpgradeReceiptVaultsToV4: n+1 did not roll beacon back to V1 impl"
+            );
+        }
+        console2.log("n+1 reversibility check passed: all three beacons rolled back to V1 impls");
+    }
+
+    /// @notice Pre-flight: every V1 production beacon is Safe-owned and
+    /// still at its V1 implementation, and every V4 implementation is
+    /// deployed with its audited codehash. The receipt-vault entry is
+    /// checked first (via the scalar constants) so its typed-error paths
+    /// stay deterministic for the test suite.
+    function _preflightBeaconsAndImpls() internal view {
+        address[3] memory beaconList = beacons();
+        address[3] memory v1ImplList = v1Impls();
+        address[3] memory v4ImplList = v4Impls();
+        bytes32[3] memory v4CodehashList = v4Codehashes();
         if (V4_IMPL.code.length == 0) {
             revert V4ImplementationNotDeployed(V4_IMPL);
         }
@@ -172,9 +273,24 @@ contract UpgradeReceiptVaultsToV4 is Script {
         if (v4Codehash != LibProdDeployV4.STOX_RECEIPT_VAULT_CODEHASH_0_1_1) {
             revert V4CodehashMismatch(V4_IMPL, LibProdDeployV4.STOX_RECEIPT_VAULT_CODEHASH_0_1_1, v4Codehash);
         }
+        for (uint256 i = 0; i < beaconList.length; i++) {
+            LibBeaconInvariants.assertBeaconInvariants(
+                beaconList[i], LibBeaconInvariants.PROD_BEACON_OWNER, v1ImplList[i]
+            );
+            if (v4ImplList[i].code.length == 0) {
+                revert V4ImplementationNotDeployed(v4ImplList[i]);
+            }
+            bytes32 actualCodehash = v4ImplList[i].codehash;
+            if (actualCodehash != v4CodehashList[i]) {
+                revert V4CodehashMismatch(v4ImplList[i], v4CodehashList[i], actualCodehash);
+            }
+        }
+    }
 
-        // V4 authoriser clone pinned, deployed, codehash matches EIP-1167
-        // runtime with V4 impl embedded, and the grant map matches the lib.
+    /// @notice Pre-flight: the V4 authoriser clone is pinned, deployed, its
+    /// codehash matches the EIP-1167 runtime with the V4 impl embedded, and
+    /// the grant map matches the lib.
+    function _preflightClone() internal view {
         if (V4_AUTHORISER_CLONE == address(0)) {
             revert V4AuthoriserCloneNotPinned();
         }
@@ -200,9 +316,7 @@ contract UpgradeReceiptVaultsToV4 is Script {
         // (`SCHEDULE_/CANCEL_CORPORATE_ACTION_ADMIN`) that `expectedGrants()`
         // doesn't carry. Without them the swapped clone can't admin corporate
         // actions, so this is the enforcement point that must reject a clone
-        // deployed missing them. (The five base admins overlap the
-        // `expectedGrants()` sweep above; re-checking them keeps the admin-set
-        // assertion self-contained and matches the V4 post-swap pin.)
+        // deployed missing them.
         bytes32[7] memory adminRoles = [
             keccak256("CERTIFY_ADMIN"),
             keccak256("CONFISCATE_RECEIPT_ADMIN"),
@@ -218,70 +332,49 @@ contract UpgradeReceiptVaultsToV4 is Script {
                 revert V4AuthoriserCloneExpectedGrantMissing(V4_AUTHORISER_CLONE, adminRoles[i], ownerSafe);
             }
         }
+    }
 
-        // --- Build the bundle --------------------------------------------
-
-        // One beacon upgrade + one setAuthorizer per production receipt vault.
-        SafeTx[] memory txs = new SafeTx[](1 + vaults.length);
-        bytes memory beaconData = abi.encodeCall(IUpgradeableBeacon.upgradeTo, (V4_IMPL));
-        txs[0] = SafeTx({to: BEACON, value: 0, data: beaconData, operation: 0});
+    /// @notice Build the bundle: one `upgradeTo(V4 impl)` per V1 beacon
+    /// followed by one `setAuthorizer(V4 clone)` per production vault.
+    /// @param vaults The production receipt vaults the swap targets.
+    /// @return txs The bundle transactions in execution order.
+    function _buildBundle(address[] memory vaults) internal pure returns (SafeTx[] memory txs) {
+        address[3] memory beaconList = beacons();
+        address[3] memory v4ImplList = v4Impls();
+        txs = new SafeTx[](beaconList.length + vaults.length);
+        for (uint256 i = 0; i < beaconList.length; i++) {
+            txs[i] = SafeTx({
+                to: beaconList[i],
+                value: 0,
+                data: abi.encodeCall(IUpgradeableBeacon.upgradeTo, (v4ImplList[i])),
+                operation: 0
+            });
+        }
         bytes memory setAuthoriserData =
             abi.encodeCall(OffchainAssetReceiptVaultLike.setAuthorizer, (IAuthorizeV1(V4_AUTHORISER_CLONE)));
         for (uint256 i = 0; i < vaults.length; i++) {
-            txs[i + 1] = SafeTx({to: vaults[i], value: 0, data: setAuthoriserData, operation: 0});
+            txs[beaconList.length + i] = SafeTx({to: vaults[i], value: 0, data: setAuthoriserData, operation: 0});
         }
-
-        // Capture the nonce before any simulation. `simulateExternalCall`
-        // does not advance the nonce, so the hash binds to the current Safe
-        // state.
-        uint256 nonce = safe.nonce();
-        bytes32 beaconSafeTxHash = LibSafeOps.computeSafeTxHashViaSafe(safe, txs[0], nonce);
-
-        // --- Simulate -----------------------------------------------------
-
-        LibSafeOps.simulateExternalCall(safe, BEACON, beaconData);
-        for (uint256 i = 0; i < vaults.length; i++) {
-            LibSafeOps.simulateExternalCall(safe, vaults[i], setAuthoriserData);
-        }
-
-        // --- Post-state ---------------------------------------------------
-
-        _assertPostState(safe, vaults);
-
-        // --- Artifact -----------------------------------------------------
-
-        string memory json = LibSafeOps.emitTxBuilderJson(address(safe), block.chainid, BUNDLE_NAME, txs);
-        vm.writeFile(ARTIFACT_PATH, json);
-
-        console2.log("==== TX BUILDER JSON BEGIN ====");
-        console2.log(json);
-        console2.log("==== TX BUILDER JSON END ====");
-        console2.log("Beacon-upgrade SafeTxHash:", vm.toString(beaconSafeTxHash));
-        console2.log("Nonce:", nonce);
-        console2.log("Bundle item count:", txs.length);
-
-        // --- n+1 reversibility -------------------------------------------
-
-        bytes memory inverseData = abi.encodeCall(IUpgradeableBeacon.upgradeTo, (V1_IMPL));
-        LibSafeOps.simulateNPlus1(safe, BEACON, inverseData, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD);
-        require(
-            IBeacon(BEACON).implementation() == V1_IMPL,
-            "UpgradeReceiptVaultsToV4: n+1 did not roll beacon back to V1 impl"
-        );
-        console2.log("n+1 reversibility check passed: beacon rolled back to V1 impl");
     }
 
-    /// @notice Post-state assertions after the upgrade + swap simulate: the
-    /// beacon is at V4 and Safe-owned, every production receipt vault reports
-    /// the V4 clone as its authoriser, and the Safe identity + threshold are
-    /// unchanged. Split from `run()` so tests can drive it against a
-    /// deliberately-malformed post-state (e.g. an un-swapped vault) and assert
-    /// the `VaultAuthoriserMismatchPostUpgrade` guard fires.
+    /// @notice Post-state assertions after the upgrade + swap simulate: all
+    /// three beacons are at V4 and Safe-owned, every production receipt vault
+    /// reports the V4 clone as its authoriser, and the Safe identity +
+    /// threshold are unchanged. Split from `run()` so tests can drive it
+    /// against a deliberately-malformed post-state (e.g. an un-swapped vault)
+    /// and assert the `VaultAuthoriserMismatchPostUpgrade` guard fires.
     /// @param safe The ST0x token-owner Safe.
     /// @param vaults The production receipt vaults the swap targets.
     function _assertPostState(IGnosisSafe safe, address[] memory vaults) internal view {
-        // Beacon now at V4, still Safe-owned.
-        LibBeaconInvariants.assertBeaconInvariants(BEACON, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE, V4_IMPL);
+        // All three beacons now at their V4 implementations, still
+        // Safe-owned.
+        address[3] memory beaconList = beacons();
+        address[3] memory v4ImplList = v4Impls();
+        for (uint256 i = 0; i < beaconList.length; i++) {
+            LibBeaconInvariants.assertBeaconInvariants(
+                beaconList[i], LibBeaconInvariants.PROD_BEACON_OWNER, v4ImplList[i]
+            );
+        }
         // Every production receipt vault now authorised by the V4 clone.
         for (uint256 i = 0; i < vaults.length; i++) {
             address actual = address(IAuthorizableV1(vaults[i]).authorizer());

--- a/test/script/20260623-upgrade-receipt-vaults-to-v4.t.sol
+++ b/test/script/20260623-upgrade-receipt-vaults-to-v4.t.sol
@@ -132,14 +132,14 @@ contract UpgradeReceiptVaultsToV4Test is Test {
         upgradeScript.run();
 
         // The artifact landed with the pinned bundle name and the expected
-        // shape: 1 beacon upgrade + one setAuthorizer per production vault.
+        // shape: 3 beacon upgrades + one setAuthorizer per production vault.
         string memory json = vm.readFile("out/v4-upgrade.json");
         assertEq(
             vm.parseJsonString(json, ".meta.name"),
             "ST0x receipt vault V4 upgrade + authoriser swap",
             "artifact bundle name"
         );
-        uint256 expectedTxCount = 1 + LibTokenInvariants.productionReceiptVaults().length;
+        uint256 expectedTxCount = 3 + LibTokenInvariants.productionReceiptVaults().length;
         assertTrue(
             vm.keyExistsJson(json, string.concat(".transactions[", vm.toString(expectedTxCount - 1), "].to")),
             "last expected tx present"
@@ -152,10 +152,10 @@ contract UpgradeReceiptVaultsToV4Test is Test {
 
     /// @notice `_assertPostState` reverts `VaultAuthoriserMismatchPostUpgrade`
     /// when a production vault still reports a non-V4-clone authoriser after
-    /// the beacon leg. Drives the beacon to V4 (so the beacon post-state
-    /// passes) but leaves authorisers un-swapped, so the per-vault loop trips
-    /// on vault 0. Exercises the post-state guard the placeholder clone pin
-    /// otherwise keeps `run()` from ever reaching.
+    /// the beacon leg. Drives all three beacons to their V4 impls (so the
+    /// beacon post-state passes) but leaves authorisers un-swapped, so the
+    /// per-vault loop trips on vault 0. Exercises the post-state guard the
+    /// placeholder clone pin otherwise keeps `run()` from ever reaching.
     function testAssertPostStateRevertsWhenVaultNotSwapped() external {
         _forkAndMigrateBeaconOwnership();
         deployCodeTo("src/concrete/StoxReceiptVault.sol:StoxReceiptVault", V4_IMPL);
@@ -163,8 +163,16 @@ contract UpgradeReceiptVaultsToV4Test is Test {
             "src/concrete/StoxCorporateActionsFacet.sol:StoxCorporateActionsFacet",
             LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_1
         );
+        // All three V1 beacons to their V4 impls (receipt + wrapped impls
+        // are live on Base already; the receipt-vault impl was planted
+        // above).
+        vm.prank(LibBeaconInvariants.PROD_BEACON_OWNER);
+        IUpgradeableBeacon(LibProdDeployV1.STOX_RECEIPT_BEACON_V1).upgradeTo(LibProdDeployV4.STOX_RECEIPT_0_1_1);
         vm.prank(LibBeaconInvariants.PROD_BEACON_OWNER);
         IUpgradeableBeacon(BEACON).upgradeTo(V4_IMPL);
+        vm.prank(LibBeaconInvariants.PROD_BEACON_OWNER);
+        IUpgradeableBeacon(LibProdDeployV1.STOX_WRAPPED_TOKEN_VAULT_BEACON_V1)
+            .upgradeTo(LibProdDeployV4.STOX_WRAPPED_TOKEN_VAULT_0_1_1);
 
         UpgradeReceiptVaultsToV4Harness harness = new UpgradeReceiptVaultsToV4Harness();
         IGnosisSafe safe = IGnosisSafe(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE);


### PR DESCRIPTION
## Summary

The swap bundle previously upgraded only the receipt-vault beacon. Every live production token proxies through **three** V1 beacons — receipt (ERC-1155), receipt vault (ERC-20), wrapped token vault (ERC-4626) — whose V4 implementations assume each other's V4 behaviour, so they must move together.

**New bundle shape (23 txs):**
1. receipt beacon → `STOX_RECEIPT_0_1_1`
2. receipt-vault beacon → `STOX_RECEIPT_VAULT_0_1_1`
3. wrapped-token-vault beacon → `STOX_WRAPPED_TOKEN_VAULT_0_1_1`
4. …23. `setAuthorizer(V4 clone)` × 20 production vaults

Per beacon: pre-flight (Safe-owned via `LibBeaconInvariants.PROD_BEACON_OWNER` + still at V1 impl; V4 impl deployed with the audited codehash), post-state (at V4 impl, still Safe-owned), and n+1 reversibility (the Safe rolls each back to its V1 impl under the live threshold).

`run()` split into `_preflightBeaconsAndImpls` / `_preflightClone` / `_buildBundle` helpers (stack-too-deep with the beacon arrays inline).

**GREEN**: `testRunCompletesAndWritesArtifact` proves the 23-tx bundle authors end-to-end against unmodified live Base state — this is the exact dry-run the `run-script` dispatch executes. Merge before dispatching runbook step 5.

Stack: `#252 (clone pin) → this PR → #254 (invariant repoint, red until execution)`.