### PR TITLE
Cutover bundle: mint/burn to the orchestrator, signer via MINT/BURN

### DIFF
--- a/.github/workflows/run-script.yaml
+++ b/.github/workflows/run-script.yaml
@@ -33,6 +33,7 @@ on:
           - 20260729-migrate-governance-to-timelock
           - 20260813-timelock-rehearsal-schedule
           - 20260813-timelock-rehearsal-cancel
+          - 20260831-enable-orchestrator-roles
       network:
         description: 'Network to author against (default: base)'
         required: true

--- a/script/20260831-enable-orchestrator-roles.s.sol
+++ b/script/20260831-enable-orchestrator-roles.s.sol
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+
+import {IGnosisSafe} from "../src/interface/IGnosisSafe.sol";
+import {IST0xOrchestratorV1} from "../src/interface/IST0xOrchestratorV1.sol";
+import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
+import {LibAuthoriserInvariants} from "../src/lib/LibAuthoriserInvariants.sol";
+import {LibBeaconInvariants} from "../src/lib/LibBeaconInvariants.sol";
+import {LibOrchestratorInvariants} from "../src/lib/LibOrchestratorInvariants.sol";
+import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
+
+/// @notice Dispatched against a chain without a hydrated authoriser pin.
+/// @param chainId The active chain id.
+error UnsupportedChainForEnable(uint256 chainId);
+
+/// @notice The active chain's V4 authoriser is not ready (unpinned, no code,
+/// or the wrong codehash).
+/// @param authoriser The authoriser address inspected.
+error AuthoriserNotReadyForEnable(address authoriser);
+
+/// @notice The chain's production token beacons do not point at the audited
+/// 0.1.30 implementations the orchestrator was built for. The fleet upgrade
+/// must execute BEFORE the orchestrator gains vault access — the
+/// orchestrator's own vault-logic lock cannot see these beacons (RAI-2125),
+/// so this pre-flight is the interlock that rule lives in.
+/// @param beacon The production beacon inspected.
+/// @param expectedImpl The 0.1.30 implementation it must point at.
+/// @param actualImpl The implementation it points at.
+error FleetNotUpgraded(address beacon, address expectedImpl, address actualImpl);
+
+/// @notice The Safe does not hold the `_ADMIN` role needed to move an
+/// authoriser grant in the bundle.
+/// @param adminRole The missing `_ADMIN` role.
+error SafeMissingRoleAdminForEnable(bytes32 adminRole);
+
+/// @notice The Safe does not hold `DEFAULT_ADMIN_ROLE` on the orchestrator
+/// instance, so it cannot grant the operational roles.
+/// @param orchestrator The orchestrator instance inspected.
+error SafeNotOrchestratorAdmin(address orchestrator);
+
+/// @notice Every enable item already holds on the active chain — the
+/// orchestrator has vault access and the signer holds the orchestrator's
+/// operational roles. Nothing left to author; re-dispatch cannot
+/// double-execute.
+error OrchestratorRolesAlreadyEnabled();
+
+/// @title EnableOrchestratorRoles
+/// @notice **PENDING.** Authors the per-chain Safe Tx Builder bundle that
+/// ENABLES the orchestrator mint/burn path, as ONE atomic MultiSend:
+///
+///  1. authoriser `grantRole(DEPOSIT, orchestrator)` and
+///     `grantRole(WITHDRAW, orchestrator)` — the orchestrator becomes a
+///     vault-authorised principal;
+///  2. orchestrator `grantRole(MINT_ROLE, service signer)` and
+///     `grantRole(BURN_ROLE, service signer)` — the signer can mint/burn
+///     THROUGH the orchestrator (recipient-auth, receipt custody, nonce
+///     discipline).
+///
+/// The signer's DIRECT vault roles are deliberately LEFT IN PLACE: both
+/// paths run in parallel for a burn-in window so an off-chain issue with
+/// the orchestrator has an immediate fallback. The sibling
+/// `20260831-retire-direct-signer-roles` authors the revokes once the
+/// orchestrator has proven itself — that split is the point, not an
+/// oversight. Also untouched: the signer's `CERTIFY` (the orchestrator has
+/// no certify surface) and the Safe's own three direct action roles (the
+/// break-glass path).
+///
+/// @dev Dispatch via `Actions → run-script` with
+/// `script = 20260831-enable-orchestrator-roles` per chain; sign and
+/// execute the emitted artifact in the Safe UI. Pre-flight refuses to
+/// author until, on the active chain: the 0.1.30 orchestrator instance is
+/// live at its pin with the Safe as admin, AND the production token beacons
+/// point at the 0.1.30 implementations (`FleetNotUpgraded`) — the
+/// orchestrator's own vault-logic lock cannot see the in-use beacons
+/// (RAI-2125), so the "fleet upgrade first, roles after" rule is enforced
+/// HERE rather than by runbook. Self-scoping: only items not yet live are
+/// authored, and a fully-enabled chain refuses
+/// (`OrchestratorRolesAlreadyEnabled`).
+///
+/// The post-execution pin PR ADDS the orchestrator's DEPOSIT/WITHDRAW rows
+/// to the authoriser grant map (nothing is removed — the signer's rows
+/// stay until the retire script executes) and retires this script's
+/// fixtures.
+contract EnableOrchestratorRoles is Script {
+    /// @notice The service signer whose direct vault access moves behind
+    /// the orchestrator.
+    address internal constant SERVICE_SIGNER = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
+
+    /// @notice The orchestrator's operational roles (pinned to the audited
+    /// 0.1.30 source: `MINT_ROLE = keccak256("MINT")`,
+    /// `BURN_ROLE = keccak256("BURN")`).
+    bytes32 internal constant ORCHESTRATOR_MINT_ROLE = keccak256("MINT");
+    bytes32 internal constant ORCHESTRATOR_BURN_ROLE = keccak256("BURN");
+
+    /// @notice Signer-visible `meta.name` for the emitted bundle.
+    string internal constant BUNDLE_NAME =
+        "ST0x enable: orchestrator vault access + service signer MINT/BURN via orchestrator";
+
+    /// @notice Chain-suffixed artifact path — three chains dispatch in one
+    /// operational window; a shared path would let one chain's bundle
+    /// silently overwrite another's.
+    /// @return path The artifact path for the ACTIVE chain.
+    function artifactPath() internal view virtual returns (string memory path) {
+        path = string.concat("out/20260831-enable-orchestrator-roles-", vm.toString(block.chainid), ".json");
+    }
+
+    /// @notice The active chain's hydrated V4 authoriser, asserted deployed
+    /// with the shared EIP-1167 codehash.
+    /// @return authoriser The validated authoriser address.
+    function activeChainAuthoriser() internal view returns (address authoriser) {
+        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+        } else if (block.chainid == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+        } else if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
+        } else {
+            revert UnsupportedChainForEnable(block.chainid);
+        }
+        if (
+            authoriser == address(0) || authoriser.code.length == 0
+                || authoriser.codehash != LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
+        ) {
+            revert AuthoriserNotReadyForEnable(authoriser);
+        }
+    }
+
+    /// @notice The fleet-upgrade interlock: the active chain's in-use
+    /// production receipt + receipt-vault beacons must point at the audited
+    /// 0.1.30 implementations the orchestrator was built for. The
+    /// orchestrator's own vault-logic lock reads its release set-deployer's
+    /// beacons, not these (RAI-2125), so this pre-flight carries the rule.
+    function assertFleetUpgraded() internal view {
+        // Index order pinned by LibProdBeacons*: receipt, receipt vault,
+        // wrapped token vault. The wrapped-token-vault beacon is not part of
+        // the orchestrator's surface and is not gated here.
+        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
+        address receiptImpl = IBeacon(beacons[0]).implementation();
+        if (receiptImpl != LibProdDeployV4.STOX_RECEIPT_0_1_30) {
+            revert FleetNotUpgraded(beacons[0], LibProdDeployV4.STOX_RECEIPT_0_1_30, receiptImpl);
+        }
+        address vaultImpl = IBeacon(beacons[1]).implementation();
+        if (vaultImpl != LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30) {
+            revert FleetNotUpgraded(beacons[1], LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30, vaultImpl);
+        }
+    }
+
+    /// @notice Pre-flight the principals and self-scope the bundle: one tx
+    /// per enable item not yet live on-chain, in the fixed order (grant
+    /// orchestrator vault roles, grant signer orchestrator roles). Refuses
+    /// when the grant map has drifted, when the Safe lacks an `_ADMIN` it
+    /// needs, when it lacks orchestrator admin, or when every item already
+    /// holds (`OrchestratorRolesAlreadyEnabled`).
+    /// @param authoriser The chain's authoriser clone.
+    /// @param orchestrator The orchestrator instance.
+    /// @param safeAddr The chain's token-owner Safe.
+    /// @return txs The self-scoped enable transactions.
+    function authorBundle(address authoriser, address orchestrator, address safeAddr)
+        internal
+        view
+        returns (SafeTx[] memory txs)
+    {
+        IAccessControl acl = IAccessControl(authoriser);
+        IAccessControl orch = IAccessControl(orchestrator);
+
+        // The canonical map must hold exactly before it is mutated — a
+        // drifted authoriser never gets the orchestrator granted onto it.
+        LibAuthoriserInvariants.assertExpectedGrants(authoriser, safeAddr);
+
+        // The Safe admins both authoriser roles being moved, and the
+        // orchestrator's roles via DEFAULT_ADMIN_ROLE.
+        if (!acl.hasRole(keccak256("DEPOSIT_ADMIN"), safeAddr)) {
+            revert SafeMissingRoleAdminForEnable(keccak256("DEPOSIT_ADMIN"));
+        }
+        if (!acl.hasRole(keccak256("WITHDRAW_ADMIN"), safeAddr)) {
+            revert SafeMissingRoleAdminForEnable(keccak256("WITHDRAW_ADMIN"));
+        }
+        if (!orch.hasRole(bytes32(0), safeAddr)) {
+            revert SafeNotOrchestratorAdmin(orchestrator);
+        }
+
+        // Self-scope: author only the items not already live. The signer's
+        // direct roles are NOT touched — the retire script owns those.
+        SafeTx[] memory candidates = new SafeTx[](4);
+        uint256 count = 0;
+        if (!acl.hasRole(keccak256("DEPOSIT"), orchestrator)) {
+            candidates[count++] = SafeTx({
+                to: authoriser,
+                value: 0,
+                data: abi.encodeCall(IAccessControl.grantRole, (keccak256("DEPOSIT"), orchestrator)),
+                operation: 0
+            });
+        }
+        if (!acl.hasRole(keccak256("WITHDRAW"), orchestrator)) {
+            candidates[count++] = SafeTx({
+                to: authoriser,
+                value: 0,
+                data: abi.encodeCall(IAccessControl.grantRole, (keccak256("WITHDRAW"), orchestrator)),
+                operation: 0
+            });
+        }
+        if (!orch.hasRole(ORCHESTRATOR_MINT_ROLE, SERVICE_SIGNER)) {
+            candidates[count++] = SafeTx({
+                to: orchestrator,
+                value: 0,
+                data: abi.encodeCall(IAccessControl.grantRole, (ORCHESTRATOR_MINT_ROLE, SERVICE_SIGNER)),
+                operation: 0
+            });
+        }
+        if (!orch.hasRole(ORCHESTRATOR_BURN_ROLE, SERVICE_SIGNER)) {
+            candidates[count++] = SafeTx({
+                to: orchestrator,
+                value: 0,
+                data: abi.encodeCall(IAccessControl.grantRole, (ORCHESTRATOR_BURN_ROLE, SERVICE_SIGNER)),
+                operation: 0
+            });
+        }
+        if (count == 0) {
+            revert OrchestratorRolesAlreadyEnabled();
+        }
+        txs = new SafeTx[](count);
+        for (uint256 i = 0; i < count; i++) {
+            txs[i] = candidates[i];
+        }
+    }
+
+    /// @notice Assert the post-enable state on the active fork: the
+    /// orchestrator holds both vault roles, the signer holds both
+    /// orchestrator roles AND still holds its direct vault roles — the
+    /// parallel burn-in state; `20260831-retire-direct-signer-roles`
+    /// removes the direct roles once the orchestrator has proven itself.
+    /// Nothing is removed here, so the ENTIRE canonical map must still
+    /// hold, and the orchestrator's vault-logic lock must still pass.
+    /// @param acl The authoriser's access-control surface.
+    /// @param orchestrator The orchestrator instance.
+    /// @param safeAddr The chain's token-owner Safe.
+    function assertPostEnableState(IAccessControl acl, address orchestrator, address safeAddr) internal view {
+        require(
+            acl.hasRole(keccak256("DEPOSIT"), orchestrator) && acl.hasRole(keccak256("WITHDRAW"), orchestrator),
+            "EnableOrchestratorRoles: orchestrator did not gain vault access"
+        );
+        IAccessControl orch = IAccessControl(orchestrator);
+        require(
+            orch.hasRole(ORCHESTRATOR_MINT_ROLE, SERVICE_SIGNER)
+                && orch.hasRole(ORCHESTRATOR_BURN_ROLE, SERVICE_SIGNER),
+            "EnableOrchestratorRoles: service signer lacks orchestrator MINT/BURN"
+        );
+        require(
+            acl.hasRole(keccak256("DEPOSIT"), SERVICE_SIGNER) && acl.hasRole(keccak256("WITHDRAW"), SERVICE_SIGNER),
+            "EnableOrchestratorRoles: the signer's parallel fallback path was disturbed"
+        );
+        // Nothing is removed: the entire canonical map still holds.
+        LibAuthoriserInvariants.assertExpectedGrants(address(acl), safeAddr);
+        require(
+            IST0xOrchestratorV1(orchestrator).vaultLogicIsExpected(),
+            "EnableOrchestratorRoles: orchestrator vault-logic lock does not pass"
+        );
+    }
+
+    /// @notice Author the enable bundle for the active chain: see the
+    /// contract-level flow. Does not broadcast — execution happens via the
+    /// Safe UI using the emitted artifact.
+    function run() external {
+        // --- Pre-flight ---------------------------------------------------
+
+        address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
+        IGnosisSafe safe = IGnosisSafe(safeAddr);
+        address authoriser = activeChainAuthoriser();
+        IAccessControl acl = IAccessControl(authoriser);
+
+        // The 0.1.30 orchestrator world must be live at its pins, with the
+        // Safe as instance admin...
+        LibOrchestratorInvariants.assertBeaconSet(safeAddr);
+        LibOrchestratorInvariants.assertInstance(safeAddr);
+        address orchestrator = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
+
+        // ...and the FLEET must already run the 0.1.30 impls — the interlock
+        // the orchestrator's own lock cannot provide (RAI-2125).
+        assertFleetUpgraded();
+
+        // --- Build the bundle ----------------------------------------------
+
+        SafeTx[] memory txs = authorBundle(authoriser, orchestrator, safeAddr);
+
+        uint256 nonce = safe.nonce();
+        bytes32 bundleSafeTxHash = LibSafeOps.computeMultiSendSafeTxHash(safe, txs, nonce);
+
+        // --- Simulate -----------------------------------------------------
+
+        for (uint256 i = 0; i < txs.length; i++) {
+            LibSafeOps.simulateExternalCall(safe, txs[i].to, txs[i].data);
+        }
+
+        // --- Post-state ---------------------------------------------------
+
+        assertPostEnableState(acl, orchestrator, safeAddr);
+        LibSafeInvariants.assertImmutableInvariants(safe);
+        LibSafeInvariants.assertThreshold(safe, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD);
+
+        // --- Artifact -----------------------------------------------------
+
+        string memory json = LibSafeOps.emitTxBuilderJson(safeAddr, block.chainid, BUNDLE_NAME, txs);
+        vm.writeFile(artifactPath(), json);
+
+        console2.log("==== TX BUILDER JSON BEGIN ====");
+        console2.log(json);
+        console2.log("==== TX BUILDER JSON END ====");
+        console2.log("Bundle MultiSend SafeTxHash:", vm.toString(bundleSafeTxHash));
+        console2.log("Nonce:", nonce);
+        console2.log("Bundle item count:", txs.length);
+        console2.log("Chain:", block.chainid);
+        console2.log("Authoriser:", authoriser);
+        console2.log("Orchestrator instance:", orchestrator);
+        console2.log("Service signer:", SERVICE_SIGNER);
+
+        // --- n+1 reversal proof --------------------------------------------
+
+        // The enable is fully reversible under roles the Safe holds. Prove
+        // the reversal path clears the live threshold: revoke the
+        // orchestrator's DEPOSIT through the Safe's exec, then re-grant so
+        // the fork ends enabled.
+        LibSafeOps.simulateNPlus1(
+            safe,
+            authoriser,
+            abi.encodeCall(IAccessControl.revokeRole, (keccak256("DEPOSIT"), orchestrator)),
+            LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD
+        );
+        require(
+            !acl.hasRole(keccak256("DEPOSIT"), orchestrator),
+            "EnableOrchestratorRoles: n+1 revoke did not remove the role"
+        );
+        LibSafeOps.simulateExternalCall(
+            safe, authoriser, abi.encodeCall(IAccessControl.grantRole, (keccak256("DEPOSIT"), orchestrator))
+        );
+        console2.log("n+1 reversal check passed: the Safe can disable (and re-enable) under the live threshold");
+    }
+
+    /// @notice Signer-side integrity check for a CI-authored enable
+    /// artifact, run LOCALLY against a live fork before signing: re-runs the
+    /// pre-flight, re-derives the bundle from CURRENT live state, asserts
+    /// the artifact at `jsonPath` matches it byte-exactly, and logs the
+    /// canonical MultiSend `SafeTxHash` at the live nonce for the Safe-UI
+    /// cross-check. Deliberately NOT in the run-script dispatcher: it takes
+    /// a local path and runs on the signer's machine.
+    /// @param jsonPath Filesystem path to the downloaded Tx Builder JSON.
+    function verify(string calldata jsonPath) external view {
+        address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
+        IGnosisSafe safe = IGnosisSafe(safeAddr);
+        address authoriser = activeChainAuthoriser();
+        LibOrchestratorInvariants.assertBeaconSet(safeAddr);
+        LibOrchestratorInvariants.assertInstance(safeAddr);
+        assertFleetUpgraded();
+
+        SafeTx[] memory expected =
+            authorBundle(authoriser, LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE, safeAddr);
+        LibSafeOps.assertParsedTxsMatch(expected, jsonPath);
+
+        uint256 nonce = safe.nonce();
+        console2.log("Artifact verified against live state.");
+        console2.log(
+            "Bundle MultiSend SafeTxHash:", vm.toString(LibSafeOps.computeMultiSendSafeTxHash(safe, expected, nonce))
+        );
+        console2.log("Nonce:", nonce);
+    }
+}

