### PR TITLE
feat(timelock): permissionless execution

### DIFF
--- a/docs/TIMELOCK.md
+++ b/docs/TIMELOCK.md
@@ -40,9 +40,19 @@ timelock). That keeps the audited contract set untouched.
 | -------------------- | ------------------------------------------------------ | --------------------------------------------------------------- |
 | `PROPOSER_ROLE`      | token-owner Safe                                       | schedules operations                                            |
 | `CANCELLER_ROLE`     | token-owner Safe (+ dedicated canceller, once decided) | vetoes a scheduled operation inside the window                  |
-| `EXECUTOR_ROLE`      | token-owner Safe                                       | executes once the delay elapses                                 |
+| `EXECUTOR_ROLE`      | `address(0)` — i.e. anyone                             | executes once the delay elapses                                 |
 | `DEFAULT_ADMIN_ROLE` | the timelock itself                                    | role changes are themselves timelocked (OZ self-administration) |
 
+- **Execution is permissionless.** `EXECUTOR_ROLE` is granted to `address(0)`,
+  which OZ's `onlyRoleOrOpenRole` reads as "open to everyone", so once the delay
+  has run ANYONE may execute a scheduled operation. The operator cannot censor a
+  matured operation, and the Safe executes as a member of the public rather than
+  by privilege. `cancel()` has no open-role path in OZ, so vetoing stays
+  privileged — the asymmetry is the design.
+- **Operations never expire.** OZ keeps a matured operation executable
+  indefinitely. With open execution that means a scheduled-then-abandoned
+  operation can be executed by anyone, at any later time. An operation you
+  decide against must be CANCELLED, not merely left unexecuted.
 - **Min delay: 48 hours** (`LibTimelockInvariants.TIMELOCK_MIN_DELAY`). Changing
   it is a timelocked `updateDelay` operation and must update the pin in the same
   operational window.

