### PR TITLE
Drop snapshot-generate-cmd: rainix owns the release freeze

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -20,13 +20,13 @@ jobs:
     # moves only at release, in lockstep with the frozen snapshot the tag cuts.
     # This is the counterpart to library repos, which use rainix-autopublish and
     # bump a next-version slot on every merge. Mirrors the rain.factory.deploy
-    # caller. `cut-release.sh` freezes `src/generated/candidate/` into
-    # `src/generated/<version>/` (see the script) then regenerates the libs.
+    # caller. The freeze itself — regenerate `src/generated/candidate/`, format,
+    # then copy it to `src/generated/<version>/` — is `rainix-static cut-release`
+    # inside the reusable, so this caller supplies no command for it.
     uses: rainlanguage/rainix/.github/workflows/rainix-tag-release.yaml@main
     with:
       soldeer-package: st0x-deploy
       tag-prefix: sol-v
-      snapshot-generate-cmd: bash script/cut-release.sh
     # Secrets passed explicitly (not `inherit`), mirroring this repo's other
     # cross-org rainix callers — exactly the set rainix-tag-release declares. The
     # RPC_URL_*_FORK secrets are what its verify step forks with; omitting them


### PR DESCRIPTION
Drops `snapshot-generate-cmd` from the `rainix-tag-release` call. The freeze it
named — `bash script/cut-release.sh` — is now `rainix-static cut-release` inside
the reusable, which owns the regenerate -> `forge fmt` -> freeze order rather
than taking it as a shell string (rainlanguage/rainix#301, implemented in
rainlanguage/rainix#302).

This repo generates its pins with `forge script ./script/BuildPointers.sol`,
which is the reusable's default, so nothing replaces the removed line.

## This repo's `script/cut-release.sh` has the ordering backwards

Worth being explicit, because it is the reason rainix took the freeze over.
`script/cut-release.sh` on `main` today does:

```
cp -r src/generated/candidate "src/generated/${TAG}"   # freeze
forge script ./script/BuildPointers.sol                # …then regenerate
forge fmt
```

If the committed `candidate` has drifted from source, that freezes the stale
bytes into a dir the `frozen-snapshots-append-only` gate then protects forever,
while the regeneration moves `candidate` on to the real ones — **the release
publishes one address and permanently records another**. Nothing downstream
catches it: the self-consistency test checks the *regenerated* candidate against
source, and no test compares a numbered dir to `candidate`.

`rainix-static cut-release` runs the generate command first, formats, then
copies, and asserts the frozen dir is byte-identical to `candidate` afterwards.
The order is not expressible any other way — the consumer supplies a *generate*
command, and a generate command that creates the numbered dir itself is refused.

`script/cut-release.sh` is dead once this lands. I have deliberately not deleted
it in this PR: this one is a single line in the release call, and deleting the
script is a separate change to make once #302 is on `main`.

## Merge AFTER rainlanguage/rainix#302, not before

**This is not a no-op today, and merging it first breaks the release path.** On
`rainlanguage/rainix@main` right now `snapshot-generate-cmd` is
`required: true`. A caller that omits a required input fails at `workflow_call`
startup ("Input is required, but not provided while calling"), so between this
merging and #302 merging, a `sol-v*` tag here would fail immediately.

The reverse order is safe: #302 deletes the input, and until this lands the call
passes an input the reusable no longer declares, which also fails at startup —
so the two are a coordinated set either way. #302 first is the better order
because the dependency then runs from a finished, reviewed PR to a one-line
follow-up that merges in seconds, rather than from a merged one-liner to a large
PR that might still be sent back for changes.

Neither failure can corrupt a release: both are input-validation errors raised
before any step runs, so nothing is generated, published or committed. The only
real precaution is not to push a `sol-v*` tag between the two merges.

Unlike `rain.factory.deploy`, this repo is already on the rolling-candidate
model (`src/generated/candidate/` exists alongside the frozen `0_1_1/`), so once
#302 lands its releases work with no further change — and get the corrected
ordering.

## QA

- Discriminating tests: none exist for a workflow-call input list, and none can
  — GitHub validates `with:` against the reusable's declared inputs at run
  startup, so the only oracle is the reusable's own `on: workflow_call: inputs:`
  block. Checked directly: `pointers-generate-cmd` (optional, defaults to this
  repo's exact generate command) and no `snapshot-generate-cmd` on
  rainlanguage/rainix#302's branch; `soldeer-package` and `tag-prefix` unchanged
  and still declared. The remaining `with:` keys and all eleven `secrets:`
  entries were matched one by one against that block, since this caller passes
  secrets explicitly rather than by `inherit`.
- Mutations applied: none — this is a one-line deletion in a workflow call with
  no executable logic to mutate. The failure modes were instead enumerated from
  GitHub's validation semantics and stated above: input present but undeclared
  (fails at startup), input absent but required (fails at startup), input absent
  and optional-or-undeclared (correct). The merge order follows from which of
  those the window lands in.
- Oracle: `rainlanguage/rainix#302`'s `rainix-tag-release.yaml` read directly for
  the post-merge input set, and `rainlanguage/rainix@main`'s read for the
  pre-merge one. This repo's `script/cut-release.sh` and `script/BuildPointers.sol`
  read directly for the ordering claim above and to confirm the removed command's
  replacement default matches what this repo actually runs.
- Category check: the ask is to stop passing an input rainix is deleting.
  Covered: the line is gone, nothing replaces it because the default already
  matches, the stale comment above the call describing `cut-release.sh` as the
  thing that freezes is corrected, and the ordering constraint the deletion
  creates is stated rather than left for a release to discover. Deleting the now
  dead `script/cut-release.sh` is called out as follow-up, not folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release process by relying on the standard automated workflow for candidate regeneration, formatting, and versioned snapshot creation.
  * Updated release workflow documentation to clarify these automated steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->