--- a/test/script/20260831-enable-orchestrator-roles.prod.t.sol
+++ b/test/script/20260831-enable-orchestrator-roles.prod.t.sol
@@ -9,7 +9,11 @@ import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessContro
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 
 import {EnableOrchestratorRoles, FleetNotUpgraded} from "../../script/20260831-enable-orchestrator-roles.s.sol";
-import {LibOrchestratorInvariants, OrchestratorSetDeployerMissing} from "../../src/lib/LibOrchestratorInvariants.sol";
+import {
+    LibOrchestratorInvariants,
+    OrchestratorInstanceMissing,
+    OrchestratorSetDeployerMissing
+} from "../../src/lib/LibOrchestratorInvariants.sol";
 import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
 import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
@@ -63,7 +67,13 @@ contract EnableOrchestratorRolesProdTest is Test {
             }
             console2.log(string.concat("PENDING [", label, "]: 0.1.30 orchestrator world not deployed"));
             console2.log("-> manual-sol-artifacts-0-1-30 suites, then 20260818-deploy-orchestrator, come first");
-            vm.expectRevert(abi.encodeWithSelector(OrchestratorSetDeployerMissing.selector, setDeployer));
+            // run() reads the beacon set before the instance, so whichever
+            // is missing first decides the revert.
+            if (setDeployer.code.length == 0) {
+                vm.expectRevert(abi.encodeWithSelector(OrchestratorSetDeployerMissing.selector, setDeployer));
+            } else {
+                vm.expectRevert(abi.encodeWithSelector(OrchestratorInstanceMissing.selector, orchestrator));
+            }
             script.run();
             return;
         }

