### PR TITLE
pin(timelock): hydrate the permissionless governance timelocks

### DIFF
--- a/src/lib/LibTimelockInvariants.sol
+++ b/src/lib/LibTimelockInvariants.sol
@@ -123,12 +123,12 @@ library LibTimelockInvariants {
     /// `expectedTimelockAddress(STOX_TOKEN_OWNER_SAFE)`, which
     /// `testPinsMatchDerivedAddresses` asserts.
     /// https://basescan.org/address/0xdb4b2187a685310e6b64170c97b80e90dd4a9b71
-    address internal constant STOX_GOVERNANCE_TIMELOCK = address(0);
+    address internal constant STOX_GOVERNANCE_TIMELOCK = address(0x48ba1371A78E6cC54157c63721756ab444510DB3);
 
     /// @notice The ST0x governance timelock on **Ethereum mainnet**. Equals
     /// `expectedTimelockAddress(STOX_TOKEN_OWNER_SAFE_ETHEREUM)`.
     /// https://etherscan.io/address/0x290961ef70a86ab70b7201d46d29f2f357416b49
-    address internal constant STOX_GOVERNANCE_TIMELOCK_ETHEREUM = address(0);
+    address internal constant STOX_GOVERNANCE_TIMELOCK_ETHEREUM = address(0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B);
 
     /// @notice The ST0x governance timelock on **HyperEVM**. HyperEVM
     /// carries 29 live production tokens, so it is governed on exactly the
@@ -142,7 +142,7 @@ library LibTimelockInvariants {
     /// the DEPLOY is per-chain and either could diverge if a chain's Safe ever
     /// moves.
     /// https://hyperevmscan.io/address/0x290961ef70a86ab70b7201d46d29f2f357416b49
-    address internal constant STOX_GOVERNANCE_TIMELOCK_HYPEREVM = address(0);
+    address internal constant STOX_GOVERNANCE_TIMELOCK_HYPEREVM = address(0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B);
 
     /// @notice **PLACEHOLDER** for a dedicated canceller principal (a
     /// separate key or Safe that can veto a scheduled operation during the


### PR DESCRIPTION
Records the addresses deployed by `20260729-deploy-governance-timelock` (run `31592665815`), which covered all three chains in one dispatch:

| Chain | Timelock |
|---|---|
| Base | `0x48ba1371A78E6cC54157c63721756ab444510DB3` |
| Ethereum | `0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B` |
| HyperEVM | `0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B` |

Verified on-chain, not just from the deploy log:

- `getMinDelay()` = 172800 (48h)
- `hasRole(EXECUTOR_ROLE, address(0))` = **true** — execution is open
- `hasRole(EXECUTOR_ROLE, tokenOwnerSafe)` = **false** — the Safe executes as a member of the public, not by privilege
- timelock self-administers; deploy key holds nothing

Each equals `expectedTimelockAddress` for its chain's Safe, which `testPinsMatchDerivedAddressesOnceHydrated` asserts. Ethereum and HyperEVM share an address because they share a Safe and the constructor embeds only that Safe.

All three are Sourcify-verified. Etherscan verification is still skipped — the repo's `CI_DEPLOY_BASE_ETHERSCAN_API_KEY` is free-tier and `EXPLORER_VERIFICATION_KEY` is unset; setting a paid v2 key there turns that leg on with no code change.

Supersedes the earlier `0xdb4b…` / `0x290961…` deployment, which is abandoned — the open-executor change moved every CREATE2 address, and nothing was ever migrated to those.

Local: build, fmt, 14/14 timelock lib, 13/13 script suites, 6/6 forcing function.