### PR TITLE
feat(beacon): migrate Ethereum production beacons to the Ethereum Safe

### DIFF
--- a/script/20260716-migrate-beacon-owners-ethereum.s.sol
+++ b/script/20260716-migrate-beacon-owners-ethereum.s.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
+import {LibProdBeaconsEthereum} from "../src/lib/LibProdBeaconsEthereum.sol";
+import {LibProdDeployV1} from "../src/lib/LibProdDeployV1.sol";
+import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
+import {LibBeaconInvariants} from "../src/lib/LibBeaconInvariants.sol";
+
+/// @title MigrateBeaconOwnersEthereum
+/// @notice Transfers ownership of the three ST0x production beacons on
+/// **Ethereum mainnet** from the deploy EOA (`LibProdDeployV1.BEACON_INITIAL_OWNER`,
+/// rainlang.eth) to the Ethereum token-owner Safe
+/// (`LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM`). The Ethereum
+/// equivalent of `MigrateBeaconOwners` (which already ran this migration for
+/// Base's V1 beacons, #253) — the beacons differ per chain by deployer version
+/// but the operation is identical.
+///
+/// @dev This is a **deploy-key broadcast**, not a Safe artifact: the beacons
+/// are EOA-owned, so the migration is the EOA calling `transferOwnership`.
+/// Broadcast as the EOA:
+///
+///   forge script script/20260716-migrate-beacon-owners-ethereum.s.sol \
+///     --rpc-url ethereum --broadcast --private-key <EOA key>
+///
+/// Ordering: run AFTER the Ethereum Safe's threshold has been raised to match
+/// Base (3-of-6). The beacons are not yet backing any vaults (no Ethereum
+/// proxies exist yet), so this is pure ownership hand-off with no live-vault
+/// risk — but doing it early makes the "Ethereum beacons are Safe-owned"
+/// invariant (`EthereumBeaconOwnershipTest`) go green.
+contract MigrateBeaconOwnersEthereum is Script {
+    /// @notice Pre-flight every beacon against the EOA-owned state, broadcast
+    /// the three `transferOwnership` calls to the Ethereum Safe, then re-assert
+    /// every beacon against the Safe-owned state. Implementations are asserted
+    /// unchanged across the transfer.
+    function run() external {
+        address safe = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM;
+        require(safe != address(0), "Ethereum token-owner Safe not pinned");
+        address[3] memory beaconList = LibProdBeaconsEthereum.beacons();
+        address[3] memory implList = LibProdBeaconsEthereum.implementations();
+
+        // Pre-flight: every beacon is deployed, is the OZ UpgradeableBeacon,
+        // is still owned by the deploy EOA, and points at its pinned impl.
+        // Reverts with the relevant typed error on the first drift, before any
+        // broadcast happens.
+        for (uint256 i = 0; i < beaconList.length; i++) {
+            LibBeaconInvariants.assertBeaconInvariants(beaconList[i], LibProdDeployV1.BEACON_INITIAL_OWNER, implList[i]);
+        }
+
+        // Broadcast the ownership transfers from the EOA — three separate
+        // transactions, one per beacon.
+        vm.startBroadcast();
+        for (uint256 i = 0; i < beaconList.length; i++) {
+            Ownable(beaconList[i]).transferOwnership(safe);
+        }
+        vm.stopBroadcast();
+
+        // Post-state: every beacon is now Safe-owned, implementations
+        // unchanged.
+        for (uint256 i = 0; i < beaconList.length; i++) {
+            LibBeaconInvariants.assertBeaconInvariants(beaconList[i], safe, implList[i]);
+        }
+
+        console2.log("Transferred ownership of 3 Ethereum beacons to:", vm.toString(safe));
+    }
+}

--- a/src/lib/LibProdBeaconsEthereum.sol
+++ b/src/lib/LibProdBeaconsEthereum.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {IST0xVaultBeaconSet} from "../interface/IST0xVaultBeaconSet.sol";
+import {LibProdDeployV4} from "../generated/LibProdDeployV4.sol";
+
+/// @title LibProdBeaconsEthereum
+/// @notice The three ST0x production beacons on **Ethereum mainnet** and the
+/// implementations they point at — every address traced to the generated
+/// `0_1_1` pins rather than re-pasted as fresh literals.
+/// @dev Ethereum bootstrapped fresh at the **0.1.1** release, so its beacons
+/// and impls are the `0_1_1` deployment. Two principles keep this lib free of
+/// pasted addresses:
+///
+/// 1. **Implementations are chain-agnostic.** They are deployed
+///    deterministically (Zoltu), so a version's impl has the SAME address on
+///    every chain — matching impls across chains is the goal. `implementations()`
+///    references the generated `0_1_1` impl pins directly; there is no second
+///    copy to drift.
+///
+/// 2. **Beacons are per-chain, sourced from the generated `0_1_1` pins.** A
+///    proxy points at the beacon; the beacon points at the (versioned) impl —
+///    the beacon is the non-versioned anchor, so cross-chain parity compares
+///    the beacon's IMPLEMENTATION, not its address. The wrapped-token-vault
+///    beacon has its own generated pin (`STOX_WRAPPED_TOKEN_VAULT_BEACON_0_1_1`)
+///    so it is referenced directly. The receipt and receipt-vault beacons are
+///    NOT emitted as individual generated pointers — they are created by, and
+///    read live from, the generated `0_1_1` beacon-set-deployer
+///    (`STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_0_1_1`) via its
+///    `iReceiptBeacon()` / `iOffchainAssetReceiptVaultBeacon()` getters. So all
+///    three beacon addresses resolve from `0_1_1` pins, none are hand-pasted.
+///
+/// As deployed, all three beacons are owned by
+/// `LibProdDeployV1.BEACON_INITIAL_OWNER` (rainlang.eth, the deploy EOA). The
+/// Ethereum migration (`20260716-migrate-beacon-owners-ethereum`) transfers
+/// them to `LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM`, mirroring what
+/// `MigrateBeaconOwners` already did for Base's beacons.
+library LibProdBeaconsEthereum {
+    /// @notice The three production beacons, in a fixed order (receipt,
+    /// receipt vault, wrapped token vault) — index-aligned with
+    /// `implementations()`. The receipt / receipt-vault beacons are read from
+    /// the `0_1_1` beacon-set-deployer's getters; the wrapped beacon is its
+    /// generated `0_1_1` pin. `view` because the first two are live reads from
+    /// the deployer (which is why callers run against an Ethereum fork).
+    /// @return The three Ethereum beacon addresses.
+    function beacons() internal view returns (address[3] memory) {
+        IST0xVaultBeaconSet deployer =
+            IST0xVaultBeaconSet(LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_0_1_1);
+        return [
+            address(deployer.iReceiptBeacon()),
+            address(deployer.iOffchainAssetReceiptVaultBeacon()),
+            LibProdDeployV4.STOX_WRAPPED_TOKEN_VAULT_BEACON_0_1_1
+        ];
+    }
+
+    /// @notice The implementation each beacon points at, index-aligned with
+    /// `beacons()`. Referenced from the generated `0_1_1` impl pins — the same
+    /// deterministic addresses on every chain, so no separate Ethereum copy.
+    /// Asserted unchanged across the ownership transfer.
+    /// @return The three implementation addresses.
+    function implementations() internal pure returns (address[3] memory) {
+        return [
+            LibProdDeployV4.STOX_RECEIPT_0_1_1,
+            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1,
+            LibProdDeployV4.STOX_WRAPPED_TOKEN_VAULT_0_1_1
+        ];
+    }
+}