--- a/test/script/20260831-enable-orchestrator-roles.prod.t.sol
+++ b/test/script/20260831-enable-orchestrator-roles.prod.t.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
+
+import {EnableOrchestratorRoles, FleetNotUpgraded} from "../../script/20260831-enable-orchestrator-roles.s.sol";
+import {LibOrchestratorInvariants, OrchestratorSetDeployerMissing} from "../../src/lib/LibOrchestratorInvariants.sol";
+import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
+import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
+import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
+
+/// @notice The enable deadline passed with this chain still pending.
+/// Run the outstanding dispatches, extend the deadline, or delete the
+/// invariant.
+/// @param label The chain still pending.
+error OrchestratorEnableOverdue(string label);
+
+/// @title EnableOrchestratorRolesProdTest
+/// @notice PROD coverage for the orchestrator enable: what production IS on each
+/// chain, read from a real fork with no mocks, walking the rollout states:
+///
+/// 1. **Orchestrator world pending** (every chain today): `run()`'s
+///    pre-flight refuses at the 0.1.30 beacon-set read
+///    (`OrchestratorSetDeployerMissing`) — the closure + instance dispatches
+///    come first.
+/// 2. **Fleet pending** (orchestrator live, production beacons still on
+///    pre-0.1.30 impls): pins the `FleetNotUpgraded` interlock — the rule
+///    that vault access is granted only after the fleet upgrade (RAI-2125).
+/// 3. **Ready** (fleet upgraded, not cut over): drives `run()` end to end
+///    on the fork — bundle authored, simulated, post-state and n+1 proven.
+/// 4. **Executed** (the parallel burn-in state): the orchestrator holds
+///    vault access, the signer holds MINT/BURN on it AND keeps its direct
+///    roles (the fallback path the retire script removes later); plus the
+///    re-authoring refusal.
+///
+/// States 1–3 stop passing at `ENABLE_DEADLINE`; state 4 is steady and
+/// never expires.
+contract EnableOrchestratorRolesProdTest is Test {
+    /// @notice Unix timestamp (2026-10-01T00:00:00Z) past which a chain
+    /// still in a pending state fails instead of logging PENDING. Shared
+    /// with the orchestrator rollout deadline — the cutover is its last
+    /// step.
+    uint256 internal constant ENABLE_DEADLINE = 1_790_812_800;
+
+    /// @notice Walk the active fork's cutover state (see the contract
+    /// NatSpec) and assert it.
+    /// @param label Human chain name, surfaced in logs and messages.
+    function assertEnableRollout(string memory label) internal {
+        EnableOrchestratorRoles script = new EnableOrchestratorRoles();
+        address setDeployer = LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30;
+        address orchestrator = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
+
+        if (setDeployer.code.length == 0 || orchestrator.code.length == 0) {
+            if (block.timestamp >= ENABLE_DEADLINE) {
+                revert OrchestratorEnableOverdue(label);
+            }
+            console2.log(string.concat("PENDING [", label, "]: 0.1.30 orchestrator world not deployed"));
+            console2.log("-> manual-sol-artifacts-0-1-30 suites, then 20260818-deploy-orchestrator, come first");
+            vm.expectRevert(abi.encodeWithSelector(OrchestratorSetDeployerMissing.selector, setDeployer));
+            script.run();
+            return;
+        }
+
+        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
+        bool fleetUpgraded = IBeacon(beacons[0]).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
+            && IBeacon(beacons[1]).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30;
+        if (!fleetUpgraded) {
+            if (block.timestamp >= ENABLE_DEADLINE) {
+                revert OrchestratorEnableOverdue(label);
+            }
+            console2.log(string.concat("PENDING [", label, "]: fleet not upgraded to 0.1.30 - cutover gated"));
+            console2.log("-> execute the fleet beacon-repoint through governance first");
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    FleetNotUpgraded.selector,
+                    beacons[0],
+                    LibProdDeployV4.STOX_RECEIPT_0_1_30,
+                    IBeacon(beacons[0]).implementation()
+                )
+            );
+            script.run();
+            return;
+        }
+
+        IAccessControl acl = IAccessControl(activeAuthoriser());
+        bool enabled = acl.hasRole(keccak256("DEPOSIT"), orchestrator);
+        if (!enabled) {
+            if (block.timestamp >= ENABLE_DEADLINE) {
+                revert OrchestratorEnableOverdue(label);
+            }
+            console2.log(string.concat("PENDING [", label, "]: ready - driving the authoring end to end"));
+            script.run();
+            return;
+        }
+
+        // Executed steady state — the parallel burn-in: the orchestrator
+        // holds vault access AND the signer keeps its direct roles until
+        // the retire script removes them.
+        assertTrue(acl.hasRole(keccak256("WITHDRAW"), orchestrator), string.concat(label, ": orchestrator WITHDRAW"));
+        IAccessControl orch = IAccessControl(orchestrator);
+        assertTrue(
+            orch.hasRole(keccak256("MINT"), LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C)
+                && orch.hasRole(keccak256("BURN"), LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C),
+            string.concat(label, ": signer lacks orchestrator MINT/BURN")
+        );
+        // While the retire script is pending, the signer's direct roles are
+        // the fallback path and must still hold; the retire prod test owns
+        // the post-retirement asserts.
+        if (acl.hasRole(keccak256("DEPOSIT"), LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C)) {
+            console2.log(string.concat("PARALLEL [", label, "]: burn-in window - direct signer path still live"));
+        }
+    }
+
+    /// @notice The active chain's authoriser pin (mirrors the script's
+    /// chain switch; the script's own guard covers validation).
+    function activeAuthoriser() internal view returns (address) {
+        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+        }
+        return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+    }
+
+    function testEnableRolloutBase() external {
+        vm.createSelectFork(LibRainDeploy.BASE);
+        assertEnableRollout("base");
+    }
+
+    function testEnableRolloutEthereum() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
+        assertEnableRollout("ethereum");
+    }
+
+    function testEnableRolloutHyperEvm() external {
+        vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
+        assertEnableRollout("hyperevm");
+    }
+}