--- a/src/lib/LibTimelockInvariants.sol
+++ b/src/lib/LibTimelockInvariants.sol
@@ -122,13 +122,13 @@ library LibTimelockInvariants {
     /// @notice The ST0x governance timelock on **Base**. Equals
     /// `expectedTimelockAddress(STOX_TOKEN_OWNER_SAFE)`, which
     /// `testPinsMatchDerivedAddresses` asserts.
-    /// https://basescan.org/address/0xdb4b2187a685310e6b64170c97b80e90dd4a9b71
-    address internal constant STOX_GOVERNANCE_TIMELOCK = address(0);
+    /// https://basescan.org/address/0x48ba1371a78e6cc54157c63721756ab444510db3
+    address internal constant STOX_GOVERNANCE_TIMELOCK = address(0x48ba1371A78E6cC54157c63721756ab444510DB3);
 
     /// @notice The ST0x governance timelock on **Ethereum mainnet**. Equals
     /// `expectedTimelockAddress(STOX_TOKEN_OWNER_SAFE_ETHEREUM)`.
-    /// https://etherscan.io/address/0x290961ef70a86ab70b7201d46d29f2f357416b49
-    address internal constant STOX_GOVERNANCE_TIMELOCK_ETHEREUM = address(0);
+    /// https://etherscan.io/address/0x831e4e1bb2b9a67c00b7d17f252a18a22cd0bd2b
+    address internal constant STOX_GOVERNANCE_TIMELOCK_ETHEREUM = address(0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B);
 
     /// @notice The ST0x governance timelock on **HyperEVM**. HyperEVM
     /// carries 29 live production tokens, so it is governed on exactly the
@@ -141,8 +141,8 @@ library LibTimelockInvariants {
     /// init code, same CREATE2 address); they stay separate constants because
     /// the DEPLOY is per-chain and either could diverge if a chain's Safe ever
     /// moves.
-    /// https://hyperevmscan.io/address/0x290961ef70a86ab70b7201d46d29f2f357416b49
-    address internal constant STOX_GOVERNANCE_TIMELOCK_HYPEREVM = address(0);
+    /// https://hyperevmscan.io/address/0x831e4e1bb2b9a67c00b7d17f252a18a22cd0bd2b
+    address internal constant STOX_GOVERNANCE_TIMELOCK_HYPEREVM = address(0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B);
 
     /// @notice **PLACEHOLDER** for a dedicated canceller principal (a
     /// separate key or Safe that can veto a scheduled operation during the

--- a/src/lib/LibTimelockInvariants.sol
+++ b/src/lib/LibTimelockInvariants.sol
@@ -68,9 +68,12 @@ error TimelockUnexpectedRole(address timelock, bytes32 role, address account);
 /// only then execute.
 ///
 /// Role model (pinned by `assertTimelockState`):
-/// - The chain's token-owner Safe holds `PROPOSER_ROLE`, `CANCELLER_ROLE`
-///   and `EXECUTOR_ROLE` — it schedules, can cancel during the window, and
-///   executes once the delay elapses.
+/// - The chain's token-owner Safe holds `PROPOSER_ROLE` and
+///   `CANCELLER_ROLE` — it schedules, and can veto during the window.
+/// - `EXECUTOR_ROLE` is held by `address(0)`, which OZ reads as "open to
+///   everyone": once the delay has run ANYONE may execute. The operator
+///   cannot censor a matured operation, and the Safe executes as a member of
+///   the public rather than by privilege.
 /// - The timelock holds `DEFAULT_ADMIN_ROLE` on itself (OZ
 ///   self-administration): role changes — e.g. provisioning the dedicated
 ///   canceller once `TIMELOCK_CANCELLER` is decided — must themselves go
@@ -120,12 +123,12 @@ library LibTimelockInvariants {
     /// `expectedTimelockAddress(STOX_TOKEN_OWNER_SAFE)`, which
     /// `testPinsMatchDerivedAddresses` asserts.
     /// https://basescan.org/address/0xdb4b2187a685310e6b64170c97b80e90dd4a9b71
-    address internal constant STOX_GOVERNANCE_TIMELOCK = address(0xdb4b2187A685310E6b64170c97B80E90DD4a9B71);
+    address internal constant STOX_GOVERNANCE_TIMELOCK = address(0);
 
     /// @notice The ST0x governance timelock on **Ethereum mainnet**. Equals
     /// `expectedTimelockAddress(STOX_TOKEN_OWNER_SAFE_ETHEREUM)`.
     /// https://etherscan.io/address/0x290961ef70a86ab70b7201d46d29f2f357416b49
-    address internal constant STOX_GOVERNANCE_TIMELOCK_ETHEREUM = address(0x290961EF70A86aB70B7201D46d29f2f357416b49);
+    address internal constant STOX_GOVERNANCE_TIMELOCK_ETHEREUM = address(0);
 
     /// @notice The ST0x governance timelock on **HyperEVM**. HyperEVM
     /// carries 29 live production tokens, so it is governed on exactly the
@@ -139,7 +142,7 @@ library LibTimelockInvariants {
     /// the DEPLOY is per-chain and either could diverge if a chain's Safe ever
     /// moves.
     /// https://hyperevmscan.io/address/0x290961ef70a86ab70b7201d46d29f2f357416b49
-    address internal constant STOX_GOVERNANCE_TIMELOCK_HYPEREVM = address(0x290961EF70A86aB70B7201D46d29f2f357416b49);
+    address internal constant STOX_GOVERNANCE_TIMELOCK_HYPEREVM = address(0);
 
     /// @notice **PLACEHOLDER** for a dedicated canceller principal (a
     /// separate key or Safe that can veto a scheduled operation during the
@@ -201,17 +204,24 @@ library LibTimelockInvariants {
 
     /// @notice The exact creation code the governance timelock deploy
     /// broadcasts: the FROZEN `TIMELOCK_CREATION_CODE` with the pinned
-    /// constructor arguments appended — `TIMELOCK_MIN_DELAY`, the supplied Safe as sole
-    /// proposer (which also makes it canceller) and sole executor, and
-    /// `admin = address(0)` so the timelock is self-administered from birth
-    /// and the deploy key is never granted anything.
-    /// @param proposerExecutorSafe The chain's token-owner Safe.
+    /// constructor arguments appended — `TIMELOCK_MIN_DELAY`, the supplied
+    /// Safe as sole proposer (which also makes it canceller), `address(0)` as
+    /// executor so EXECUTION IS PERMISSIONLESS, and `admin = address(0)` so
+    /// the timelock is self-administered from birth and the deploy key is
+    /// never granted anything.
+    ///
+    /// OZ's `onlyRoleOrOpenRole` treats a zero-address role holder as "open
+    /// to everyone", so granting `EXECUTOR_ROLE` to `address(0)` at
+    /// construction means anyone may execute a matured operation. That is
+    /// deliberate: it removes the operator as a censor once the delay has
+    /// run. `cancel()` has no open-role path, so vetoing stays privileged.
+    /// @param proposerSafe The chain's token-owner Safe.
     /// @return The creation code including constructor arguments.
-    function timelockInitCode(address proposerExecutorSafe) internal pure returns (bytes memory) {
+    function timelockInitCode(address proposerSafe) internal pure returns (bytes memory) {
         address[] memory proposers = new address[](1);
-        proposers[0] = proposerExecutorSafe;
+        proposers[0] = proposerSafe;
         address[] memory executors = new address[](1);
-        executors[0] = proposerExecutorSafe;
+        executors[0] = address(0);
         return
             abi.encodePacked(TIMELOCK_CREATION_CODE, abi.encode(TIMELOCK_MIN_DELAY, proposers, executors, address(0)));
     }
@@ -222,10 +232,10 @@ library LibTimelockInvariants {
     /// of the creation code. The deploy script asserts the landed address
     /// equals this; once the per-chain pin is hydrated a structure test
     /// pins `pin == expectedTimelockAddress(chain's Safe)`.
-    /// @param proposerExecutorSafe The chain's token-owner Safe.
+    /// @param proposerSafe The chain's token-owner Safe.
     /// @return The deterministic timelock address for that Safe.
-    function expectedTimelockAddress(address proposerExecutorSafe) internal pure returns (address) {
-        bytes32 initCodeHash = keccak256(timelockInitCode(proposerExecutorSafe));
+    function expectedTimelockAddress(address proposerSafe) internal pure returns (address) {
+        bytes32 initCodeHash = keccak256(timelockInitCode(proposerSafe));
         // forge-lint: disable-next-line(unsafe-typecast)
         return address(
             uint160(
@@ -248,9 +258,9 @@ library LibTimelockInvariants {
     /// documents for the authoriser's grant map. Once `TIMELOCK_CANCELLER`
     /// is hydrated the dedicated canceller's grant is asserted too.
     /// @param timelock The governance timelock to validate.
-    /// @param proposerExecutorSafe The chain's token-owner Safe expected to
+    /// @param proposerSafe The chain's token-owner Safe expected to
     /// hold the proposer / canceller / executor roles.
-    function assertTimelockState(address timelock, address proposerExecutorSafe) internal view {
+    function assertTimelockState(address timelock, address proposerSafe) internal view {
         if (timelock.code.length == 0) revert TimelockNotDeployed(timelock);
         bytes32 actualCodehash = timelock.codehash;
         if (actualCodehash != TIMELOCK_RUNTIME_CODEHASH) {
@@ -264,11 +274,11 @@ library LibTimelockInvariants {
 
         IAccessControl acl = IAccessControl(timelock);
 
-        // The Safe drives every stage of the operation lifecycle: schedule,
-        // cancel (until a dedicated canceller is provisioned), execute.
-        _assertHasRole(acl, timelock, TIMELOCK_PROPOSER_ROLE, proposerExecutorSafe);
-        _assertHasRole(acl, timelock, TIMELOCK_CANCELLER_ROLE, proposerExecutorSafe);
-        _assertHasRole(acl, timelock, TIMELOCK_EXECUTOR_ROLE, proposerExecutorSafe);
+        // The Safe schedules and can cancel during the window. It does NOT
+        // need to hold EXECUTOR_ROLE: execution is open (asserted below), so
+        // the Safe can execute like anyone else without holding the role.
+        _assertHasRole(acl, timelock, TIMELOCK_PROPOSER_ROLE, proposerSafe);
+        _assertHasRole(acl, timelock, TIMELOCK_CANCELLER_ROLE, proposerSafe);
 
         // Self-administration: role changes go through the delay.
         _assertHasRole(acl, timelock, TIMELOCK_DEFAULT_ADMIN_ROLE, timelock);
@@ -276,18 +286,23 @@ library LibTimelockInvariants {
         // The Safe must NOT hold root admin — that would let it re-grant
         // roles instantly, bypassing the delay the timelock exists to
         // impose.
-        if (acl.hasRole(TIMELOCK_DEFAULT_ADMIN_ROLE, proposerExecutorSafe)) {
-            revert TimelockUnexpectedRole(timelock, TIMELOCK_DEFAULT_ADMIN_ROLE, proposerExecutorSafe);
+        if (acl.hasRole(TIMELOCK_DEFAULT_ADMIN_ROLE, proposerSafe)) {
+            revert TimelockUnexpectedRole(timelock, TIMELOCK_DEFAULT_ADMIN_ROLE, proposerSafe);
         }
 
         // OZ treats a zero-address grantee as "role open to everyone".
-        // Every lifecycle role must stay closed: open-proposer or
-        // open-canceller is an obvious takeover, and open-executor would
-        // let anyone execute (acceptable in some designs, but not the
-        // pinned one — execution stays with the Safe).
+        // EXECUTION IS DELIBERATELY OPEN: once the delay has run, anyone may
+        // execute, so the operator cannot censor a matured operation. Asserted
+        // positively — a closed executor role would silently reintroduce the
+        // operator as a gatekeeper.
+        _assertHasRole(acl, timelock, TIMELOCK_EXECUTOR_ROLE, address(0));
+
+        // Every other lifecycle role must stay closed: open-proposer lets
+        // anyone schedule, open-canceller lets anyone veto (and `cancel` has
+        // no open-role path in OZ precisely so vetoing stays privileged), and
+        // open root admin is total capture.
         _assertNotOpenRole(acl, timelock, TIMELOCK_PROPOSER_ROLE);
         _assertNotOpenRole(acl, timelock, TIMELOCK_CANCELLER_ROLE);
-        _assertNotOpenRole(acl, timelock, TIMELOCK_EXECUTOR_ROLE);
         _assertNotOpenRole(acl, timelock, TIMELOCK_DEFAULT_ADMIN_ROLE);
 
         // Once the dedicated canceller is decided and its pin hydrated, it

--- a/test/src/lib/LibTimelockInvariants.t.sol
+++ b/test/src/lib/LibTimelockInvariants.t.sol
@@ -176,20 +176,22 @@ contract LibTimelockInvariantsTest is Test {
         harness.callAssertTimelockState(timelock, SAFE);
     }
 
-    /// @notice A zero-address grant on ANY lifecycle role — OZ's
+    /// @notice A zero-address grant on any role that must stay CLOSED — OZ's
     /// `onlyRoleOrOpenRole` treats `hasRole(role, address(0))` as "open to
-    /// everyone" — is rejected, walked per role: proposer, canceller,
-    /// executor, and root admin each trip their own typed revert, and the
-    /// closed state passes again after each revoke. Simulated through the
-    /// timelock's own self-administration path, proving the pinned deploy
-    /// COULD drift here only via a (timelocked) governance action that this
-    /// invariant would then flag.
+    /// everyone" — is rejected, walked per role: proposer, canceller and root
+    /// admin each trip their own typed revert, and the closed state passes
+    /// again after each revoke. Simulated through the timelock's own
+    /// self-administration path, proving the pinned deploy COULD drift here
+    /// only via a (timelocked) governance action that this invariant would
+    /// then flag.
+    /// @dev EXECUTOR is deliberately excluded: execution is permissionless,
+    /// so an open executor is the REQUIRED state, pinned by
+    /// `testAssertRejectsClosedExecutorRole` below.
     function testAssertRejectsEveryOpenRole() external {
         address timelock = deployPinnedTimelock();
-        bytes32[4] memory roles = [
+        bytes32[3] memory roles = [
             LibTimelockInvariants.TIMELOCK_PROPOSER_ROLE,
             LibTimelockInvariants.TIMELOCK_CANCELLER_ROLE,
-            LibTimelockInvariants.TIMELOCK_EXECUTOR_ROLE,
             LibTimelockInvariants.TIMELOCK_DEFAULT_ADMIN_ROLE
         ];
         for (uint256 i = 0; i < roles.length; i++) {
@@ -202,6 +204,23 @@ contract LibTimelockInvariantsTest is Test {
         }
         // Every zero-grant revoked: the closed state passes again, proving
         // each rejection above was the zero-grant and nothing else.
+        harness.callAssertTimelockState(timelock, SAFE);
+    }
+
+    /// @notice A CLOSED executor role is rejected. Execution is deliberately
+    /// permissionless, so revoking the open grant would put the operator back
+    /// in the path as a censor of matured operations — the exact property
+    /// Clearstar asked us to remove. Asserted by revoking `EXECUTOR_ROLE`
+    /// from the zero address on an otherwise-pinned timelock.
+    function testAssertRejectsClosedExecutorRole() external {
+        address timelock = deployPinnedTimelock();
+        vm.prank(timelock);
+        IAccessControl(timelock).revokeRole(LibTimelockInvariants.TIMELOCK_EXECUTOR_ROLE, address(0));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TimelockMissingRole.selector, timelock, LibTimelockInvariants.TIMELOCK_EXECUTOR_ROLE, address(0)
+            )
+        );
         harness.callAssertTimelockState(timelock, SAFE);
     }
 

--- a/test/src/lib/LibTimelockInvariants.t.sol
+++ b/test/src/lib/LibTimelockInvariants.t.sol
@@ -208,6 +208,77 @@ contract LibTimelockInvariantsTest is Test {
         harness.callAssertTimelockState(timelock, SAFE);
     }
 
+    /// @notice Execution is permissionless END-TO-END, not just as a role
+    /// bit: a caller holding no role at all executes a matured operation and
+    /// the operation's effect lands. Schedule (Safe) → warp out the 48h
+    /// delay → execute (anon) → the scheduled self-administration grant is
+    /// live and the operation is `Done`. This is the behavioural proof of
+    /// the property the open-executor state assert pins; without it the
+    /// property rests only on OZ's `onlyRoleOrOpenRole` semantics being what
+    /// the assert assumes.
+    function testAnonExecutesMaturedOperation() external {
+        TimelockController timelock = TimelockController(payable(deployPinnedTimelock()));
+        address anon = address(0xA904);
+        address newCanceller = address(0xCACE);
+
+        bytes memory data =
+            abi.encodeCall(IAccessControl.grantRole, (LibTimelockInvariants.TIMELOCK_CANCELLER_ROLE, newCanceller));
+        bytes32 salt = keccak256("anon-executes-matured-operation");
+        bytes32 id = timelock.hashOperation(address(timelock), 0, data, bytes32(0), salt);
+
+        vm.prank(SAFE);
+        timelock.schedule(address(timelock), 0, data, bytes32(0), salt, LibTimelockInvariants.TIMELOCK_MIN_DELAY);
+        assertTrue(timelock.isOperationPending(id), "operation must be pending after schedule");
+        assertFalse(timelock.isOperationReady(id), "operation must not be executable inside the delay");
+
+        vm.warp(block.timestamp + LibTimelockInvariants.TIMELOCK_MIN_DELAY);
+        vm.prank(anon);
+        timelock.execute(address(timelock), 0, data, bytes32(0), salt);
+
+        assertTrue(timelock.isOperationDone(id), "anon execution must complete the operation");
+        assertTrue(
+            IAccessControl(address(timelock)).hasRole(LibTimelockInvariants.TIMELOCK_CANCELLER_ROLE, newCanceller),
+            "the executed operation's effect must land"
+        );
+    }
+
+    /// @notice The asymmetry is the design: execution is open, scheduling
+    /// and vetoing stay privileged. The same roleless anon that can execute
+    /// can neither schedule nor cancel — each attempt reverts with OZ's
+    /// missing-role error naming the exact role gate it hit.
+    function testAnonCannotScheduleOrCancel() external {
+        TimelockController timelock = TimelockController(payable(deployPinnedTimelock()));
+        address anon = address(0xA904);
+        bytes memory data =
+            abi.encodeCall(IAccessControl.grantRole, (LibTimelockInvariants.TIMELOCK_CANCELLER_ROLE, anon));
+        bytes32 salt = keccak256("anon-cannot-schedule-or-cancel");
+
+        vm.prank(anon);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                anon,
+                LibTimelockInvariants.TIMELOCK_PROPOSER_ROLE
+            )
+        );
+        timelock.schedule(address(timelock), 0, data, bytes32(0), salt, LibTimelockInvariants.TIMELOCK_MIN_DELAY);
+
+        vm.prank(SAFE);
+        timelock.schedule(address(timelock), 0, data, bytes32(0), salt, LibTimelockInvariants.TIMELOCK_MIN_DELAY);
+        bytes32 id = timelock.hashOperation(address(timelock), 0, data, bytes32(0), salt);
+
+        vm.prank(anon);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                anon,
+                LibTimelockInvariants.TIMELOCK_CANCELLER_ROLE
+            )
+        );
+        timelock.cancel(id);
+        assertTrue(timelock.isOperationPending(id), "the anon cancel attempt must not have removed the operation");
+    }
+
     /// @notice A CLOSED executor role is rejected. Execution is deliberately
     /// permissionless, so revoking the open grant would put the operator back
     /// in the path as a censor of matured operations — the exact property

--- a/test/src/lib/LibTimelockInvariants.t.sol
+++ b/test/src/lib/LibTimelockInvariants.t.sol
@@ -151,11 +151,12 @@ contract LibTimelockInvariantsTest is Test {
     /// which is exactly why the invariant pins it.
     function testAssertRejectsEveryMissingRole() external {
         address timelock = deployPinnedTimelock();
-        bytes32[3] memory safeRoles = [
-            LibTimelockInvariants.TIMELOCK_PROPOSER_ROLE,
-            LibTimelockInvariants.TIMELOCK_CANCELLER_ROLE,
-            LibTimelockInvariants.TIMELOCK_EXECUTOR_ROLE
-        ];
+        // EXECUTOR is not among them: execution is permissionless, so the
+        // Safe never holds that role and revoking it from the Safe is a
+        // no-op. The executor requirement is pinned by
+        // `testAssertRejectsClosedExecutorRole` against the zero address.
+        bytes32[2] memory safeRoles =
+            [LibTimelockInvariants.TIMELOCK_PROPOSER_ROLE, LibTimelockInvariants.TIMELOCK_CANCELLER_ROLE];
         for (uint256 i = 0; i < safeRoles.length; i++) {
             vm.prank(timelock);
             IAccessControl(timelock).revokeRole(safeRoles[i], SAFE);


### PR DESCRIPTION
Clearstar want a 48h lock with **permissionless execution**. `EXECUTOR_ROLE` is now granted to `address(0)` at construction, which OZ's `onlyRoleOrOpenRole` reads as "open to everyone": once the delay has run anyone may execute, so the operator cannot censor a matured operation. The Safe keeps `PROPOSER` and `CANCELLER` and executes as a member of the public rather than by privilege.

`cancel()` has no open-role path in OZ, so vetoing stays privileged — that asymmetry is the design. No separate canceller for now; `TIMELOCK_CANCELLER` stays a placeholder and the Safe cancels.

### This moves every address

Executors are a **constructor argument**, so the CREATE2 address changes on all three chains. The permissionless timelocks are deployed and live on Base, Ethereum and HyperEVM, and this PR records their pins — `testPinsMatchDerivedAddresses` ties each pin to the derivation. The superseded timelocks hold no power — nothing was migrated to them, so they are abandoned in place.

### Invariant inverted

`assertTimelockState` previously **rejected** an open executor. It now **requires** one, and the test that pinned the old policy is inverted to reject a *closed* executor — so silently re-closing execution fails rather than passing.

The property is also proven behaviourally, not just as a role bit: a roleless anon executes a matured operation end-to-end (and its effect lands), and the same anon can neither schedule nor cancel — the open/privileged asymmetry as tests.

### Hazard recorded

OZ operations never expire. With open execution an abandoned operation stays executable by anyone indefinitely, so an operation you decide against must be **cancelled**, not merely left unexecuted. Written into the runbook.

Local: build, fmt, 18/18 timelock lib, 13/13 script suites, 6/6 forcing function — all three chains.