--- a/test/src/concrete/deploy/EthereumBeaconOwnership.t.sol
+++ b/test/src/concrete/deploy/EthereumBeaconOwnership.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibProdBeaconsEthereum} from "../../../../src/lib/LibProdBeaconsEthereum.sol";
+import {LibProdDeployV1} from "../../../../src/lib/LibProdDeployV1.sol";
+import {LibSafeInvariants} from "../../../../src/lib/LibSafeInvariants.sol";
+import {LibBeaconInvariants} from "../../../../src/lib/LibBeaconInvariants.sol";
+import {LibStoxDeployNetworks} from "../../../../src/lib/LibStoxDeployNetworks.sol";
+
+/// @title EthereumBeaconOwnershipTest
+/// @notice The forcing function for the Ethereum beacon-ownership migration.
+/// Ethereum's 3 production beacons are deployed but still owned by the deploy
+/// EOA (`LibProdDeployV1.BEACON_INITIAL_OWNER`, rainlang.eth). ST0x requires
+/// every chain's beacons to be owned by that chain's token-owner Safe (Base's
+/// were migrated in #253); until the Ethereum migration
+/// (`20260716-migrate-beacon-owners-ethereum`) runs, this invariant is RED by
+/// design — that is exactly what forces the migration to happen. It goes green
+/// the moment ownership lands on `STOX_TOKEN_OWNER_SAFE_ETHEREUM`, and stays
+/// green in CI thereafter (catching any later ownership drift).
+contract EthereumBeaconOwnershipTest is Test {
+    /// Every Ethereum beacon is owned by the Ethereum token-owner Safe (with
+    /// the OZ beacon codehash + its pinned impl unchanged). RED until the
+    /// migration transfers ownership from the deploy EOA to the Safe.
+    function testEthereumBeaconsAreSafeOwned() external {
+        address safe = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM;
+        if (safe == address(0)) {
+            emit log("PENDING: Ethereum token-owner Safe not yet pinned - beacon-owner invariant cannot run");
+            return;
+        }
+
+        vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
+        address[3] memory beacons = LibProdBeaconsEthereum.beacons();
+        address[3] memory impls = LibProdBeaconsEthereum.implementations();
+        for (uint256 i = 0; i < beacons.length; i++) {
+            LibBeaconInvariants.assertBeaconInvariants(beacons[i], safe, impls[i]);
+        }
+    }
+}


### PR DESCRIPTION
Ethereum's 3 production beacons (0.1.1 deployer-created, distinct from Base's
V1 beacons by deployer version — the beacon is the non-versioned anchor) are
deployed but still owned by the deploy EOA (rainlang.eth). Add:

- LibProdBeaconsEthereum: the 3 beacon + 3 impl pins (read from the live 0.1.1
  beacon-set-deployers on Ethereum; all OZ UpgradeableBeacons).
- 20260716-migrate-beacon-owners-ethereum.s.sol: a deploy-key broadcast (the
  EOA transferOwnership) moving the 3 beacons to STOX_TOKEN_OWNER_SAFE_ETHEREUM,
  mirroring MigrateBeaconOwners (which did this for Base's V1 beacons, #253).
- EthereumBeaconOwnershipTest: the forcing function — asserts the beacons are
  Safe-owned, RED until the migration runs, green + drift-guarded after.

No Ethereum proxies exist yet, so this is pure ownership hand-off.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VPs1hCTxusmaSeFKvoc4Kr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Ethereum production migration script to transfer ownership of three beacons to the designated token-owner Safe.
  * Added centralized access to Ethereum production beacon and implementation addresses.

* **Tests**
  * Added validation covering beacon ownership, implementations, and deployment invariants.
  * Tests now verify that all Ethereum production beacons are controlled by the designated Safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->