--- a/test/script/20260831-enable-orchestrator-roles.prod.t.sol
+++ b/test/script/20260831-enable-orchestrator-roles.prod.t.sol
@@ -8,7 +8,8 @@ import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 
-import {EnableOrchestratorRoles, FleetNotUpgraded} from "../../script/20260831-enable-orchestrator-roles.s.sol";
+import {FleetNotUpgraded, OrchestratorRolesAlreadyEnabled} from "../../script/20260831-enable-orchestrator-roles.s.sol";
+import {EnableOrchestratorRolesHarness} from "./EnableOrchestratorRolesHarness.sol";
 import {
     LibOrchestratorInvariants,
     OrchestratorInstanceMissing,
@@ -17,7 +18,6 @@ import {
 import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
 import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
-import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
 import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
 
 /// @notice The enable deadline passed with this chain still pending.
@@ -57,7 +57,7 @@ contract EnableOrchestratorRolesProdTest is Test {
     /// NatSpec) and assert it.
     /// @param label Human chain name, surfaced in logs and messages.
     function assertEnableRollout(string memory label) internal {
-        EnableOrchestratorRoles script = new EnableOrchestratorRoles();
+        EnableOrchestratorRolesHarness script = new EnableOrchestratorRolesHarness();
         address setDeployer = LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30;
         address orchestrator = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
 
@@ -99,7 +99,7 @@ contract EnableOrchestratorRolesProdTest is Test {
             return;
         }
 
-        IAccessControl acl = IAccessControl(activeAuthoriser());
+        IAccessControl acl = IAccessControl(script.callActiveChainAuthoriser());
         bool enabled = acl.hasRole(keccak256("DEPOSIT"), orchestrator);
         if (!enabled) {
             if (block.timestamp >= ENABLE_DEADLINE) {
@@ -126,15 +126,10 @@ contract EnableOrchestratorRolesProdTest is Test {
         if (acl.hasRole(keccak256("DEPOSIT"), LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C)) {
             console2.log(string.concat("PARALLEL [", label, "]: burn-in window - direct signer path still live"));
         }
-    }
-
-    /// @notice The active chain's authoriser pin (mirrors the script's
-    /// chain switch; the script's own guard covers validation).
-    function activeAuthoriser() internal view returns (address) {
-        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
-            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
-        }
-        return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+        // Re-authoring against the executed state refuses rather than
+        // emitting an empty bundle.
+        vm.expectRevert(OrchestratorRolesAlreadyEnabled.selector);
+        script.run();
     }
 
     function testEnableRolloutBase() external {

--- a/test/script/20260831-enable-orchestrator-roles.t.sol
+++ b/test/script/20260831-enable-orchestrator-roles.t.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+
+import {
+    FleetNotUpgraded,
+    SafeNotOrchestratorAdmin,
+    OrchestratorRolesAlreadyEnabled
+} from "../../script/20260831-enable-orchestrator-roles.s.sol";
+import {EnableOrchestratorRolesHarness} from "./EnableOrchestratorRolesHarness.sol";
+import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
+import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
+import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {SafeTx} from "../../src/lib/LibSafeOps.sol";
+
+/// @title EnableOrchestratorRolesTest
+/// @notice Guard coverage for `20260831-enable-orchestrator-roles` without
+/// a full replica: the fleet-upgrade interlock, the orchestrator-admin
+/// refusal, the self-scoping, and the already-executed refusal are each
+/// shown to fire. The live-fork walk of the rollout states is in
+/// `20260831-enable-orchestrator-roles.prod.t.sol`.
+contract EnableOrchestratorRolesTest is Test {
+    EnableOrchestratorRolesHarness internal harness;
+
+    address internal constant SAFE = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE;
+    address internal constant AUTHORISER = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+    address internal constant ORCHESTRATOR = LibProdDeployV4.ST0X_ORCHESTRATOR_INSTANCE;
+    address internal constant SIGNER = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
+
+    function setUp() external {
+        vm.chainId(LibSafeInvariants.BASE_CHAIN_ID);
+        harness = new EnableOrchestratorRolesHarness();
+    }
+
+    /// @notice Mock Base's three in-use production beacons pointing at the
+    /// 0.1.30 receipt/vault impls (the post-fleet-upgrade state).
+    function mockUpgradedFleet() internal {
+        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(LibSafeInvariants.BASE_CHAIN_ID);
+        vm.etch(beacons[0], hex"fe");
+        vm.etch(beacons[1], hex"fe");
+        vm.mockCall(
+            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
+        );
+        vm.mockCall(
+            beacons[1],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30)
+        );
+    }
+
+    /// @notice Mock the canonical grant map fully held on the authoriser,
+    /// with no principal holding `DEFAULT_ADMIN_ROLE`, and the Safe holding
+    /// orchestrator admin. `hasRole` defaults are then narrowed per test.
+    function mockHealthyPrincipals() internal {
+        vm.etch(AUTHORISER, hex"fe");
+        vm.etch(ORCHESTRATOR, hex"fe");
+        // Default every authoriser hasRole probe to true, then carve out the
+        // DEFAULT_ADMIN probes the map assertion requires to be false.
+        vm.mockCall(AUTHORISER, abi.encodeWithSelector(IAccessControl.hasRole.selector), abi.encode(true));
+        address[4] memory admins = [SAFE, SAFE, LibAuthoriserInvariants.GRANTEE_SERVICE_1C66, SIGNER];
+        for (uint256 i = 0; i < admins.length; i++) {
+            vm.mockCall(AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), admins[i])), abi.encode(false));
+        }
+        // The retired signer holds nothing (absence pin).
+        bytes32[3] memory actionRoles = [keccak256("DEPOSIT"), keccak256("WITHDRAW"), keccak256("CERTIFY")];
+        for (uint256 i = 0; i < actionRoles.length; i++) {
+            vm.mockCall(
+                AUTHORISER,
+                abi.encodeCall(IAccessControl.hasRole, (actionRoles[i], LibAuthoriserInvariants.GRANTEE_SERVICE_1C66)),
+                abi.encode(false)
+            );
+        }
+        // Orchestrator: Safe is admin; signer holds nothing yet; the
+        // orchestrator itself holds no direct vault roles yet.
+        vm.mockCall(ORCHESTRATOR, abi.encodeWithSelector(IAccessControl.hasRole.selector), abi.encode(false));
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), SAFE)), abi.encode(true));
+        bytes32[2] memory vaultRoles = [keccak256("DEPOSIT"), keccak256("WITHDRAW")];
+        for (uint256 i = 0; i < vaultRoles.length; i++) {
+            vm.mockCall(
+                AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (vaultRoles[i], ORCHESTRATOR)), abi.encode(false)
+            );
+        }
+    }
+
+    /// The fleet-upgrade interlock refuses beacons still on pre-0.1.30
+    /// impls, naming the beacon and both impls.
+    function testFleetGateRefusesUnupgradedBeacons() external {
+        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(LibSafeInvariants.BASE_CHAIN_ID);
+        vm.etch(beacons[0], hex"fe");
+        vm.mockCall(
+            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_1)
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FleetNotUpgraded.selector,
+                beacons[0],
+                LibProdDeployV4.STOX_RECEIPT_0_1_30,
+                LibProdDeployV4.STOX_RECEIPT_0_1_1
+            )
+        );
+        harness.callAssertFleetUpgraded();
+    }
+
+    /// The interlock passes once both gated beacons point at 0.1.30.
+    function testFleetGateAcceptsUpgradedBeacons() external {
+        mockUpgradedFleet();
+        harness.callAssertFleetUpgraded();
+    }
+
+    /// Authoring refuses when the Safe lacks `DEFAULT_ADMIN_ROLE` on the
+    /// orchestrator — the bundle's orchestrator grants could never execute.
+    function testAuthoringRefusesWithoutOrchestratorAdmin() external {
+        mockHealthyPrincipals();
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), SAFE)), abi.encode(false));
+        vm.expectRevert(abi.encodeWithSelector(SafeNotOrchestratorAdmin.selector, ORCHESTRATOR));
+        harness.callAuthorBundle(AUTHORISER, ORCHESTRATOR, SAFE);
+    }
+
+    /// The fresh pre-enable state authors all four transactions in the
+    /// fixed order: grant orchestrator both vault roles, grant the signer
+    /// both orchestrator roles. NO revokes — the signer's direct roles stay
+    /// for the parallel burn-in window.
+    function testAuthoringProducesTheFullFourTxBundle() external {
+        mockHealthyPrincipals();
+        SafeTx[] memory txs = harness.callAuthorBundle(AUTHORISER, ORCHESTRATOR, SAFE);
+        assertEq(txs.length, 4);
+        assertEq(txs[0].to, AUTHORISER);
+        assertEq(txs[0].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("DEPOSIT"), ORCHESTRATOR)));
+        assertEq(txs[1].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("WITHDRAW"), ORCHESTRATOR)));
+        assertEq(txs[2].to, ORCHESTRATOR);
+        assertEq(txs[2].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("MINT"), SIGNER)));
+        assertEq(txs[3].to, ORCHESTRATOR);
+        assertEq(txs[3].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("BURN"), SIGNER)));
+    }
+
+    /// A partially-executed cutover self-scopes: an orchestrator grant that
+    /// already landed is not re-authored (the canonical map is untouched by
+    /// EXTRA holders, so the map gate still passes).
+    function testAuthoringSelfScopesLandedOrchestratorGrants() external {
+        mockHealthyPrincipals();
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("DEPOSIT"), ORCHESTRATOR)), abi.encode(true)
+        );
+        SafeTx[] memory txs = harness.callAuthorBundle(AUTHORISER, ORCHESTRATOR, SAFE);
+        assertEq(txs.length, 3);
+        assertEq(txs[0].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("WITHDRAW"), ORCHESTRATOR)));
+    }
+
+    /// A fully-enabled chain refuses to author anything — and because the
+    /// enable removes no map rows, this refusal is reachable immediately
+    /// after execution, before any pin PR.
+    function testRefusesWhenAlreadyEnabled() external {
+        mockHealthyPrincipals();
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("DEPOSIT"), ORCHESTRATOR)), abi.encode(true)
+        );
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("WITHDRAW"), ORCHESTRATOR)), abi.encode(true)
+        );
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (keccak256("MINT"), SIGNER)), abi.encode(true));
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (keccak256("BURN"), SIGNER)), abi.encode(true));
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), SAFE)), abi.encode(true));
+        vm.expectRevert(OrchestratorRolesAlreadyEnabled.selector);
+        harness.callAuthorBundle(AUTHORISER, ORCHESTRATOR, SAFE);
+    }
+}

