### PR TITLE
feat(tokens): add AAPL, GOOGL, INTC, LLY, MSFT, PTY across Base, Ethereum and HyperEVM

### DIFF
--- a/src/lib/LibProdTokenConfig.sol
+++ b/src/lib/LibProdTokenConfig.sol
@@ -51,7 +51,7 @@ library LibProdTokenConfig {
     /// @notice The production token deploy configs, Base table order.
     /// @return configs The name/symbol table.
     function productionTokenConfigs() internal pure returns (TokenConfig[] memory configs) {
-        configs = new TokenConfig[](34);
+        configs = new TokenConfig[](40);
         configs[0] = TokenConfig("MSTR", "MicroStrategy Incorporated ST0x", "tMSTR");
         configs[1] = TokenConfig("TSLA", "Tesla Inc ST0x", "tTSLA");
         configs[2] = TokenConfig("COIN", "Coinbase Global Inc ST0x", "tCOIN");
@@ -91,5 +91,11 @@ library LibProdTokenConfig {
         // TQQQ is a leveraged ETF rather than a plain equity; the name follows
         // the fund's own product name.
         configs[33] = TokenConfig("TQQQ", "ProShares UltraPro QQQ ST0x", "tTQQQ");
+        configs[34] = TokenConfig("AAPL", "Apple Inc. ST0x", "tAAPL");
+        configs[35] = TokenConfig("GOOGL", "Alphabet Inc. Class A ST0x", "tGOOGL");
+        configs[36] = TokenConfig("INTC", "Intel Corporation ST0x", "tINTC");
+        configs[37] = TokenConfig("LLY", "Eli Lilly and Company ST0x", "tLLY");
+        configs[38] = TokenConfig("MSFT", "Microsoft Corporation ST0x", "tMSFT");
+        configs[39] = TokenConfig("PTY", "PIMCO Corporate & Income Opportunity Fund ST0x", "tPTY");
     }
 }

--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -333,6 +333,54 @@ library LibTokenInvariants {
     /// https://basescan.org/address/0x295e9eCAb319006900a53b3f8D6Fcb0C131F4ada
     address internal constant TQQQ_WRAPPED_TOKEN_VAULT = address(0x295e9eCAb319006900a53b3f8D6Fcb0C131F4ada);
 
+    // ---- tAAPL / wtAAPL — Apple Inc. ST0x ----
+    /// https://basescan.org/address/0x3156EB08c9dd870979f1475C5CFe681b8f6A3b53
+    address internal constant AAPL_RECEIPT = address(0x3156EB08c9dd870979f1475C5CFe681b8f6A3b53);
+    /// https://basescan.org/address/0xD36056a4a03707D3743fCE4e9C08852820ADcfdC
+    address internal constant AAPL_RECEIPT_VAULT = address(0xD36056a4a03707D3743fCE4e9C08852820ADcfdC);
+    /// https://basescan.org/address/0x1020EC8Aa3f709a1f3D8705cdBa89b950451bd88
+    address internal constant AAPL_WRAPPED_TOKEN_VAULT = address(0x1020EC8Aa3f709a1f3D8705cdBa89b950451bd88);
+
+    // ---- tGOOGL / wtGOOGL — Alphabet Inc. Class A ST0x ----
+    /// https://basescan.org/address/0x85ac79F639C692B2f1290d0994c79eEffF350D00
+    address internal constant GOOGL_RECEIPT = address(0x85ac79F639C692B2f1290d0994c79eEffF350D00);
+    /// https://basescan.org/address/0x15De944Cd020A18C8E5626fB0F81b36e73956199
+    address internal constant GOOGL_RECEIPT_VAULT = address(0x15De944Cd020A18C8E5626fB0F81b36e73956199);
+    /// https://basescan.org/address/0x6a2357Df4975C667B171bE53dA6FFe6deBf7030c
+    address internal constant GOOGL_WRAPPED_TOKEN_VAULT = address(0x6a2357Df4975C667B171bE53dA6FFe6deBf7030c);
+
+    // ---- tINTC / wtINTC — Intel Corporation ST0x ----
+    /// https://basescan.org/address/0xAFEd850e458d331EF2A13569547258A84e2e42D2
+    address internal constant INTC_RECEIPT = address(0xAFEd850e458d331EF2A13569547258A84e2e42D2);
+    /// https://basescan.org/address/0xBDC237Aa3B67cC3088adAf117913F30Bf08157a3
+    address internal constant INTC_RECEIPT_VAULT = address(0xBDC237Aa3B67cC3088adAf117913F30Bf08157a3);
+    /// https://basescan.org/address/0xf567652fC2d7Db8D5469fD06AEbe8C9c4372d722
+    address internal constant INTC_WRAPPED_TOKEN_VAULT = address(0xf567652fC2d7Db8D5469fD06AEbe8C9c4372d722);
+
+    // ---- tLLY / wtLLY — Eli Lilly and Company ST0x ----
+    /// https://basescan.org/address/0x7b345A02d56f989420EbEd4df647D1C673608F3C
+    address internal constant LLY_RECEIPT = address(0x7b345A02d56f989420EbEd4df647D1C673608F3C);
+    /// https://basescan.org/address/0xA41Ce7B8255A01062ED1AF23ea5E8137B9300554
+    address internal constant LLY_RECEIPT_VAULT = address(0xA41Ce7B8255A01062ED1AF23ea5E8137B9300554);
+    /// https://basescan.org/address/0x892CcF5E75f4a7Ee6402971a1587F65BEE4d52bd
+    address internal constant LLY_WRAPPED_TOKEN_VAULT = address(0x892CcF5E75f4a7Ee6402971a1587F65BEE4d52bd);
+
+    // ---- tMSFT / wtMSFT — Microsoft Corporation ST0x ----
+    /// https://basescan.org/address/0x6862e34dE9AFE099ca19934fC768A8eB9a906b90
+    address internal constant MSFT_RECEIPT = address(0x6862e34dE9AFE099ca19934fC768A8eB9a906b90);
+    /// https://basescan.org/address/0x6a071E25fa25653cF15d1ee320eA3df771926Aa0
+    address internal constant MSFT_RECEIPT_VAULT = address(0x6a071E25fa25653cF15d1ee320eA3df771926Aa0);
+    /// https://basescan.org/address/0x515A3Ac2a6aB590bDFa970caFFFd7fAdC680886E
+    address internal constant MSFT_WRAPPED_TOKEN_VAULT = address(0x515A3Ac2a6aB590bDFa970caFFFd7fAdC680886E);
+
+    // ---- tPTY / wtPTY — PIMCO Corporate & Income Opportunity Fund ST0x ----
+    /// https://basescan.org/address/0x019Ea210a98f5E74F03376712BDAab3801079b7F
+    address internal constant PTY_RECEIPT = address(0x019Ea210a98f5E74F03376712BDAab3801079b7F);
+    /// https://basescan.org/address/0xb6021810971714cD48572af527307Acc324ecF61
+    address internal constant PTY_RECEIPT_VAULT = address(0xb6021810971714cD48572af527307Acc324ecF61);
+    /// https://basescan.org/address/0xb6D779A79E7493ed821a65D52bA419F0F6D5dD0a
+    address internal constant PTY_WRAPPED_TOKEN_VAULT = address(0xb6D779A79E7493ed821a65D52bA419F0F6D5dD0a);
+
     /// @notice Returns the production token instance triples on Base, in
     /// the order they were deployed. This is the structured source of truth
     /// the flat `productionReceiptVaults()` accessor derives from; consumers
@@ -340,7 +388,7 @@ library LibTokenInvariants {
     /// (cross-chain parity, per-token config checks) iterate this instead.
     /// @return tokens The production token instances on Base.
     function productionTokensBase() internal pure returns (TokenInstance[] memory tokens) {
-        tokens = new TokenInstance[](34);
+        tokens = new TokenInstance[](40);
         tokens[0] = TokenInstance("MSTR", MSTR_RECEIPT, MSTR_RECEIPT_VAULT, MSTR_WRAPPED_TOKEN_VAULT);
         tokens[1] = TokenInstance("TSLA", TSLA_RECEIPT, TSLA_RECEIPT_VAULT, TSLA_WRAPPED_TOKEN_VAULT);
         tokens[2] = TokenInstance("COIN", COIN_RECEIPT, COIN_RECEIPT_VAULT, COIN_WRAPPED_TOKEN_VAULT);
@@ -375,6 +423,12 @@ library LibTokenInvariants {
         tokens[31] = TokenInstance("SMCI", SMCI_RECEIPT, SMCI_RECEIPT_VAULT, SMCI_WRAPPED_TOKEN_VAULT);
         tokens[32] = TokenInstance("BABA", BABA_RECEIPT, BABA_RECEIPT_VAULT, BABA_WRAPPED_TOKEN_VAULT);
         tokens[33] = TokenInstance("TQQQ", TQQQ_RECEIPT, TQQQ_RECEIPT_VAULT, TQQQ_WRAPPED_TOKEN_VAULT);
+        tokens[34] = TokenInstance("AAPL", AAPL_RECEIPT, AAPL_RECEIPT_VAULT, AAPL_WRAPPED_TOKEN_VAULT);
+        tokens[35] = TokenInstance("GOOGL", GOOGL_RECEIPT, GOOGL_RECEIPT_VAULT, GOOGL_WRAPPED_TOKEN_VAULT);
+        tokens[36] = TokenInstance("INTC", INTC_RECEIPT, INTC_RECEIPT_VAULT, INTC_WRAPPED_TOKEN_VAULT);
+        tokens[37] = TokenInstance("LLY", LLY_RECEIPT, LLY_RECEIPT_VAULT, LLY_WRAPPED_TOKEN_VAULT);
+        tokens[38] = TokenInstance("MSFT", MSFT_RECEIPT, MSFT_RECEIPT_VAULT, MSFT_WRAPPED_TOKEN_VAULT);
+        tokens[39] = TokenInstance("PTY", PTY_RECEIPT, PTY_RECEIPT_VAULT, PTY_WRAPPED_TOKEN_VAULT);
     }
 
     /// @notice Returns the production token instance triples on Ethereum

--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -444,7 +444,7 @@ library LibTokenInvariants {
         // run's logged (underlying, receipt, receiptVault, wrapped) tuples.
         // Order and underlyings match Base row-for-row (the cross-chain
         // parity pin asserts this).
-        tokens = new TokenInstance[](34);
+        tokens = new TokenInstance[](40);
         tokens[0] = TokenInstance(
             "MSTR",
             address(0xE3772C8695c2cf3dcAA2Dd29759f4Bb91a342763),
@@ -654,6 +654,42 @@ library LibTokenInvariants {
             address(0xf3875383506677BCdA6b9F12c48Ff7fE300970D7),
             address(0x04eE4ED5FF6643eA955503f966012b684f479966)
         );
+        tokens[34] = TokenInstance(
+            "AAPL",
+            address(0x5f1DBfBf9345f3185C52aC3c080a0EDDb4f540c2),
+            address(0xb526Bf49DAB7F72B772FEF4B6D572C254A454ef7),
+            address(0x4E3600f48C61eF4513c72923ab50851bD546FFA9)
+        );
+        tokens[35] = TokenInstance(
+            "GOOGL",
+            address(0xdC29d07D2125699FA44cAB7e940542b526dB0abd),
+            address(0x50DE74136b67911799fc39B726bFC2707cCec769),
+            address(0xca678d0d69F9E815d1A4f4dF05C904b2DDE017f8)
+        );
+        tokens[36] = TokenInstance(
+            "INTC",
+            address(0x8CF3E580465e8DFaE05FF42BbFCe0d98BfF79580),
+            address(0x06aE3f6CFaE124039902a79Da44ad2a4A4489250),
+            address(0xd702276d50fdCf58b0E41b3f1f9651faBC1141f4)
+        );
+        tokens[37] = TokenInstance(
+            "LLY",
+            address(0x9a288A27a9898f145AF9575b46617bB1DF705106),
+            address(0x1eE2cE9654FFa008029e8e328a95f45EBfB3bC63),
+            address(0xa6890e89D99Fd4F275c016d89A28ec24A428846D)
+        );
+        tokens[38] = TokenInstance(
+            "MSFT",
+            address(0x824eA918F35821a72E34b4eaD257AF60603cb20C),
+            address(0xb3f9A61b0e97c7F7Bb85Ea5E9Dad0da8f3496B57),
+            address(0xAbb2641950C7dE9D3ec9AA05668e112E1DB701F6)
+        );
+        tokens[39] = TokenInstance(
+            "PTY",
+            address(0x7b66449B3d7cD6569F1e235f6E4A664C24538EA8),
+            address(0xdf4F0897Ec6f0C37Bfc974a815cA440A3c2C2e8B),
+            address(0xc80730995D2C53114BAaFd2736E02f4E274D5B83)
+        );
     }
 
     /// @notice Returns the production token instance triples on HyperEVM,
@@ -668,7 +704,7 @@ library LibTokenInvariants {
         // (underlying, receipt, receiptVault, wrapped) tuples. The script that
         // ran it was per-chain and has since been superseded by
         // `20260807-deploy-missing-tokens`, so this is the record of the run.
-        tokens = new TokenInstance[](34);
+        tokens = new TokenInstance[](40);
         tokens[0] = TokenInstance(
             "MSTR",
             0xE3772C8695c2cf3dcAA2Dd29759f4Bb91a342763,
@@ -872,6 +908,42 @@ library LibTokenInvariants {
             0x58916AC4e186ad201376288a6655Ea46b55b8ac5,
             0xf3875383506677BCdA6b9F12c48Ff7fE300970D7,
             0x04eE4ED5FF6643eA955503f966012b684f479966
+        );
+        tokens[34] = TokenInstance(
+            "AAPL",
+            0x5f1DBfBf9345f3185C52aC3c080a0EDDb4f540c2,
+            0xb526Bf49DAB7F72B772FEF4B6D572C254A454ef7,
+            0x4E3600f48C61eF4513c72923ab50851bD546FFA9
+        );
+        tokens[35] = TokenInstance(
+            "GOOGL",
+            0xdC29d07D2125699FA44cAB7e940542b526dB0abd,
+            0x50DE74136b67911799fc39B726bFC2707cCec769,
+            0xca678d0d69F9E815d1A4f4dF05C904b2DDE017f8
+        );
+        tokens[36] = TokenInstance(
+            "INTC",
+            0x8CF3E580465e8DFaE05FF42BbFCe0d98BfF79580,
+            0x06aE3f6CFaE124039902a79Da44ad2a4A4489250,
+            0xd702276d50fdCf58b0E41b3f1f9651faBC1141f4
+        );
+        tokens[37] = TokenInstance(
+            "LLY",
+            0x9a288A27a9898f145AF9575b46617bB1DF705106,
+            0x1eE2cE9654FFa008029e8e328a95f45EBfB3bC63,
+            0xa6890e89D99Fd4F275c016d89A28ec24A428846D
+        );
+        tokens[38] = TokenInstance(
+            "MSFT",
+            0x824eA918F35821a72E34b4eaD257AF60603cb20C,
+            0xb3f9A61b0e97c7F7Bb85Ea5E9Dad0da8f3496B57,
+            0xAbb2641950C7dE9D3ec9AA05668e112E1DB701F6
+        );
+        tokens[39] = TokenInstance(
+            "PTY",
+            0x7b66449B3d7cD6569F1e235f6E4A664C24538EA8,
+            0xdf4F0897Ec6f0C37Bfc974a815cA440A3c2C2e8B,
+            0xc80730995D2C53114BAaFd2736E02f4E274D5B83
         );
     }
 


### PR DESCRIPTION
Adds **AAPL, GOOGL, INTC, LLY, MSFT, PTY** to the canonical token set and pins their Base instances.

Stacked on [#294](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/294).

## Why

These six are live on Base and listed in `st0x.registry`'s Base token list, but were absent from `LibProdTokenConfig`. Two consequences:

- nothing in this repo asserted anything about them — no ownership, authoriser, beacon or name/symbol checks
- `20260807-deploy-missing-tokens` would not carry them to Ethereum or HyperEVM, because it selects against the canonical Base table

Same gap the previous five had, found while diffing the registry against the repo.

| Ticker | Name | Symbol |
|---|---|---|
| AAPL | `Apple Inc. ST0x` | `tAAPL` |
| GOOGL | `Alphabet Inc. Class A ST0x` | `tGOOGL` |
| INTC | `Intel Corporation ST0x` | `tINTC` |
| LLY | `Eli Lilly and Company ST0x` | `tLLY` |
| MSFT | `Microsoft Corporation ST0x` | `tMSFT` |
| PTY | `PIMCO Corporate & Income Opportunity Fund ST0x` | `tPTY` |

## Verified on-chain, not taken on trust

Addresses come from the registry's Base list, but every value was checked against Base before pinning:

- each receipt vault's `name`, `symbol` and `decimals`
- `receiptVault.receipt()` equals the pinned receipt
- `wrapped.asset()` equals the receipt vault
- the wrapped leg derives `"Wrapped " + name` and `"w" + symbol`
- every vault is owned by the token-owner Safe
- every vault carries the V4 authoriser clone

All six pass on every chain, and the Base-fork suite now asserts all 40 tokens: `testConfigAlignsWithBaseTokenTable`, `testConfigMatchesLiveBase`, `testWrappedDerivationHoldsOnBase`, `testProdReceiptVaultsUniformOwnership`, `testProdReceiptVaultsShareUniformAuthoriser` and `testProductionTokensRunOnTheseBeacons` all green.

`rainix-sol-static`, `rainix-sol-legal` and `rainix-sol-single-contract` are clean.

## All three chains

The six were copied to Ethereum and HyperEVM with `20260807-deploy-missing-tokens`:

| chain | `manual-broadcast` run |
|---|---|
| ethereum | `31624478447` |
| hyperevm | `31625585429` |

Each run selected exactly the six Base had and the target lacked. Ethereum and HyperEVM landed at matching addresses, as every other row in those tables does; they differ from Base, which was deployed separately by other tooling. The tables pair by `underlying`, not by address equality.

Both chains were verified the same way as Base before pinning, including `receipt.manager()`. `testCrossChainParity` and `testEthereumTokenTableMirrorsBaseUnderlyings` pass, and parity now covers all 40 tokens across three chains with nothing skipped.

## Still outstanding

**IBHG** and **RKLB** are in the canonical set but absent from the registry's Base list. Possibly just unlisted for trading rather than anything wrong, but the two sources disagree.
