### PR TITLE
feat(tokens): add HOOD, ORCL, SMCI, BABA, TQQQ across Base, Ethereum and HyperEVM

### DIFF
--- a/src/lib/LibProdTokenConfig.sol
+++ b/src/lib/LibProdTokenConfig.sol
@@ -24,7 +24,7 @@ struct TokenConfig {
 }
 
 /// @title LibProdTokenConfig
-/// @notice The canonical name/symbol table for the 28 ST0x production
+/// @notice The canonical name/symbol table for the ST0x production
 /// tokens, captured verbatim from the live Base receipt vaults so a new
 /// chain's token set can be deployed byte-identical to Base. This is the
 /// deploy-input companion to `LibTokenInvariants` (which holds the deployed
@@ -48,7 +48,7 @@ struct TokenConfig {
 /// convention such a row follows is `"<issuer's legal name> ST0x"`, with
 /// `" ADR"` before the suffix for depositary receipts (see TSM, SKHY).
 library LibProdTokenConfig {
-    /// @notice The 28 production token deploy configs, Base table order.
+    /// @notice The production token deploy configs, Base table order.
     /// @return configs The name/symbol table.
     function productionTokenConfigs() internal pure returns (TokenConfig[] memory configs) {
         configs = new TokenConfig[](34);

--- a/src/lib/LibProdTokenConfig.sol
+++ b/src/lib/LibProdTokenConfig.sol
@@ -41,11 +41,17 @@ struct TokenConfig {
 /// Base — notably `SGOV`'s name has a leading space. Matching Base "exactly"
 /// means carrying that space forward; the parity pin would flag it as a
 /// divergence otherwise.
+///
+/// @dev A ticker deployed on Base after this table was first captured has no
+/// live Base vault to capture strings from at the time it is authored, so its
+/// `name` / `symbol` originate here and the Base deploy uses them. The
+/// convention such a row follows is `"<issuer's legal name> ST0x"`, with
+/// `" ADR"` before the suffix for depositary receipts (see TSM, SKHY).
 library LibProdTokenConfig {
     /// @notice The 28 production token deploy configs, Base table order.
     /// @return configs The name/symbol table.
     function productionTokenConfigs() internal pure returns (TokenConfig[] memory configs) {
-        configs = new TokenConfig[](29);
+        configs = new TokenConfig[](34);
         configs[0] = TokenConfig("MSTR", "MicroStrategy Incorporated ST0x", "tMSTR");
         configs[1] = TokenConfig("TSLA", "Tesla Inc ST0x", "tTSLA");
         configs[2] = TokenConfig("COIN", "Coinbase Global Inc ST0x", "tCOIN");
@@ -76,5 +82,14 @@ library LibProdTokenConfig {
         configs[26] = TokenConfig("LRCX", "Lam Research Corporation ST0x", "tLRCX");
         configs[27] = TokenConfig("TTWO", "Take-Two Interactive Software, Inc. ST0x", "tTTWO");
         configs[28] = TokenConfig("RKLB", "Rocket Lab USA Inc ST0x", "tRKLB");
+        configs[29] = TokenConfig("HOOD", "Robinhood Markets, Inc. ST0x", "tHOOD");
+        configs[30] = TokenConfig("ORCL", "Oracle Corporation ST0x", "tORCL");
+        configs[31] = TokenConfig("SMCI", "Super Micro Computer, Inc. ST0x", "tSMCI");
+        // BABA trades in the US as a depositary receipt, hence the " ADR"
+        // suffix, matching TSM and SKHY.
+        configs[32] = TokenConfig("BABA", "Alibaba Group Holding Limited ADR ST0x", "tBABA");
+        // TQQQ is a leveraged ETF rather than a plain equity; the name follows
+        // the fund's own product name.
+        configs[33] = TokenConfig("TQQQ", "ProShares UltraPro QQQ ST0x", "tTQQQ");
     }
 }

--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -390,7 +390,7 @@ library LibTokenInvariants {
         // run's logged (underlying, receipt, receiptVault, wrapped) tuples.
         // Order and underlyings match Base row-for-row (the cross-chain
         // parity pin asserts this).
-        tokens = new TokenInstance[](29);
+        tokens = new TokenInstance[](34);
         tokens[0] = TokenInstance(
             "MSTR",
             address(0xE3772C8695c2cf3dcAA2Dd29759f4Bb91a342763),
@@ -570,6 +570,36 @@ library LibTokenInvariants {
             address(0xED0c085d92C262FB46937CB0B3C9763Af7fCCf30),
             address(0x8FC87Be766C0cB6f254F1FDc9351D4B85B560FB3)
         );
+        tokens[29] = TokenInstance(
+            "HOOD",
+            address(0x9e2C9bE59aEB0D9ea7bF070B37fc02AF8a5af239),
+            address(0xDA52106FC0D44096Fd500E096b9045FdAc1d27B9),
+            address(0x3209384FB852E7D0510aFa896236f3f866c3876f)
+        );
+        tokens[30] = TokenInstance(
+            "ORCL",
+            address(0xE3D23D83a750789D6c4150B70013D896e623c948),
+            address(0xC982730643321f3643436Eb4a6E910219Caa55f0),
+            address(0x1B2A2C8c3621642c64cf1245016488fA0f76da78)
+        );
+        tokens[31] = TokenInstance(
+            "SMCI",
+            address(0x1B5df34bD6397Ba7d9A365263692A006e7a2972a),
+            address(0x3b3936b5Ec170Cdb5823012dBF4dF1d56Cfa1ba5),
+            address(0x8DdAEC53399E5324BbC60a368eA853c713629B1d)
+        );
+        tokens[32] = TokenInstance(
+            "BABA",
+            address(0xB7D42b94A8E51b098270ac92ceD23fDC8042FDB3),
+            address(0x15d415952a36D4cE80671e918B2531bdB25274E5),
+            address(0x908266E3C3bFBb603d2EdF295deBE37C88985239)
+        );
+        tokens[33] = TokenInstance(
+            "TQQQ",
+            address(0x58916AC4e186ad201376288a6655Ea46b55b8ac5),
+            address(0xf3875383506677BCdA6b9F12c48Ff7fE300970D7),
+            address(0x04eE4ED5FF6643eA955503f966012b684f479966)
+        );
     }
 
     /// @notice Returns the 29 production token instance triples on HyperEVM,
@@ -584,7 +614,7 @@ library LibTokenInvariants {
         // (underlying, receipt, receiptVault, wrapped) tuples. The script that
         // ran it was per-chain and has since been superseded by
         // `20260807-deploy-missing-tokens`, so this is the record of the run.
-        tokens = new TokenInstance[](29);
+        tokens = new TokenInstance[](34);
         tokens[0] = TokenInstance(
             "MSTR",
             0xE3772C8695c2cf3dcAA2Dd29759f4Bb91a342763,
@@ -758,6 +788,36 @@ library LibTokenInvariants {
             0xFf5b15a4f478F296893b0b244D9b118Be87bCda2,
             0xED0c085d92C262FB46937CB0B3C9763Af7fCCf30,
             0x8FC87Be766C0cB6f254F1FDc9351D4B85B560FB3
+        );
+        tokens[29] = TokenInstance(
+            "HOOD",
+            0x9e2C9bE59aEB0D9ea7bF070B37fc02AF8a5af239,
+            0xDA52106FC0D44096Fd500E096b9045FdAc1d27B9,
+            0x3209384FB852E7D0510aFa896236f3f866c3876f
+        );
+        tokens[30] = TokenInstance(
+            "ORCL",
+            0xE3D23D83a750789D6c4150B70013D896e623c948,
+            0xC982730643321f3643436Eb4a6E910219Caa55f0,
+            0x1B2A2C8c3621642c64cf1245016488fA0f76da78
+        );
+        tokens[31] = TokenInstance(
+            "SMCI",
+            0x1B5df34bD6397Ba7d9A365263692A006e7a2972a,
+            0x3b3936b5Ec170Cdb5823012dBF4dF1d56Cfa1ba5,
+            0x8DdAEC53399E5324BbC60a368eA853c713629B1d
+        );
+        tokens[32] = TokenInstance(
+            "BABA",
+            0xB7D42b94A8E51b098270ac92ceD23fDC8042FDB3,
+            0x15d415952a36D4cE80671e918B2531bdB25274E5,
+            0x908266E3C3bFBb603d2EdF295deBE37C88985239
+        );
+        tokens[33] = TokenInstance(
+            "TQQQ",
+            0x58916AC4e186ad201376288a6655Ea46b55b8ac5,
+            0xf3875383506677BCdA6b9F12c48Ff7fE300970D7,
+            0x04eE4ED5FF6643eA955503f966012b684f479966
         );
     }
 

--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -378,9 +378,9 @@ library LibTokenInvariants {
     }
 
     /// @notice Returns the production token instance triples on Ethereum
-    /// mainnet — the same 29 underlyings as Base, in the same order, so the
+    /// mainnet — the same underlyings as Base, in the same order, so the
     /// two tables pair by index as well as by key.
-    /// @return tokens The 29 production token instances on Ethereum.
+    /// @return tokens The production token instances on Ethereum.
     function productionTokensEthereum() internal pure returns (TokenInstance[] memory tokens) {
         // Deployed on Ethereum mainnet 2026-07-22 by
         // `20260706-deploy-tokens-ethereum` (manual-broadcast run
@@ -602,10 +602,10 @@ library LibTokenInvariants {
         );
     }
 
-    /// @notice Returns the 29 production token instance triples on HyperEVM,
+    /// @notice Returns the production token instance triples on HyperEVM,
     /// in the same row order as `productionTokensBase()` (the cross-chain
     /// parity pin asserts the alignment).
-    /// @return tokens The 29 production token instances on HyperEVM.
+    /// @return tokens The production token instances on HyperEVM.
     function productionTokensHyperEvm() internal pure returns (TokenInstance[] memory tokens) {
         // Deployed on HyperEVM 2026-07-24 (manual-broadcast run 30114307165):
         // all 29 tokens via the 0.1.1 unified deployer, each wired onto the
@@ -821,13 +821,13 @@ library LibTokenInvariants {
         );
     }
 
-    /// @notice Returns the 29 production receipt vault addresses on Base, in
+    /// @notice Returns the production receipt vault addresses on Base, in
     /// the order they were deployed. Provided so consumers (e.g. invariant
     /// assertions, migration scripts) can iterate without hardcoding the
     /// list inline.
     /// @dev Derived from `productionTokensBase()` so the token table is the
     /// single source of truth and the two accessors cannot drift.
-    /// @return vaults The 29 production receipt vault addresses on Base.
+    /// @return vaults The production receipt vault addresses on Base.
     function productionReceiptVaults() internal pure returns (address[] memory vaults) {
         TokenInstance[] memory tokens = productionTokensBase();
         vaults = new address[](tokens.length);

--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -293,14 +293,54 @@ library LibTokenInvariants {
     /// https://basescan.org/address/0xF4f8c66085910d583c01f3b4e44Bf731D4e2c565
     address internal constant RKLB_WRAPPED_TOKEN_VAULT = address(0xF4f8c66085910d583c01f3b4e44Bf731D4e2c565);
 
-    /// @notice Returns the 29 production token instance triples on Base, in
+    // ---- tHOOD / wtHOOD — Robinhood Markets, Inc. ST0x ----
+    /// https://basescan.org/address/0x942639370E1c095ECCe2BdffebFB295d0B3e384e
+    address internal constant HOOD_RECEIPT = address(0x942639370E1c095ECCe2BdffebFB295d0B3e384e);
+    /// https://basescan.org/address/0x5cEfd886dD05001c2Fc32c313E05360D07f37d8f
+    address internal constant HOOD_RECEIPT_VAULT = address(0x5cEfd886dD05001c2Fc32c313E05360D07f37d8f);
+    /// https://basescan.org/address/0xd50f561322fe3235DBc9Ec8b3aB7693383d8A425
+    address internal constant HOOD_WRAPPED_TOKEN_VAULT = address(0xd50f561322fe3235DBc9Ec8b3aB7693383d8A425);
+
+    // ---- tORCL / wtORCL — Oracle Corporation ST0x ----
+    /// https://basescan.org/address/0xBaf83f5D1dbC8CF4D5F5BCb93EfE23d0E333223f
+    address internal constant ORCL_RECEIPT = address(0xBaf83f5D1dbC8CF4D5F5BCb93EfE23d0E333223f);
+    /// https://basescan.org/address/0x57573351f3fdD20a57dEE4a7f836de1cE9900d4B
+    address internal constant ORCL_RECEIPT_VAULT = address(0x57573351f3fdD20a57dEE4a7f836de1cE9900d4B);
+    /// https://basescan.org/address/0xCB9571aB96aA47374eF30D8E9ACCC1cD51064726
+    address internal constant ORCL_WRAPPED_TOKEN_VAULT = address(0xCB9571aB96aA47374eF30D8E9ACCC1cD51064726);
+
+    // ---- tSMCI / wtSMCI — Super Micro Computer, Inc. ST0x ----
+    /// https://basescan.org/address/0xC23aC719988d2ABeffEE8AC75C790E328c44Fe79
+    address internal constant SMCI_RECEIPT = address(0xC23aC719988d2ABeffEE8AC75C790E328c44Fe79);
+    /// https://basescan.org/address/0x8518931497d2A8f07Bc607D1D3295b398D065A65
+    address internal constant SMCI_RECEIPT_VAULT = address(0x8518931497d2A8f07Bc607D1D3295b398D065A65);
+    /// https://basescan.org/address/0xA759FAbbD866e6DB8bF76613C35825dC2e380bf0
+    address internal constant SMCI_WRAPPED_TOKEN_VAULT = address(0xA759FAbbD866e6DB8bF76613C35825dC2e380bf0);
+
+    // ---- tBABA / wtBABA — Alibaba Group Holding Limited ADR ST0x ----
+    /// https://basescan.org/address/0x635983387673B0Da01f70a94985c6F88BfAf78c2
+    address internal constant BABA_RECEIPT = address(0x635983387673B0Da01f70a94985c6F88BfAf78c2);
+    /// https://basescan.org/address/0x6B8fa7288dBEc7C1c62BfE59Cbd7Bec7EBF846C5
+    address internal constant BABA_RECEIPT_VAULT = address(0x6B8fa7288dBEc7C1c62BfE59Cbd7Bec7EBF846C5);
+    /// https://basescan.org/address/0x7e5cc7eAe0455A07Ab4abf354E0f5657BA2888BD
+    address internal constant BABA_WRAPPED_TOKEN_VAULT = address(0x7e5cc7eAe0455A07Ab4abf354E0f5657BA2888BD);
+
+    // ---- tTQQQ / wtTQQQ — ProShares UltraPro QQQ ST0x ----
+    /// https://basescan.org/address/0x81eFD642eBb942D725C4B035e7C3Cad154a37FAF
+    address internal constant TQQQ_RECEIPT = address(0x81eFD642eBb942D725C4B035e7C3Cad154a37FAF);
+    /// https://basescan.org/address/0xcA1A378F9a250131A2fE51c10f120FeF7EDCa56E
+    address internal constant TQQQ_RECEIPT_VAULT = address(0xcA1A378F9a250131A2fE51c10f120FeF7EDCa56E);
+    /// https://basescan.org/address/0x295e9eCAb319006900a53b3f8D6Fcb0C131F4ada
+    address internal constant TQQQ_WRAPPED_TOKEN_VAULT = address(0x295e9eCAb319006900a53b3f8D6Fcb0C131F4ada);
+
+    /// @notice Returns the production token instance triples on Base, in
     /// the order they were deployed. This is the structured source of truth
     /// the flat `productionReceiptVaults()` accessor derives from; consumers
     /// that need the receipt / wrapped-vault legs or the underlying join key
     /// (cross-chain parity, per-token config checks) iterate this instead.
-    /// @return tokens The 29 production token instances on Base.
+    /// @return tokens The production token instances on Base.
     function productionTokensBase() internal pure returns (TokenInstance[] memory tokens) {
-        tokens = new TokenInstance[](29);
+        tokens = new TokenInstance[](34);
         tokens[0] = TokenInstance("MSTR", MSTR_RECEIPT, MSTR_RECEIPT_VAULT, MSTR_WRAPPED_TOKEN_VAULT);
         tokens[1] = TokenInstance("TSLA", TSLA_RECEIPT, TSLA_RECEIPT_VAULT, TSLA_WRAPPED_TOKEN_VAULT);
         tokens[2] = TokenInstance("COIN", COIN_RECEIPT, COIN_RECEIPT_VAULT, COIN_WRAPPED_TOKEN_VAULT);
@@ -330,6 +370,11 @@ library LibTokenInvariants {
         tokens[26] = TokenInstance("LRCX", LRCX_RECEIPT, LRCX_RECEIPT_VAULT, LRCX_WRAPPED_TOKEN_VAULT);
         tokens[27] = TokenInstance("TTWO", TTWO_RECEIPT, TTWO_RECEIPT_VAULT, TTWO_WRAPPED_TOKEN_VAULT);
         tokens[28] = TokenInstance("RKLB", RKLB_RECEIPT, RKLB_RECEIPT_VAULT, RKLB_WRAPPED_TOKEN_VAULT);
+        tokens[29] = TokenInstance("HOOD", HOOD_RECEIPT, HOOD_RECEIPT_VAULT, HOOD_WRAPPED_TOKEN_VAULT);
+        tokens[30] = TokenInstance("ORCL", ORCL_RECEIPT, ORCL_RECEIPT_VAULT, ORCL_WRAPPED_TOKEN_VAULT);
+        tokens[31] = TokenInstance("SMCI", SMCI_RECEIPT, SMCI_RECEIPT_VAULT, SMCI_WRAPPED_TOKEN_VAULT);
+        tokens[32] = TokenInstance("BABA", BABA_RECEIPT, BABA_RECEIPT_VAULT, BABA_WRAPPED_TOKEN_VAULT);
+        tokens[33] = TokenInstance("TQQQ", TQQQ_RECEIPT, TQQQ_RECEIPT_VAULT, TQQQ_WRAPPED_TOKEN_VAULT);
     }
 
     /// @notice Returns the production token instance triples on Ethereum

--- a/test/src/lib/LibProdTokenConfig.t.sol
+++ b/test/src/lib/LibProdTokenConfig.t.sol
@@ -36,7 +36,12 @@ contract LibProdTokenConfigTest is Test {
         vm.createSelectFork(LibRainDeploy.BASE);
         TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
         TokenInstance[] memory tokens = LibTokenInvariants.productionTokensBase();
-        for (uint256 i = 0; i < configs.length; i++) {
+        // Bounded by the DEPLOYED table, not the config table: a config row
+        // authored ahead of its Base deploy has no live vault to compare
+        // against. Any length divergence is `testConfigAlignsWithBaseTokenTable`'s
+        // to report — bounding here keeps that one clear failure instead of an
+        // out-of-bounds panic on top of it.
+        for (uint256 i = 0; i < tokens.length; i++) {
             IERC20Metadata vault = IERC20Metadata(tokens[i].receiptVault);
             assertEq(
                 configs[i].name, vault.name(), string.concat(configs[i].underlying, ": config name != live Base name")
@@ -58,7 +63,8 @@ contract LibProdTokenConfigTest is Test {
         vm.createSelectFork(LibRainDeploy.BASE);
         TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
         TokenInstance[] memory tokens = LibTokenInvariants.productionTokensBase();
-        for (uint256 i = 0; i < configs.length; i++) {
+        // Bounded by the deployed table — see `testConfigMatchesLiveBase`.
+        for (uint256 i = 0; i < tokens.length; i++) {
             IERC20Metadata wrapped = IERC20Metadata(tokens[i].wrappedTokenVault);
             assertEq(
                 wrapped.name(),


### PR DESCRIPTION
Adds **HOOD, ORCL, SMCI, BABA, TQQQ** to the canonical token set and pins their deployed instances on **Base, Ethereum and HyperEVM**.

Based on `main`, which carries the merged `20260807-deploy-missing-tokens` script from [#291](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/291).

## Two commits

**1. Add to the canonical set.** Five `TokenConfig` rows plus their Base `TokenInstance` rows and address constants, following the existing basescan-linked pattern.

**2. Pin the copies.** The Ethereum and HyperEVM triples logged by the two broadcasts:

| chain | `manual-broadcast` run |
|---|---|
| ethereum | `31613854321` |
| hyperevm | `31614605147` |

Each run selected exactly the five tokens Base had and the target chain lacked, and deployed them with the name/symbol from the canonical config, so all three chains serve identical strings. The addresses match across Ethereum and HyperEVM — the same property every other row in those tables already has, since the 0.1.1 core is Zoltu-deterministic and both chains bootstrap at it from the same deploy key.

## Verified on-chain, not taken on trust

The Base addresses came from `st0x.registry`'s Base list; the Ethereum and HyperEVM ones came from the broadcast logs. Every value was then checked against the chain it belongs to:

- each receipt vault's `name`, `symbol` and `decimals`
- `receiptVault.receipt()` equals the pinned receipt
- `wrapped.asset()` equals the receipt vault
- the wrapped leg derives `"Wrapped " + name` and `"w" + symbol` (Base)
- every vault is owned by that chain's token-owner Safe
- every vault carries that chain's V4 authoriser clone

All fifteen instances pass. The names follow the convention the existing rows use, including the `" ADR"` suffix on BABA that TSM and SKHY also carry.

## CI

840 tests pass, with no failures other than public-RPC rate limits. `rainix-sol-static`, `rainix-sol-legal` and `rainix-sol-single-contract` are all clean.

`testCrossChainParity` and `testEthereumTokenTableMirrorsBaseUnderlyings` pass, and parity now covers all 34 tokens across the three chains rather than skipping the new ones.

## Not included

The registry's Base list also carries **AAPL, GOOGL, INTC, LLY, MSFT, PTY**, which are absent from the canonical set. They are live on Base, so `20260807-deploy-missing-tokens` will not carry them to Ethereum or HyperEVM either — the same gap these five had, out of scope here.

Separately, **IBHG** and **RKLB** are in the canonical set but not in the registry's Base list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production token support for HOOD, ORCL, SMCI, BABA, and TQQQ.
  * Added associated receipt, vault, and wrapped-vault token configurations across supported networks.

* **Bug Fixes**
  * Improved token validation to handle differing configuration and deployment record counts without runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->