--- a/test/script/EnableOrchestratorRolesHarness.sol
+++ b/test/script/EnableOrchestratorRolesHarness.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {EnableOrchestratorRoles} from "../../script/20260831-enable-orchestrator-roles.s.sol";
+import {SafeTx} from "../../src/lib/LibSafeOps.sol";
+
+/// @dev Exposes the script's internals so the guard tests can drive them
+/// directly.
+contract EnableOrchestratorRolesHarness is EnableOrchestratorRoles {
+    /// @notice The script's `assertFleetUpgraded()`, externally callable.
+    function callAssertFleetUpgraded() external view {
+        assertFleetUpgraded();
+    }
+
+    /// @notice The script's `authorBundle()`, externally callable.
+    function callAuthorBundle(address authoriser, address orchestrator, address safeAddr)
+        external
+        view
+        returns (SafeTx[] memory)
+    {
+        return authorBundle(authoriser, orchestrator, safeAddr);
+    }
+
+    /// @notice The script's `activeChainAuthoriser()`, externally callable.
+    function callActiveChainAuthoriser() external view returns (address) {
+        return activeChainAuthoriser();
+    }
+}


### PR DESCRIPTION
Now the **enable half** of the split (per review: keep both mint paths in parallel for a burn-in window rather than atomically revoking the direct path).

`20260831-enable-orchestrator-roles` (`run-script` registry, per chain) authors one atomic Safe MultiSend: authoriser `grantRole(DEPOSIT/WITHDRAW, orchestrator)` + orchestrator `grantRole(MINT/BURN, signer)`. **No revokes** — the signer's direct roles stay as the emergency fallback; `20260831-retire-direct-signer-roles` (#336, top of stack) removes them after the burn-in.

Pre-flight unchanged from the cutover version: 0.1.30 orchestrator world at its pins with the Safe as instance admin, plus the `FleetNotUpgraded` interlock ([RAI-2125](https://linear.app/makeitrain/issue/RAI-2125)) — vault access only after the fleet runs the audited impls. Post-state asserts the FULL canonical map still holds (nothing removed) and the signer's fallback path is intact. Post-execution pin PR only ADDs orchestrator rows.

Unit 6/6 (4-tx bundle shape), prod walk 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbsbYN4C4YDa8pu9DdudoX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dispatchable operational script to enable orchestrator minting and burning permissions.
  * Generates atomic Safe transaction bundles for granting the required orchestrator and signer roles.
  * Supports rollout verification across Base, Ethereum, and HyperEVM deployments.
  * Validates deployment readiness and prevents duplicate or unsafe enablement.
  * Provides transaction bundle verification and limits changes to permissions that are not already active.

* **Tests**
  * Added coverage for rollout states, permission checks, transaction ordering, and already-enabled configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->