### PR TITLE
Fleet upgrade bundle: receipt + receipt-vault beacons to audited 0.1.30

### DIFF
--- a/.github/workflows/run-script.yaml
+++ b/.github/workflows/run-script.yaml
@@ -34,6 +34,7 @@ on:
           - 20260813-timelock-rehearsal-schedule
           - 20260813-timelock-rehearsal-cancel
           - 20260831-enable-orchestrator-roles
+          - 20260825-upgrade-fleet-to-0-1-30
       network:
         description: 'Network to author against (default: base)'
         required: true

--- a/script/20260818-deploy-orchestrator.s.sol
+++ b/script/20260818-deploy-orchestrator.s.sol
@@ -7,22 +7,9 @@ import {console2} from "forge-std-1.16.1/src/console2.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
 import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
+import {LibClosureInvariants} from "../src/lib/LibClosureInvariants.sol";
 import {LibOrchestratorInvariants} from "../src/lib/LibOrchestratorInvariants.sol";
 import {IST0xOrchestratorBeaconSetDeployerV1} from "../src/interface/IST0xOrchestratorBeaconSetDeployerV1.sol";
-
-/// @notice Pre-flight failed: a contract of the audited 0.1.30 orchestrator
-/// closure has no runtime code at its pinned address on the active chain.
-/// Ship the closure first via `manual-sol-artifacts-0-1-30.yaml`.
-/// @param pinned The pinned closure address that is missing.
-error ClosureNotDeployed(address pinned);
-
-/// @notice Pre-flight failed: a closure contract's runtime codehash does not
-/// match its 0.1.30 pin — something other than the audited bytecode sits at
-/// the pinned address.
-/// @param pinned The pinned closure address inspected.
-/// @param expected The pinned 0.1.30 codehash.
-/// @param actual The codehash read from the chain.
-error ClosureCodehashMismatch(address pinned, bytes32 expected, bytes32 actual);
 
 /// @notice The pinned orchestrator instance already has code on this chain —
 /// the production instance exists and there is nothing to deploy. This is
@@ -86,38 +73,27 @@ error DeployKeyHoldsAdmin(address instance, address deployer);
 /// the source of truth (`deploy` is permissionless, so an attacker can emit
 /// lookalike `Deployment` events; see the interface's event NatSpec).
 contract DeployOrchestrator is Script {
-    /// @notice Assert one closure contract is live at its pin with the
-    /// audited 0.1.30 codehash.
-    /// @param pinned The pinned closure address.
-    /// @param codehash The pinned 0.1.30 codehash.
-    function _assertClosureContract(address pinned, bytes32 codehash) internal view {
-        if (pinned.code.length == 0) {
-            revert ClosureNotDeployed(pinned);
-        }
-        if (pinned.codehash != codehash) {
-            revert ClosureCodehashMismatch(pinned, codehash, pinned.codehash);
-        }
-    }
-
     /// @notice Assert the full audited 0.1.30 orchestrator closure is live on
     /// the active chain, by codehash, in dependency order.
     function _assertClosureReady() internal view {
-        _assertClosureContract(
+        LibClosureInvariants.assertClosureContract(
             LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30,
             LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_CODEHASH_0_1_30
         );
-        _assertClosureContract(LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30);
-        _assertClosureContract(
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30
+        );
+        LibClosureInvariants.assertClosureContract(
             LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30, LibProdDeployV4.STOX_RECEIPT_VAULT_CODEHASH_0_1_30
         );
-        _assertClosureContract(
+        LibClosureInvariants.assertClosureContract(
             LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_0_1_30,
             LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_CODEHASH_0_1_30
         );
-        _assertClosureContract(
+        LibClosureInvariants.assertClosureContract(
             LibProdDeployV4.ST0X_ORCHESTRATOR_0_1_30, LibProdDeployV4.ST0X_ORCHESTRATOR_CODEHASH_0_1_30
         );
-        _assertClosureContract(
+        LibClosureInvariants.assertClosureContract(
             LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30,
             LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_CODEHASH_0_1_30
         );

--- a/script/20260825-upgrade-fleet-to-0-1-30.s.sol
+++ b/script/20260825-upgrade-fleet-to-0-1-30.s.sol
@@ -12,7 +12,9 @@ import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
 import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
 import {LibBeaconInvariants} from "../src/lib/LibBeaconInvariants.sol";
 import {LibTokenInvariants, TokenInstance} from "../src/lib/LibTokenInvariants.sol";
-import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
+import {LibSafeOps, SafeTx, IUpgradeableBeacon} from "../src/lib/LibSafeOps.sol";
+import {LibClosureInvariants} from "../src/lib/LibClosureInvariants.sol";
+import {IReceiptV3} from "rain-vats-0.1.6/src/interface/IReceiptV3.sol";
 
 /// @dev Unix timestamp (2026-10-01T00:00:00Z) by which the fleet upgrade
 /// must have executed on every chain. Shared by the migration-window
@@ -20,12 +22,6 @@ import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
 /// then; the orchestrator rollout shares the same date — this upgrade gates
 /// its cutover.
 uint256 constant FLEET_UPGRADE_DEADLINE = 1_790_812_800;
-
-/// @notice A 0.1.30 implementation this upgrade would repoint a beacon to
-/// has no runtime code (or the wrong codehash) on the active chain. Ship the
-/// audited closure via `manual-sol-artifacts-0-1-30.yaml` first.
-/// @param impl The pinned 0.1.30 implementation inspected.
-error UpgradeTargetNotDeployed(address impl);
 
 /// @notice A production beacon is neither in the pre-upgrade (0.1.1) nor the
 /// post-upgrade (0.1.30) implementation state — unknown drift; resolve
@@ -74,8 +70,9 @@ error UpgradeChangedTokenState(address receiptVault);
 /// no-ops); each gated beacon must be exactly in the 0.1.1 state (or
 /// already upgraded — self-scoped); the Safe must own both beacons. The
 /// simulation then proves, for EVERY production token on the chain, that
-/// `totalSupply` / `symbol` / `decimals` read identically across the
-/// upgrade — the H01 fix changes internal accounting, never reported state.
+/// `totalSupply` / `symbol` / `decimals` and each receipt's `manager` read
+/// identically across the upgrade — the H01 fix changes internal accounting,
+/// never reported state.
 ///
 /// The post-execution pin PR flips `LibProdBeaconsBase` /
 /// `LibProdBeacons0_1_1`'s `implementations()` (and the fork asserts riding
@@ -89,16 +86,6 @@ contract UpgradeFleetTo0_1_30 is Script {
     /// @return path The artifact path for the ACTIVE chain.
     function artifactPath() internal view virtual returns (string memory path) {
         path = string.concat("out/20260825-upgrade-fleet-to-0-1-30-", vm.toString(block.chainid), ".json");
-    }
-
-    /// @notice Assert one 0.1.30 upgrade target is live at its pin with the
-    /// audited codehash.
-    /// @param impl The pinned implementation address.
-    /// @param codehash The pinned 0.1.30 codehash.
-    function assertTargetDeployed(address impl, bytes32 codehash) internal view {
-        if (impl.code.length == 0 || impl.codehash != codehash) {
-            revert UpgradeTargetNotDeployed(impl);
-        }
     }
 
     /// @notice Pre-flight the beacons and self-scope the bundle: one
@@ -125,7 +112,7 @@ contract UpgradeFleetTo0_1_30 is Script {
                 revert BeaconInUnknownState(gated[i], actual);
             }
             candidates[count++] = SafeTx({
-                to: gated[i], value: 0, data: abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (post[i])), operation: 0
+                to: gated[i], value: 0, data: abi.encodeCall(IUpgradeableBeacon.upgradeTo, (post[i])), operation: 0
             });
         }
         if (count == 0) {
@@ -151,11 +138,12 @@ contract UpgradeFleetTo0_1_30 is Script {
     }
 
     /// @notice Snapshot every production token's reported state (receipt
-    /// vault `totalSupply`, `symbol` hash, `decimals`) so the post-upgrade
-    /// reads can be proven identical.
+    /// vault `totalSupply`, `symbol`, `decimals`; receipt `manager`) so the
+    /// post-upgrade reads can be proven identical.
     /// @param tokens The chain's token instances.
     /// @return supplies Each vault's `totalSupply`.
-    /// @return metaHashes keccak of each vault's `symbol` + `decimals`.
+    /// @return metaHashes keccak of each vault's `symbol` + `decimals` and its
+    /// receipt's `manager`.
     function snapshotTokenState(TokenInstance[] memory tokens)
         internal
         view
@@ -166,7 +154,8 @@ contract UpgradeFleetTo0_1_30 is Script {
         for (uint256 i = 0; i < tokens.length; i++) {
             IERC20Metadata vault = IERC20Metadata(tokens[i].receiptVault);
             supplies[i] = vault.totalSupply();
-            metaHashes[i] = keccak256(abi.encode(vault.symbol(), vault.decimals()));
+            metaHashes[i] =
+                keccak256(abi.encode(vault.symbol(), vault.decimals(), IReceiptV3(tokens[i].receipt).manager()));
         }
     }
 
@@ -184,7 +173,8 @@ contract UpgradeFleetTo0_1_30 is Script {
             IERC20Metadata vault = IERC20Metadata(tokens[i].receiptVault);
             if (
                 vault.totalSupply() != supplies[i]
-                    || keccak256(abi.encode(vault.symbol(), vault.decimals())) != metaHashes[i]
+                    || keccak256(abi.encode(vault.symbol(), vault.decimals(), IReceiptV3(tokens[i].receipt).manager()))
+                        != metaHashes[i]
             ) {
                 revert UpgradeChangedTokenState(tokens[i].receiptVault);
             }
@@ -202,11 +192,13 @@ contract UpgradeFleetTo0_1_30 is Script {
 
         // The audited 0.1.30 targets (and the facet the new vault
         // delegatecalls) must be live at their pins by codehash.
-        assertTargetDeployed(LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30);
-        assertTargetDeployed(
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30
+        );
+        LibClosureInvariants.assertClosureContract(
             LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30, LibProdDeployV4.STOX_RECEIPT_VAULT_CODEHASH_0_1_30
         );
-        assertTargetDeployed(
+        LibClosureInvariants.assertClosureContract(
             LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30,
             LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_CODEHASH_0_1_30
         );
@@ -266,7 +258,7 @@ contract UpgradeFleetTo0_1_30 is Script {
         LibSafeOps.simulateNPlus1(
             safe,
             beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
-            abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_1)),
+            abi.encodeCall(IUpgradeableBeacon.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_1)),
             LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD
         );
         require(
@@ -277,7 +269,7 @@ contract UpgradeFleetTo0_1_30 is Script {
         LibSafeOps.simulateExternalCall(
             safe,
             beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
-            abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30))
+            abi.encodeCall(IUpgradeableBeacon.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30))
         );
         console2.log("n+1 reversal check passed: the Safe can downgrade (and re-upgrade) under the live threshold");
     }
@@ -302,10 +294,4 @@ contract UpgradeFleetTo0_1_30 is Script {
         );
         console2.log("Nonce:", nonce);
     }
-}
-
-/// @dev Local mirror of OZ `UpgradeableBeacon.upgradeTo` — rain-vats ships
-/// no interface carrying it and OZ's contract is not an interface.
-interface IUpgradeableBeaconLike {
-    function upgradeTo(address newImplementation) external;
 }

--- a/script/20260825-upgrade-fleet-to-0-1-30.s.sol
+++ b/script/20260825-upgrade-fleet-to-0-1-30.s.sol
@@ -63,6 +63,10 @@ error UpgradeChangedTokenState(address receiptVault);
 /// the artifact in the Safe UI (the in-use beacons are owned by each
 /// chain's token-owner Safe). Dispatch the three chains in ONE operational
 /// window — cross-chain parity is red in between, by design.
+/// Dispatch BEFORE `20260729-migrate-governance-to-timelock` executes on
+/// the chain: once the beacons are the timelock's, this script refuses
+/// (`BeaconOwnerMismatch`) and the upgrade has to go schedule → delay →
+/// execute through the timelock, which it does not author.
 ///
 /// Pre-flight: the 0.1.30 receipt, receipt-vault and corporate-actions
 /// facet must be live at their pins by codehash (the new vault's

--- a/script/20260825-upgrade-fleet-to-0-1-30.s.sol
+++ b/script/20260825-upgrade-fleet-to-0-1-30.s.sol
@@ -88,6 +88,22 @@ contract UpgradeFleetTo0_1_30 is Script {
         path = string.concat("out/20260825-upgrade-fleet-to-0-1-30-", vm.toString(block.chainid), ".json");
     }
 
+    /// @notice The audited 0.1.30 targets (and the facet the new vault
+    /// delegatecalls) must be live at their pins by codehash. Shared by
+    /// `run()` and the signer-side `verify()`.
+    function assertUpgradeTargetsLive() internal view {
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30
+        );
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30, LibProdDeployV4.STOX_RECEIPT_VAULT_CODEHASH_0_1_30
+        );
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30,
+            LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_CODEHASH_0_1_30
+        );
+    }
+
     /// @notice Pre-flight the beacons and self-scope the bundle: one
     /// `upgradeTo` per gated beacon still serving 0.1.1. A beacon in
     /// neither state is unknown drift; both already at 0.1.30 refuses.
@@ -190,18 +206,7 @@ contract UpgradeFleetTo0_1_30 is Script {
         address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
         IGnosisSafe safe = IGnosisSafe(safeAddr);
 
-        // The audited 0.1.30 targets (and the facet the new vault
-        // delegatecalls) must be live at their pins by codehash.
-        LibClosureInvariants.assertClosureContract(
-            LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30
-        );
-        LibClosureInvariants.assertClosureContract(
-            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30, LibProdDeployV4.STOX_RECEIPT_VAULT_CODEHASH_0_1_30
-        );
-        LibClosureInvariants.assertClosureContract(
-            LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30,
-            LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_CODEHASH_0_1_30
-        );
+        assertUpgradeTargetsLive();
 
         // The in-use beacons are deployed, OZ bytecode, Safe-owned.
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
@@ -282,6 +287,7 @@ contract UpgradeFleetTo0_1_30 is Script {
     function verify(string calldata jsonPath) external view {
         address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
         IGnosisSafe safe = IGnosisSafe(safeAddr);
+        assertUpgradeTargetsLive();
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
 
         SafeTx[] memory expected = authorBundle(LibBeaconInvariants.prodBeaconsForChainId(block.chainid));

--- a/script/20260825-upgrade-fleet-to-0-1-30.s.sol
+++ b/script/20260825-upgrade-fleet-to-0-1-30.s.sol
@@ -104,11 +104,15 @@ contract UpgradeFleetTo0_1_30 is Script {
     /// @notice Pre-flight the beacons and self-scope the bundle: one
     /// `upgradeTo` per gated beacon still serving 0.1.1. A beacon in
     /// neither state is unknown drift; both already at 0.1.30 refuses.
-    /// @param beacons The chain's in-use beacons (receipt, receipt vault,
-    /// wrapped token vault) — index order pinned by `LibProdBeacons*`.
     /// @return txs The self-scoped upgrade transactions.
-    function authorBundle(address[3] memory beacons) internal view returns (SafeTx[] memory txs) {
-        address[2] memory gated = [beacons[0], beacons[1]];
+    /// @dev The two gated beacons are resolved by role, not by position in
+    /// `prodBeaconsForChainId`, so that set can gain the orchestrator beacon
+    /// (#333) without this bundle silently re-pointing at a different one.
+    function authorBundle() internal view returns (SafeTx[] memory txs) {
+        address[2] memory gated = [
+            LibBeaconInvariants.receiptBeaconForChainId(block.chainid),
+            LibBeaconInvariants.receiptVaultBeaconForChainId(block.chainid)
+        ];
         address[2] memory pre = [LibProdDeployV4.STOX_RECEIPT_0_1_1, LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1];
         address[2] memory post = [LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30];
 
@@ -211,11 +215,12 @@ contract UpgradeFleetTo0_1_30 is Script {
 
         // The in-use beacons are deployed, OZ bytecode, Safe-owned.
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
-        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
+        address receiptBeacon = LibBeaconInvariants.receiptBeaconForChainId(block.chainid);
+        address receiptVaultBeacon = LibBeaconInvariants.receiptVaultBeaconForChainId(block.chainid);
 
         // --- Build the bundle ----------------------------------------------
 
-        SafeTx[] memory txs = authorBundle(beacons);
+        SafeTx[] memory txs = authorBundle();
 
         uint256 nonce = safe.nonce();
         bytes32 bundleSafeTxHash = LibSafeOps.computeMultiSendSafeTxHash(safe, txs, nonce);
@@ -232,8 +237,8 @@ contract UpgradeFleetTo0_1_30 is Script {
         // --- Post-state ---------------------------------------------------
 
         require(
-            IBeacon(beacons[0]).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
-                && IBeacon(beacons[1]).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+            IBeacon(receiptBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
+                && IBeacon(receiptVaultBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
             "UpgradeFleetTo0_1_30: beacons did not land on the 0.1.30 impls"
         );
         assertTokenStatePreserved(tokens, supplies, metaHashes);
@@ -261,16 +266,16 @@ contract UpgradeFleetTo0_1_30 is Script {
         // so the fork ends on 0.1.30.
         LibSafeOps.simulateNPlus1(
             safe,
-            beacons[0],
+            receiptBeacon,
             abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_1)),
             LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD
         );
         require(
-            IBeacon(beacons[0]).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_1,
+            IBeacon(receiptBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_1,
             "UpgradeFleetTo0_1_30: n+1 downgrade did not land"
         );
         LibSafeOps.simulateExternalCall(
-            safe, beacons[0], abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30))
+            safe, receiptBeacon, abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30))
         );
         console2.log("n+1 reversal check passed: the Safe can downgrade (and re-upgrade) under the live threshold");
     }
@@ -285,7 +290,7 @@ contract UpgradeFleetTo0_1_30 is Script {
         IGnosisSafe safe = IGnosisSafe(safeAddr);
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
 
-        SafeTx[] memory expected = authorBundle(LibBeaconInvariants.prodBeaconsForChainId(block.chainid));
+        SafeTx[] memory expected = authorBundle();
         LibSafeOps.assertParsedTxsMatch(expected, jsonPath);
 
         uint256 nonce = safe.nonce();

--- a/script/20260825-upgrade-fleet-to-0-1-30.s.sol
+++ b/script/20260825-upgrade-fleet-to-0-1-30.s.sol
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensions/IERC20Metadata.sol";
+
+import {IGnosisSafe} from "../src/interface/IGnosisSafe.sol";
+import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
+import {LibBeaconInvariants} from "../src/lib/LibBeaconInvariants.sol";
+import {LibTokenInvariants, TokenInstance} from "../src/lib/LibTokenInvariants.sol";
+import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
+
+/// @dev Unix timestamp (2026-10-01T00:00:00Z) by which the fleet upgrade
+/// must have executed on every chain. Shared by the migration-window
+/// invariants that accept either the 0.1.1 or 0.1.30 implementation until
+/// then; the orchestrator rollout shares the same date — this upgrade gates
+/// its cutover.
+uint256 constant FLEET_UPGRADE_DEADLINE = 1_790_812_800;
+
+/// @notice A 0.1.30 implementation this upgrade would repoint a beacon to
+/// has no runtime code (or the wrong codehash) on the active chain. Ship the
+/// audited closure via `manual-sol-artifacts-0-1-30.yaml` first.
+/// @param impl The pinned 0.1.30 implementation inspected.
+error UpgradeTargetNotDeployed(address impl);
+
+/// @notice A production beacon is neither in the pre-upgrade (0.1.1) nor the
+/// post-upgrade (0.1.30) implementation state — unknown drift; resolve
+/// manually rather than upgrading over it.
+/// @param beacon The beacon inspected.
+/// @param actualImpl The implementation it points at.
+error BeaconInUnknownState(address beacon, address actualImpl);
+
+/// @notice Both gated beacons already serve the 0.1.30 implementations —
+/// the fleet upgrade has executed on this chain and a re-dispatch has
+/// nothing to author.
+error FleetAlreadyUpgraded();
+
+/// @notice A production token's reported state changed across the simulated
+/// upgrade. The 0.1.30 receipt-vault impl (the H01 remediation) must leave
+/// every reported balance and supply exactly as it was.
+/// @param receiptVault The vault whose reads drifted.
+error UpgradeChangedTokenState(address receiptVault);
+
+/// @title UpgradeFleetTo0_1_30
+/// @notice **PENDING.** Authors the per-chain Safe Tx Builder bundle that
+/// upgrades the production token fleet to the audited 0.1.30
+/// implementations — one atomic MultiSend repointing the chain's IN-USE
+/// receipt beacon and receipt-vault beacon (`upgradeTo`) from the audited
+/// 0.1.1 impls to the audited 0.1.30 impls. Every production token is a
+/// proxy of these two beacons, so the whole fleet moves in one batch: this
+/// is the H01 remediation going live, and the state the orchestrator
+/// cutover (`20260825-cutover-orchestrator-roles`) hard-gates on.
+///
+/// The wrapped-token-vault beacon is deliberately NOT repointed: the 0.1.30
+/// WTV bytecode differs only by the optimizer change (no behavioural delta,
+/// no audit finding), and the coordinated-release note in `CHANGELOG.md`
+/// scopes the lockstep set to the receipt vault (the fix), the
+/// corporate-actions facet (baked into the new vault) and the receipt (the
+/// orchestrator's lockstep partner). Repointing WTV is a separate decision.
+///
+/// @dev Dispatch via `Actions → run-script` with
+/// `script = 20260825-upgrade-fleet-to-0-1-30` per chain; sign and execute
+/// the artifact in the Safe UI (the in-use beacons are owned by each
+/// chain's token-owner Safe). Dispatch the three chains in ONE operational
+/// window — cross-chain parity is red in between, by design.
+///
+/// Pre-flight: the 0.1.30 receipt, receipt-vault and corporate-actions
+/// facet must be live at their pins by codehash (the new vault's
+/// `fallback()` delegatecalls the new facet — a code-less facet silently
+/// no-ops); each gated beacon must be exactly in the 0.1.1 state (or
+/// already upgraded — self-scoped); the Safe must own both beacons. The
+/// simulation then proves, for EVERY production token on the chain, that
+/// `totalSupply` / `symbol` / `decimals` read identically across the
+/// upgrade — the H01 fix changes internal accounting, never reported state.
+///
+/// The post-execution pin PR flips `LibProdBeaconsBase` /
+/// `LibProdBeacons0_1_1`'s `implementations()` (and the fork asserts riding
+/// them) to the 0.1.30 pins and retires this script's fixtures.
+contract UpgradeFleetTo0_1_30 is Script {
+    /// @notice Signer-visible `meta.name` for the emitted bundle.
+    string internal constant BUNDLE_NAME = "ST0x fleet upgrade: receipt + receipt-vault beacons to audited 0.1.30";
+
+    /// @notice Chain-suffixed artifact path (three chains dispatch in one
+    /// window; a shared path would let bundles overwrite each other).
+    /// @return path The artifact path for the ACTIVE chain.
+    function artifactPath() internal view virtual returns (string memory path) {
+        path = string.concat("out/20260825-upgrade-fleet-to-0-1-30-", vm.toString(block.chainid), ".json");
+    }
+
+    /// @notice Assert one 0.1.30 upgrade target is live at its pin with the
+    /// audited codehash.
+    /// @param impl The pinned implementation address.
+    /// @param codehash The pinned 0.1.30 codehash.
+    function assertTargetDeployed(address impl, bytes32 codehash) internal view {
+        if (impl.code.length == 0 || impl.codehash != codehash) {
+            revert UpgradeTargetNotDeployed(impl);
+        }
+    }
+
+    /// @notice Pre-flight the beacons and self-scope the bundle: one
+    /// `upgradeTo` per gated beacon still serving 0.1.1. A beacon in
+    /// neither state is unknown drift; both already at 0.1.30 refuses.
+    /// @param beacons The chain's in-use beacons (receipt, receipt vault,
+    /// wrapped token vault) — index order pinned by `LibProdBeacons*`.
+    /// @return txs The self-scoped upgrade transactions.
+    function authorBundle(address[3] memory beacons) internal view returns (SafeTx[] memory txs) {
+        address[2] memory gated = [beacons[0], beacons[1]];
+        address[2] memory pre = [LibProdDeployV4.STOX_RECEIPT_0_1_1, LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1];
+        address[2] memory post = [LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30];
+
+        SafeTx[] memory candidates = new SafeTx[](2);
+        uint256 count = 0;
+        for (uint256 i = 0; i < gated.length; i++) {
+            address actual = IBeacon(gated[i]).implementation();
+            if (actual == post[i]) {
+                continue;
+            }
+            if (actual != pre[i]) {
+                revert BeaconInUnknownState(gated[i], actual);
+            }
+            candidates[count++] = SafeTx({
+                to: gated[i], value: 0, data: abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (post[i])), operation: 0
+            });
+        }
+        if (count == 0) {
+            revert FleetAlreadyUpgraded();
+        }
+        txs = new SafeTx[](count);
+        for (uint256 i = 0; i < count; i++) {
+            txs[i] = candidates[i];
+        }
+    }
+
+    /// @notice The active chain's production token table (empty tables are
+    /// valid — a chain carrying no tokens yet has nothing to snapshot).
+    /// @return tokens The chain's token instances.
+    function activeChainTokens() internal view returns (TokenInstance[] memory tokens) {
+        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensBase();
+        }
+        if (block.chainid == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensEthereum();
+        }
+        return LibTokenInvariants.productionTokensHyperEvm();
+    }
+
+    /// @notice Snapshot every production token's reported state (receipt
+    /// vault `totalSupply`, `symbol` hash, `decimals`) so the post-upgrade
+    /// reads can be proven identical.
+    /// @param tokens The chain's token instances.
+    /// @return supplies Each vault's `totalSupply`.
+    /// @return metaHashes keccak of each vault's `symbol` + `decimals`.
+    function snapshotTokenState(TokenInstance[] memory tokens)
+        internal
+        view
+        returns (uint256[] memory supplies, bytes32[] memory metaHashes)
+    {
+        supplies = new uint256[](tokens.length);
+        metaHashes = new bytes32[](tokens.length);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            IERC20Metadata vault = IERC20Metadata(tokens[i].receiptVault);
+            supplies[i] = vault.totalSupply();
+            metaHashes[i] = keccak256(abi.encode(vault.symbol(), vault.decimals()));
+        }
+    }
+
+    /// @notice Assert every token's reported state is unchanged against the
+    /// pre-upgrade snapshot — the H01 fix must be invisible in reads.
+    /// @param tokens The chain's token instances.
+    /// @param supplies The pre-upgrade `totalSupply` snapshot.
+    /// @param metaHashes The pre-upgrade metadata snapshot.
+    function assertTokenStatePreserved(
+        TokenInstance[] memory tokens,
+        uint256[] memory supplies,
+        bytes32[] memory metaHashes
+    ) internal view {
+        for (uint256 i = 0; i < tokens.length; i++) {
+            IERC20Metadata vault = IERC20Metadata(tokens[i].receiptVault);
+            if (
+                vault.totalSupply() != supplies[i]
+                    || keccak256(abi.encode(vault.symbol(), vault.decimals())) != metaHashes[i]
+            ) {
+                revert UpgradeChangedTokenState(tokens[i].receiptVault);
+            }
+        }
+    }
+
+    /// @notice Author the fleet-upgrade bundle for the active chain: see
+    /// the contract-level flow. Does not broadcast — execution happens via
+    /// the Safe UI using the emitted artifact.
+    function run() external {
+        // --- Pre-flight ---------------------------------------------------
+
+        address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
+        IGnosisSafe safe = IGnosisSafe(safeAddr);
+
+        // The audited 0.1.30 targets (and the facet the new vault
+        // delegatecalls) must be live at their pins by codehash.
+        assertTargetDeployed(LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30);
+        assertTargetDeployed(
+            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30, LibProdDeployV4.STOX_RECEIPT_VAULT_CODEHASH_0_1_30
+        );
+        assertTargetDeployed(
+            LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30,
+            LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_CODEHASH_0_1_30
+        );
+
+        // The in-use beacons are deployed, OZ bytecode, Safe-owned.
+        LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
+        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
+
+        // --- Build the bundle ----------------------------------------------
+
+        SafeTx[] memory txs = authorBundle(beacons);
+
+        uint256 nonce = safe.nonce();
+        bytes32 bundleSafeTxHash = LibSafeOps.computeMultiSendSafeTxHash(safe, txs, nonce);
+
+        // --- Simulate, proving token-state preservation --------------------
+
+        TokenInstance[] memory tokens = activeChainTokens();
+        (uint256[] memory supplies, bytes32[] memory metaHashes) = snapshotTokenState(tokens);
+
+        for (uint256 i = 0; i < txs.length; i++) {
+            LibSafeOps.simulateExternalCall(safe, txs[i].to, txs[i].data);
+        }
+
+        // --- Post-state ---------------------------------------------------
+
+        require(
+            IBeacon(beacons[0]).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
+                && IBeacon(beacons[1]).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+            "UpgradeFleetTo0_1_30: beacons did not land on the 0.1.30 impls"
+        );
+        assertTokenStatePreserved(tokens, supplies, metaHashes);
+        LibSafeInvariants.assertImmutableInvariants(safe);
+        LibSafeInvariants.assertThreshold(safe, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD);
+
+        // --- Artifact -----------------------------------------------------
+
+        string memory json = LibSafeOps.emitTxBuilderJson(safeAddr, block.chainid, BUNDLE_NAME, txs);
+        vm.writeFile(artifactPath(), json);
+
+        console2.log("==== TX BUILDER JSON BEGIN ====");
+        console2.log(json);
+        console2.log("==== TX BUILDER JSON END ====");
+        console2.log("Bundle MultiSend SafeTxHash:", vm.toString(bundleSafeTxHash));
+        console2.log("Nonce:", nonce);
+        console2.log("Bundle item count:", txs.length);
+        console2.log("Chain:", block.chainid);
+        console2.log("Tokens proven state-preserving across the upgrade:", tokens.length);
+
+        // --- n+1 reversal proof --------------------------------------------
+
+        // The upgrade is reversible while the Safe owns the beacons: prove a
+        // downgrade back to 0.1.1 clears the live threshold, then re-upgrade
+        // so the fork ends on 0.1.30.
+        LibSafeOps.simulateNPlus1(
+            safe,
+            beacons[0],
+            abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_1)),
+            LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD
+        );
+        require(
+            IBeacon(beacons[0]).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_1,
+            "UpgradeFleetTo0_1_30: n+1 downgrade did not land"
+        );
+        LibSafeOps.simulateExternalCall(
+            safe, beacons[0], abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30))
+        );
+        console2.log("n+1 reversal check passed: the Safe can downgrade (and re-upgrade) under the live threshold");
+    }
+
+    /// @notice Signer-side integrity check for a CI-authored upgrade
+    /// artifact, run LOCALLY against a live fork before signing. Deliberately
+    /// NOT in the run-script dispatcher: it takes a local path and runs on
+    /// the signer's machine.
+    /// @param jsonPath Filesystem path to the downloaded Tx Builder JSON.
+    function verify(string calldata jsonPath) external view {
+        address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
+        IGnosisSafe safe = IGnosisSafe(safeAddr);
+        LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
+
+        SafeTx[] memory expected = authorBundle(LibBeaconInvariants.prodBeaconsForChainId(block.chainid));
+        LibSafeOps.assertParsedTxsMatch(expected, jsonPath);
+
+        uint256 nonce = safe.nonce();
+        console2.log("Artifact verified against live state.");
+        console2.log(
+            "Bundle MultiSend SafeTxHash:", vm.toString(LibSafeOps.computeMultiSendSafeTxHash(safe, expected, nonce))
+        );
+        console2.log("Nonce:", nonce);
+    }
+}
+
+/// @dev Local mirror of OZ `UpgradeableBeacon.upgradeTo` — rain-vats ships
+/// no interface carrying it and OZ's contract is not an interface.
+interface IUpgradeableBeaconLike {
+    function upgradeTo(address newImplementation) external;
+}

--- a/script/20260825-upgrade-fleet-to-0-1-30.s.sol
+++ b/script/20260825-upgrade-fleet-to-0-1-30.s.sol
@@ -104,14 +104,12 @@ contract UpgradeFleetTo0_1_30 is Script {
     /// @notice Pre-flight the beacons and self-scope the bundle: one
     /// `upgradeTo` per gated beacon still serving 0.1.1. A beacon in
     /// neither state is unknown drift; both already at 0.1.30 refuses.
+    /// @param beacons The chain's in-use beacons (receipt, receipt vault,
+    /// wrapped token vault) — index order pinned by `LibProdBeacons*`.
     /// @return txs The self-scoped upgrade transactions.
-    /// @dev The two gated beacons are resolved by role, not by position in
-    /// `prodBeaconsForChainId`, so that set can gain the orchestrator beacon
-    /// (#333) without this bundle silently re-pointing at a different one.
-    function authorBundle() internal view returns (SafeTx[] memory txs) {
+    function authorBundle(address[3] memory beacons) internal view returns (SafeTx[] memory txs) {
         address[2] memory gated = [
-            LibBeaconInvariants.receiptBeaconForChainId(block.chainid),
-            LibBeaconInvariants.receiptVaultBeaconForChainId(block.chainid)
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX], beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]
         ];
         address[2] memory pre = [LibProdDeployV4.STOX_RECEIPT_0_1_1, LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1];
         address[2] memory post = [LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30];
@@ -215,12 +213,11 @@ contract UpgradeFleetTo0_1_30 is Script {
 
         // The in-use beacons are deployed, OZ bytecode, Safe-owned.
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
-        address receiptBeacon = LibBeaconInvariants.receiptBeaconForChainId(block.chainid);
-        address receiptVaultBeacon = LibBeaconInvariants.receiptVaultBeaconForChainId(block.chainid);
+        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
 
         // --- Build the bundle ----------------------------------------------
 
-        SafeTx[] memory txs = authorBundle();
+        SafeTx[] memory txs = authorBundle(beacons);
 
         uint256 nonce = safe.nonce();
         bytes32 bundleSafeTxHash = LibSafeOps.computeMultiSendSafeTxHash(safe, txs, nonce);
@@ -237,8 +234,10 @@ contract UpgradeFleetTo0_1_30 is Script {
         // --- Post-state ---------------------------------------------------
 
         require(
-            IBeacon(receiptBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
-                && IBeacon(receiptVaultBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
+                    == LibProdDeployV4.STOX_RECEIPT_0_1_30
+                && IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation()
+                    == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
             "UpgradeFleetTo0_1_30: beacons did not land on the 0.1.30 impls"
         );
         assertTokenStatePreserved(tokens, supplies, metaHashes);
@@ -266,16 +265,19 @@ contract UpgradeFleetTo0_1_30 is Script {
         // so the fork ends on 0.1.30.
         LibSafeOps.simulateNPlus1(
             safe,
-            receiptBeacon,
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
             abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_1)),
             LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD
         );
         require(
-            IBeacon(receiptBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_1,
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
+                == LibProdDeployV4.STOX_RECEIPT_0_1_1,
             "UpgradeFleetTo0_1_30: n+1 downgrade did not land"
         );
         LibSafeOps.simulateExternalCall(
-            safe, receiptBeacon, abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30))
+            safe,
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30))
         );
         console2.log("n+1 reversal check passed: the Safe can downgrade (and re-upgrade) under the live threshold");
     }
@@ -290,7 +292,7 @@ contract UpgradeFleetTo0_1_30 is Script {
         IGnosisSafe safe = IGnosisSafe(safeAddr);
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
 
-        SafeTx[] memory expected = authorBundle();
+        SafeTx[] memory expected = authorBundle(LibBeaconInvariants.prodBeaconsForChainId(block.chainid));
         LibSafeOps.assertParsedTxsMatch(expected, jsonPath);
 
         uint256 nonce = safe.nonce();

--- a/script/20260831-enable-orchestrator-roles.s.sol
+++ b/script/20260831-enable-orchestrator-roles.s.sol
@@ -138,17 +138,22 @@ contract EnableOrchestratorRoles is Script {
     /// orchestrator's own vault-logic lock reads its release set-deployer's
     /// beacons, not these (RAI-2125), so this pre-flight carries the rule.
     function assertFleetUpgraded() internal view {
-        // Index order pinned by LibProdBeacons*: receipt, receipt vault,
-        // wrapped token vault. The wrapped-token-vault beacon is not part of
-        // the orchestrator's surface and is not gated here.
+        // The wrapped-token-vault beacon is not part of the orchestrator's
+        // surface and is not gated here.
         address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
-        address receiptImpl = IBeacon(beacons[0]).implementation();
+        address receiptImpl = IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation();
         if (receiptImpl != LibProdDeployV4.STOX_RECEIPT_0_1_30) {
-            revert FleetNotUpgraded(beacons[0], LibProdDeployV4.STOX_RECEIPT_0_1_30, receiptImpl);
+            revert FleetNotUpgraded(
+                beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX], LibProdDeployV4.STOX_RECEIPT_0_1_30, receiptImpl
+            );
         }
-        address vaultImpl = IBeacon(beacons[1]).implementation();
+        address vaultImpl = IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation();
         if (vaultImpl != LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30) {
-            revert FleetNotUpgraded(beacons[1], LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30, vaultImpl);
+            revert FleetNotUpgraded(
+                beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
+                LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+                vaultImpl
+            );
         }
     }
 

--- a/src/lib/LibBeaconInvariants.sol
+++ b/src/lib/LibBeaconInvariants.sol
@@ -245,6 +245,32 @@ library LibBeaconInvariants {
         revert UnsupportedChainForProdBeacons(chainId);
     }
 
+    /// @notice Position of the receipt beacon in `prodBeaconsForChainId`.
+    uint256 internal constant RECEIPT_BEACON_INDEX = 0;
+
+    /// @notice Position of the receipt-vault beacon in
+    /// `prodBeaconsForChainId`.
+    uint256 internal constant RECEIPT_VAULT_BEACON_INDEX = 1;
+
+    /// @notice The receipt beacon on `chainId`, resolved by role.
+    /// @dev Consumers that want one specific beacon ask for it by name here
+    /// rather than indexing `prodBeaconsForChainId`. Only this library knows
+    /// the array's layout, so the set can gain a member — the orchestrator
+    /// beacon is a fourth, see #333 — without every caller having to agree
+    /// about positions. New members are APPENDED so these indices hold.
+    /// @param chainId The chain to resolve for.
+    /// @return The receipt beacon.
+    function receiptBeaconForChainId(uint256 chainId) internal view returns (address) {
+        return prodBeaconsForChainId(chainId)[RECEIPT_BEACON_INDEX];
+    }
+
+    /// @notice The receipt-vault beacon on `chainId`, resolved by role.
+    /// @param chainId The chain to resolve for.
+    /// @return The receipt-vault beacon.
+    function receiptVaultBeaconForChainId(uint256 chainId) internal view returns (address) {
+        return prodBeaconsForChainId(chainId)[RECEIPT_VAULT_BEACON_INDEX];
+    }
+
     /// @notice Assert the active chain's three IN-USE production beacons are
     /// deployed and owned by THAT chain's token-owner Safe. This is the
     /// ownership invariant that matters operationally: whoever owns an in-use

--- a/src/lib/LibBeaconInvariants.sol
+++ b/src/lib/LibBeaconInvariants.sol
@@ -220,6 +220,16 @@ library LibBeaconInvariants {
         }
     }
 
+    /// @notice Position of the receipt beacon in `prodBeaconsForChainId`.
+    uint256 internal constant RECEIPT_BEACON_INDEX = 0;
+
+    /// @notice Position of the receipt-vault beacon in `prodBeaconsForChainId`.
+    uint256 internal constant RECEIPT_VAULT_BEACON_INDEX = 1;
+
+    /// @notice Position of the wrapped-token-vault beacon in
+    /// `prodBeaconsForChainId`.
+    uint256 internal constant WRAPPED_TOKEN_VAULT_BEACON_INDEX = 2;
+
     /// @notice The three production beacons IN USE on the active chain, in a
     /// fixed order (receipt, receipt vault, wrapped token vault). Beacon
     /// addresses are per-chain deploy artifacts that never change once a
@@ -243,32 +253,6 @@ library LibBeaconInvariants {
             return LibProdBeacons0_1_1.beacons();
         }
         revert UnsupportedChainForProdBeacons(chainId);
-    }
-
-    /// @notice Position of the receipt beacon in `prodBeaconsForChainId`.
-    uint256 internal constant RECEIPT_BEACON_INDEX = 0;
-
-    /// @notice Position of the receipt-vault beacon in
-    /// `prodBeaconsForChainId`.
-    uint256 internal constant RECEIPT_VAULT_BEACON_INDEX = 1;
-
-    /// @notice The receipt beacon on `chainId`, resolved by role.
-    /// @dev Consumers that want one specific beacon ask for it by name here
-    /// rather than indexing `prodBeaconsForChainId`. Only this library knows
-    /// the array's layout, so the set can gain a member — the orchestrator
-    /// beacon is a fourth, see #333 — without every caller having to agree
-    /// about positions. New members are APPENDED so these indices hold.
-    /// @param chainId The chain to resolve for.
-    /// @return The receipt beacon.
-    function receiptBeaconForChainId(uint256 chainId) internal view returns (address) {
-        return prodBeaconsForChainId(chainId)[RECEIPT_BEACON_INDEX];
-    }
-
-    /// @notice The receipt-vault beacon on `chainId`, resolved by role.
-    /// @param chainId The chain to resolve for.
-    /// @return The receipt-vault beacon.
-    function receiptVaultBeaconForChainId(uint256 chainId) internal view returns (address) {
-        return prodBeaconsForChainId(chainId)[RECEIPT_VAULT_BEACON_INDEX];
     }
 
     /// @notice Assert the active chain's three IN-USE production beacons are

--- a/src/lib/LibClosureInvariants.sol
+++ b/src/lib/LibClosureInvariants.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity ^0.8.25;
+
+/// @notice A contract of the audited 0.1.30 closure has no runtime code at
+/// its pinned address on the active chain. Ship the closure first via
+/// `manual-sol-artifacts-0-1-30.yaml`.
+/// @param pinned The pinned closure address that is missing.
+error ClosureNotDeployed(address pinned);
+
+/// @notice A closure contract's runtime codehash does not match its 0.1.30
+/// pin — something other than the audited bytecode sits at the pinned
+/// address.
+/// @param pinned The pinned closure address inspected.
+/// @param expected The pinned 0.1.30 codehash.
+/// @param actual The codehash read from the chain.
+error ClosureCodehashMismatch(address pinned, bytes32 expected, bytes32 actual);
+
+/// @title LibClosureInvariants
+/// @notice The "audited contract is live at its pin" gate every script that
+/// depends on the 0.1.30 closure runs in pre-flight.
+library LibClosureInvariants {
+    /// @notice Assert one closure contract is live at its pin with the
+    /// audited codehash.
+    /// @param pinned The pinned closure address.
+    /// @param codehash The pinned codehash.
+    function assertClosureContract(address pinned, bytes32 codehash) internal view {
+        if (pinned.code.length == 0) {
+            revert ClosureNotDeployed(pinned);
+        }
+        if (pinned.codehash != codehash) {
+            revert ClosureCodehashMismatch(pinned, codehash, pinned.codehash);
+        }
+    }
+}

--- a/test/script/20260818-deploy-orchestrator.prod.t.sol
+++ b/test/script/20260818-deploy-orchestrator.prod.t.sol
@@ -6,11 +6,8 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {console2} from "forge-std-1.16.1/src/console2.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 
-import {
-    DeployOrchestrator,
-    ClosureNotDeployed,
-    OrchestratorAlreadyDeployed
-} from "../../script/20260818-deploy-orchestrator.s.sol";
+import {DeployOrchestrator, OrchestratorAlreadyDeployed} from "../../script/20260818-deploy-orchestrator.s.sol";
+import {ClosureNotDeployed} from "../../src/lib/LibClosureInvariants.sol";
 import {LibOrchestratorInvariants} from "../../src/lib/LibOrchestratorInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";

--- a/test/script/20260818-deploy-orchestrator.t.sol
+++ b/test/script/20260818-deploy-orchestrator.t.sol
@@ -8,14 +8,13 @@ import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
 import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
 
 import {
-    ClosureNotDeployed,
-    ClosureCodehashMismatch,
     OrchestratorAlreadyDeployed,
     UnexpectedSetDeployerNonce,
     InstanceAddressMismatch,
     DeployKeyHoldsAdmin
 } from "../../script/20260818-deploy-orchestrator.s.sol";
 import {DeployOrchestratorHarness} from "./DeployOrchestratorHarness.sol";
+import {ClosureNotDeployed, ClosureCodehashMismatch} from "../../src/lib/LibClosureInvariants.sol";
 import {MigrationStateDrift} from "../../src/lib/LibMigrationInvariant.sol";
 import {
     LibOrchestratorInvariants,

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
+
+import {
+    UpgradeFleetTo0_1_30,
+    UpgradeTargetNotDeployed,
+    FleetAlreadyUpgraded,
+    FLEET_UPGRADE_DEADLINE
+} from "../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
+import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
+import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
+import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
+
+/// @notice The fleet-upgrade deadline passed with this chain still pending.
+/// Run the outstanding dispatches, extend the deadline, or delete the
+/// invariant.
+/// @param label The chain still pending.
+error FleetUpgradeOverdue(string label);
+
+/// @title UpgradeFleetProdTest
+/// @notice PROD coverage for the fleet upgrade: what production IS on each
+/// chain, read from a real fork with no mocks, walking the rollout states:
+///
+/// 1. **Targets pending** (every chain today): the 0.1.30 impls are not
+///    deployed — `run()` refuses `UpgradeTargetNotDeployed`, pinning that
+///    the closure suites come first.
+/// 2. **Ready** (targets live, beacons on 0.1.1): drives `run()` end to
+///    end on the fork — bundle authored and simulated, both beacons land
+///    on 0.1.30, EVERY production token's reported state proven unchanged,
+///    n+1 downgrade proven.
+/// 3. **Executed**: both beacons serve 0.1.30 (asserted directly) and a
+///    re-dispatch refuses (`FleetAlreadyUpgraded`).
+///
+/// States 1–2 stop passing at `FLEET_UPGRADE_DEADLINE`; state 3 is steady
+/// and never expires (until the post-execution pin PR retires this file).
+contract UpgradeFleetProdTest is Test {
+    /// @notice Walk the active fork's upgrade state (see the contract
+    /// NatSpec) and assert it.
+    /// @param label Human chain name, surfaced in logs and messages.
+    function assertFleetRollout(string memory label) internal {
+        UpgradeFleetTo0_1_30 script = new UpgradeFleetTo0_1_30();
+        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
+
+        bool targetsLive = LibProdDeployV4.STOX_RECEIPT_0_1_30.code.length != 0
+            && LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30.code.length != 0
+            && LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30.code.length != 0;
+        if (!targetsLive) {
+            if (block.timestamp >= FLEET_UPGRADE_DEADLINE) {
+                revert FleetUpgradeOverdue(label);
+            }
+            console2.log(string.concat("PENDING [", label, "]: 0.1.30 impls not deployed - fleet upgrade blocked"));
+            console2.log("-> dispatch the manual-sol-artifacts-0-1-30 suites first");
+            vm.expectRevert(
+                abi.encodeWithSelector(UpgradeTargetNotDeployed.selector, LibProdDeployV4.STOX_RECEIPT_0_1_30)
+            );
+            script.run();
+            return;
+        }
+
+        bool upgraded = IBeacon(beacons[0]).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
+            && IBeacon(beacons[1]).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30;
+        if (!upgraded) {
+            if (block.timestamp >= FLEET_UPGRADE_DEADLINE) {
+                revert FleetUpgradeOverdue(label);
+            }
+            console2.log(string.concat("PENDING [", label, "]: ready - driving the authoring end to end"));
+            // Drives the full authoring: simulation flips both beacons on
+            // the fork, every token's reported state is proven unchanged,
+            // and the n+1 downgrade path is proven.
+            script.run();
+            return;
+        }
+
+        // Executed steady state.
+        assertEq(
+            IBeacon(beacons[0]).implementation(),
+            LibProdDeployV4.STOX_RECEIPT_0_1_30,
+            string.concat(label, ": receipt beacon not on 0.1.30")
+        );
+        assertEq(
+            IBeacon(beacons[1]).implementation(),
+            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+            string.concat(label, ": receipt-vault beacon not on 0.1.30")
+        );
+        vm.expectRevert(FleetAlreadyUpgraded.selector);
+        script.run();
+    }
+
+    function testFleetRolloutBase() external {
+        vm.createSelectFork(LibRainDeploy.BASE);
+        assertFleetRollout("base");
+    }
+
+    function testFleetRolloutEthereum() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
+        assertFleetRollout("ethereum");
+    }
+
+    function testFleetRolloutHyperEvm() external {
+        vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
+        assertFleetRollout("hyperevm");
+    }
+}

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
@@ -11,6 +11,7 @@ import {FleetAlreadyUpgraded, FLEET_UPGRADE_DEADLINE} from "../../script/2026082
 import {UpgradeFleetHarness} from "./UpgradeFleetHarness.sol";
 import {LibSafeOps, SafeTx, TxBuilderArtifactMismatch} from "../../src/lib/LibSafeOps.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {ClosureCodehashMismatch} from "../../src/lib/LibClosureInvariants.sol";
 import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
@@ -29,7 +30,8 @@ error FleetUpgradeOverdue(string label);
 ///    end on the fork — bundle authored and simulated, both beacons land
 ///    on 0.1.30, EVERY production token's reported state proven unchanged,
 ///    n+1 downgrade proven; the signer-side `verify` then round-trips the
-///    written artifact against the pre-run state and refuses a tampered copy.
+///    written artifact against the pre-run state, refusing a tampered copy
+///    and a wrong build at a target pin.
 /// 2. **Executed**: both beacons serve 0.1.30 (asserted directly) and a
 ///    re-dispatch refuses (`FleetAlreadyUpgraded`).
 ///
@@ -74,6 +76,18 @@ contract UpgradeFleetProdTest is Test {
             );
             vm.expectRevert(abi.encodeWithSelector(TxBuilderArtifactMismatch.selector, "firstTarget"));
             script.verify(tampered);
+
+            // The signer-side check gates on the audited targets too.
+            vm.etch(LibProdDeployV4.STOX_RECEIPT_0_1_30, hex"fe");
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    ClosureCodehashMismatch.selector,
+                    LibProdDeployV4.STOX_RECEIPT_0_1_30,
+                    LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30,
+                    keccak256(hex"fe")
+                )
+            );
+            script.verify(path);
             return;
         }
 

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
@@ -45,7 +45,8 @@ contract UpgradeFleetProdTest is Test {
     /// @param label Human chain name, surfaced in logs and messages.
     function assertFleetRollout(string memory label) internal {
         UpgradeFleetTo0_1_30 script = new UpgradeFleetTo0_1_30();
-        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
+        address receiptBeacon = LibBeaconInvariants.receiptBeaconForChainId(block.chainid);
+        address receiptVaultBeacon = LibBeaconInvariants.receiptVaultBeaconForChainId(block.chainid);
 
         bool targetsLive = LibProdDeployV4.STOX_RECEIPT_0_1_30.code.length != 0
             && LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30.code.length != 0
@@ -63,8 +64,8 @@ contract UpgradeFleetProdTest is Test {
             return;
         }
 
-        bool upgraded = IBeacon(beacons[0]).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
-            && IBeacon(beacons[1]).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30;
+        bool upgraded = IBeacon(receiptBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
+            && IBeacon(receiptVaultBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30;
         if (!upgraded) {
             if (block.timestamp >= FLEET_UPGRADE_DEADLINE) {
                 revert FleetUpgradeOverdue(label);
@@ -79,12 +80,12 @@ contract UpgradeFleetProdTest is Test {
 
         // Executed steady state.
         assertEq(
-            IBeacon(beacons[0]).implementation(),
+            IBeacon(receiptBeacon).implementation(),
             LibProdDeployV4.STOX_RECEIPT_0_1_30,
             string.concat(label, ": receipt beacon not on 0.1.30")
         );
         assertEq(
-            IBeacon(beacons[1]).implementation(),
+            IBeacon(receiptVaultBeacon).implementation(),
             LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
             string.concat(label, ": receipt-vault beacon not on 0.1.30")
         );

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
@@ -45,8 +45,7 @@ contract UpgradeFleetProdTest is Test {
     /// @param label Human chain name, surfaced in logs and messages.
     function assertFleetRollout(string memory label) internal {
         UpgradeFleetTo0_1_30 script = new UpgradeFleetTo0_1_30();
-        address receiptBeacon = LibBeaconInvariants.receiptBeaconForChainId(block.chainid);
-        address receiptVaultBeacon = LibBeaconInvariants.receiptVaultBeaconForChainId(block.chainid);
+        address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
 
         bool targetsLive = LibProdDeployV4.STOX_RECEIPT_0_1_30.code.length != 0
             && LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30.code.length != 0
@@ -64,8 +63,10 @@ contract UpgradeFleetProdTest is Test {
             return;
         }
 
-        bool upgraded = IBeacon(receiptBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
-            && IBeacon(receiptVaultBeacon).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30;
+        bool upgraded = IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
+                == LibProdDeployV4.STOX_RECEIPT_0_1_30
+            && IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation()
+                == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30;
         if (!upgraded) {
             if (block.timestamp >= FLEET_UPGRADE_DEADLINE) {
                 revert FleetUpgradeOverdue(label);
@@ -80,12 +81,12 @@ contract UpgradeFleetProdTest is Test {
 
         // Executed steady state.
         assertEq(
-            IBeacon(receiptBeacon).implementation(),
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation(),
             LibProdDeployV4.STOX_RECEIPT_0_1_30,
             string.concat(label, ": receipt beacon not on 0.1.30")
         );
         assertEq(
-            IBeacon(receiptVaultBeacon).implementation(),
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation(),
             LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
             string.concat(label, ": receipt-vault beacon not on 0.1.30")
         );

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.prod.t.sol
@@ -7,12 +7,10 @@ import {console2} from "forge-std-1.16.1/src/console2.sol";
 import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 
-import {
-    UpgradeFleetTo0_1_30,
-    UpgradeTargetNotDeployed,
-    FleetAlreadyUpgraded,
-    FLEET_UPGRADE_DEADLINE
-} from "../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
+import {FleetAlreadyUpgraded, FLEET_UPGRADE_DEADLINE} from "../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
+import {UpgradeFleetHarness} from "./UpgradeFleetHarness.sol";
+import {LibSafeOps, SafeTx, TxBuilderArtifactMismatch} from "../../src/lib/LibSafeOps.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
 import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
@@ -27,41 +25,23 @@ error FleetUpgradeOverdue(string label);
 /// @notice PROD coverage for the fleet upgrade: what production IS on each
 /// chain, read from a real fork with no mocks, walking the rollout states:
 ///
-/// 1. **Targets pending** (every chain today): the 0.1.30 impls are not
-///    deployed — `run()` refuses `UpgradeTargetNotDeployed`, pinning that
-///    the closure suites come first.
-/// 2. **Ready** (targets live, beacons on 0.1.1): drives `run()` end to
+/// 1. **Ready** (0.1.30 impls live, beacons on 0.1.1): drives `run()` end to
 ///    end on the fork — bundle authored and simulated, both beacons land
 ///    on 0.1.30, EVERY production token's reported state proven unchanged,
-///    n+1 downgrade proven.
-/// 3. **Executed**: both beacons serve 0.1.30 (asserted directly) and a
+///    n+1 downgrade proven; the signer-side `verify` then round-trips the
+///    written artifact against the pre-run state and refuses a tampered copy.
+/// 2. **Executed**: both beacons serve 0.1.30 (asserted directly) and a
 ///    re-dispatch refuses (`FleetAlreadyUpgraded`).
 ///
-/// States 1–2 stop passing at `FLEET_UPGRADE_DEADLINE`; state 3 is steady
+/// State 1 stops passing at `FLEET_UPGRADE_DEADLINE`; state 2 is steady
 /// and never expires (until the post-execution pin PR retires this file).
 contract UpgradeFleetProdTest is Test {
     /// @notice Walk the active fork's upgrade state (see the contract
     /// NatSpec) and assert it.
     /// @param label Human chain name, surfaced in logs and messages.
     function assertFleetRollout(string memory label) internal {
-        UpgradeFleetTo0_1_30 script = new UpgradeFleetTo0_1_30();
+        UpgradeFleetHarness script = new UpgradeFleetHarness();
         address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
-
-        bool targetsLive = LibProdDeployV4.STOX_RECEIPT_0_1_30.code.length != 0
-            && LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30.code.length != 0
-            && LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30.code.length != 0;
-        if (!targetsLive) {
-            if (block.timestamp >= FLEET_UPGRADE_DEADLINE) {
-                revert FleetUpgradeOverdue(label);
-            }
-            console2.log(string.concat("PENDING [", label, "]: 0.1.30 impls not deployed - fleet upgrade blocked"));
-            console2.log("-> dispatch the manual-sol-artifacts-0-1-30 suites first");
-            vm.expectRevert(
-                abi.encodeWithSelector(UpgradeTargetNotDeployed.selector, LibProdDeployV4.STOX_RECEIPT_0_1_30)
-            );
-            script.run();
-            return;
-        }
 
         bool upgraded = IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
                 == LibProdDeployV4.STOX_RECEIPT_0_1_30
@@ -74,8 +54,26 @@ contract UpgradeFleetProdTest is Test {
             console2.log(string.concat("PENDING [", label, "]: ready - driving the authoring end to end"));
             // Drives the full authoring: simulation flips both beacons on
             // the fork, every token's reported state is proven unchanged,
-            // and the n+1 downgrade path is proven.
+            // and the n+1 downgrade path is proven. The artifact outlives the
+            // state revert, so verify() reads it against the state a signer
+            // would see.
+            uint256 preRun = vm.snapshotState();
             script.run();
+            vm.revertToState(preRun);
+            string memory path = script.callArtifactPath();
+            script.verify(path);
+
+            (,, SafeTx[] memory txs) = LibSafeOps.parseTxBuilderJson(path);
+            txs[0].to = beacons[LibBeaconInvariants.WRAPPED_TOKEN_VAULT_BEACON_INDEX];
+            string memory tampered = string.concat(path, ".tampered.json");
+            vm.writeFile(
+                tampered,
+                LibSafeOps.emitTxBuilderJson(
+                    LibSafeInvariants.safeForChainId(block.chainid), block.chainid, "tampered", txs
+                )
+            );
+            vm.expectRevert(abi.encodeWithSelector(TxBuilderArtifactMismatch.selector, "firstTarget"));
+            script.verify(tampered);
             return;
         }
 

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
@@ -24,12 +24,15 @@ import {SafeTx} from "../../src/lib/LibSafeOps.sol";
 /// The live-fork walk is in `20260825-upgrade-fleet-to-0-1-30.prod.t.sol`.
 contract UpgradeFleetTest is Test {
     UpgradeFleetHarness internal harness;
-    address[3] internal beacons;
+    address[2] internal beacons;
 
     function setUp() external {
         vm.chainId(LibSafeInvariants.BASE_CHAIN_ID);
         harness = new UpgradeFleetHarness();
-        beacons = LibBeaconInvariants.prodBeaconsForChainId(LibSafeInvariants.BASE_CHAIN_ID);
+        beacons = [
+            LibBeaconInvariants.receiptBeaconForChainId(LibSafeInvariants.BASE_CHAIN_ID),
+            LibBeaconInvariants.receiptVaultBeaconForChainId(LibSafeInvariants.BASE_CHAIN_ID)
+        ];
     }
 
     /// @notice Mock both gated beacons in the pre-upgrade (0.1.1) state.
@@ -63,7 +66,7 @@ contract UpgradeFleetTest is Test {
     /// The pre-upgrade state authors both `upgradeTo` transactions.
     function testAuthoringProducesBothUpgrades() external {
         mockPreUpgradeBeacons();
-        SafeTx[] memory txs = harness.callAuthorBundle(beacons);
+        SafeTx[] memory txs = harness.callAuthorBundle();
         assertEq(txs.length, 2);
         assertEq(txs[0].to, beacons[0]);
         assertEq(txs[0].data, abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30)));
@@ -79,7 +82,7 @@ contract UpgradeFleetTest is Test {
         vm.mockCall(
             beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
         );
-        SafeTx[] memory txs = harness.callAuthorBundle(beacons);
+        SafeTx[] memory txs = harness.callAuthorBundle();
         assertEq(txs.length, 1);
         assertEq(txs[0].to, beacons[1]);
     }
@@ -89,7 +92,7 @@ contract UpgradeFleetTest is Test {
         mockPreUpgradeBeacons();
         vm.mockCall(beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(address(0xBAD)));
         vm.expectRevert(abi.encodeWithSelector(BeaconInUnknownState.selector, beacons[0], address(0xBAD)));
-        harness.callAuthorBundle(beacons);
+        harness.callAuthorBundle();
     }
 
     /// A fully-upgraded chain refuses to author anything.
@@ -104,6 +107,6 @@ contract UpgradeFleetTest is Test {
             abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30)
         );
         vm.expectRevert(FleetAlreadyUpgraded.selector);
-        harness.callAuthorBundle(beacons);
+        harness.callAuthorBundle();
     }
 }

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
@@ -4,23 +4,26 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {IERC20} from "@openzeppelin-contracts-5.6.1/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin-contracts-5.6.1/token/ERC20/extensions/IERC20Metadata.sol";
+import {IReceiptV3} from "rain-vats-0.1.6/src/interface/IReceiptV3.sol";
 
 import {
-    UpgradeTargetNotDeployed,
     BeaconInUnknownState,
     FleetAlreadyUpgraded,
-    IUpgradeableBeaconLike
+    UpgradeChangedTokenState
 } from "../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
 import {UpgradeFleetHarness} from "./UpgradeFleetHarness.sol";
 import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
-import {SafeTx} from "../../src/lib/LibSafeOps.sol";
+import {SafeTx, IUpgradeableBeacon} from "../../src/lib/LibSafeOps.sol";
+import {TokenInstance} from "../../src/lib/LibTokenInvariants.sol";
 
 /// @title UpgradeFleetTest
 /// @notice Guard coverage for `20260825-upgrade-fleet-to-0-1-30` without a
-/// fork: the target-deployed gate, the unknown-drift refusal, the
-/// self-scoping, the already-upgraded refusal, and the exact bundle shape.
+/// fork: the unknown-drift refusal, the self-scoping, the already-upgraded
+/// refusal, the exact bundle shape, and the token-state preservation check.
 /// The live-fork walk is in `20260825-upgrade-fleet-to-0-1-30.prod.t.sol`.
 contract UpgradeFleetTest is Test {
     UpgradeFleetHarness internal harness;
@@ -48,33 +51,15 @@ contract UpgradeFleetTest is Test {
         );
     }
 
-    /// The target gate refuses a codeless (or wrong-codehash) 0.1.30 impl.
-    function testTargetGateRefusesUndeployedImpl() external {
-        vm.expectRevert(abi.encodeWithSelector(UpgradeTargetNotDeployed.selector, LibProdDeployV4.STOX_RECEIPT_0_1_30));
-        harness.callAssertTargetDeployed(
-            LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30
-        );
-    }
-
-    /// The target gate accepts the frozen 0.1.30 runtime at the pin.
-    function testTargetGateAcceptsTheFrozenRuntime() external {
-        vm.etch(LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_RUNTIME_CODE_0_1_30);
-        harness.callAssertTargetDeployed(
-            LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30
-        );
-    }
-
     /// The pre-upgrade state authors both `upgradeTo` transactions.
     function testAuthoringProducesBothUpgrades() external {
         mockPreUpgradeBeacons();
         SafeTx[] memory txs = harness.callAuthorBundle(beacons);
         assertEq(txs.length, 2);
         assertEq(txs[0].to, beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]);
-        assertEq(txs[0].data, abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30)));
+        assertEq(txs[0].data, abi.encodeCall(IUpgradeableBeacon.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30)));
         assertEq(txs[1].to, beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]);
-        assertEq(
-            txs[1].data, abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30))
-        );
+        assertEq(txs[1].data, abi.encodeCall(IUpgradeableBeacon.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30)));
     }
 
     /// A half-executed upgrade self-scopes to the remaining beacon.
@@ -121,5 +106,47 @@ contract UpgradeFleetTest is Test {
         );
         vm.expectRevert(FleetAlreadyUpgraded.selector);
         harness.callAuthorBundle(beacons);
+    }
+
+    address internal constant VAULT = address(0x1111);
+    address internal constant RECEIPT = address(0x2222);
+    address internal constant MANAGER = address(0x3333);
+
+    /// @notice Mock one production token's reads.
+    function mockToken(uint256 supply, address manager) internal returns (TokenInstance[] memory tokens) {
+        vm.etch(VAULT, hex"fe");
+        vm.etch(RECEIPT, hex"fe");
+        vm.mockCall(VAULT, abi.encodeCall(IERC20.totalSupply, ()), abi.encode(supply));
+        vm.mockCall(VAULT, abi.encodeCall(IERC20Metadata.symbol, ()), abi.encode("stTEST"));
+        vm.mockCall(VAULT, abi.encodeCall(IERC20Metadata.decimals, ()), abi.encode(uint8(18)));
+        vm.mockCall(RECEIPT, abi.encodeCall(IReceiptV3.manager, ()), abi.encode(manager));
+        tokens = new TokenInstance[](1);
+        tokens[0] =
+            TokenInstance({underlying: "TEST", receipt: RECEIPT, receiptVault: VAULT, wrappedTokenVault: address(0)});
+    }
+
+    /// Identical reads across the upgrade pass the preservation check.
+    function testTokenStatePreservedAcceptsIdenticalReads() external {
+        TokenInstance[] memory tokens = mockToken(1e18, MANAGER);
+        (uint256[] memory supplies, bytes32[] memory metaHashes) = harness.callSnapshotTokenState(tokens);
+        harness.callAssertTokenStatePreserved(tokens, supplies, metaHashes);
+    }
+
+    /// A vault whose `totalSupply` moved across the upgrade is refused.
+    function testTokenStatePreservedRefusesASupplyChange() external {
+        TokenInstance[] memory tokens = mockToken(1e18, MANAGER);
+        (uint256[] memory supplies, bytes32[] memory metaHashes) = harness.callSnapshotTokenState(tokens);
+        vm.mockCall(VAULT, abi.encodeCall(IERC20.totalSupply, ()), abi.encode(1e18 + 1));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeChangedTokenState.selector, VAULT));
+        harness.callAssertTokenStatePreserved(tokens, supplies, metaHashes);
+    }
+
+    /// A receipt whose `manager` moved across the upgrade is refused.
+    function testTokenStatePreservedRefusesAManagerChange() external {
+        TokenInstance[] memory tokens = mockToken(1e18, MANAGER);
+        (uint256[] memory supplies, bytes32[] memory metaHashes) = harness.callSnapshotTokenState(tokens);
+        vm.mockCall(RECEIPT, abi.encodeCall(IReceiptV3.manager, ()), abi.encode(address(0x4444)));
+        vm.expectRevert(abi.encodeWithSelector(UpgradeChangedTokenState.selector, VAULT));
+        harness.callAssertTokenStatePreserved(tokens, supplies, metaHashes);
     }
 }

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
@@ -24,26 +24,27 @@ import {SafeTx} from "../../src/lib/LibSafeOps.sol";
 /// The live-fork walk is in `20260825-upgrade-fleet-to-0-1-30.prod.t.sol`.
 contract UpgradeFleetTest is Test {
     UpgradeFleetHarness internal harness;
-    address[2] internal beacons;
+    address[3] internal beacons;
 
     function setUp() external {
         vm.chainId(LibSafeInvariants.BASE_CHAIN_ID);
         harness = new UpgradeFleetHarness();
-        beacons = [
-            LibBeaconInvariants.receiptBeaconForChainId(LibSafeInvariants.BASE_CHAIN_ID),
-            LibBeaconInvariants.receiptVaultBeaconForChainId(LibSafeInvariants.BASE_CHAIN_ID)
-        ];
+        beacons = LibBeaconInvariants.prodBeaconsForChainId(LibSafeInvariants.BASE_CHAIN_ID);
     }
 
     /// @notice Mock both gated beacons in the pre-upgrade (0.1.1) state.
     function mockPreUpgradeBeacons() internal {
-        vm.etch(beacons[0], hex"fe");
-        vm.etch(beacons[1], hex"fe");
+        vm.etch(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX], hex"fe");
+        vm.etch(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX], hex"fe");
         vm.mockCall(
-            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_1)
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_1)
         );
         vm.mockCall(
-            beacons[1], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1)
+            beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1)
         );
     }
 
@@ -66,11 +67,11 @@ contract UpgradeFleetTest is Test {
     /// The pre-upgrade state authors both `upgradeTo` transactions.
     function testAuthoringProducesBothUpgrades() external {
         mockPreUpgradeBeacons();
-        SafeTx[] memory txs = harness.callAuthorBundle();
+        SafeTx[] memory txs = harness.callAuthorBundle(beacons);
         assertEq(txs.length, 2);
-        assertEq(txs[0].to, beacons[0]);
+        assertEq(txs[0].to, beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]);
         assertEq(txs[0].data, abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30)));
-        assertEq(txs[1].to, beacons[1]);
+        assertEq(txs[1].to, beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]);
         assertEq(
             txs[1].data, abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30))
         );
@@ -80,33 +81,45 @@ contract UpgradeFleetTest is Test {
     function testAuthoringSelfScopesAPartialUpgrade() external {
         mockPreUpgradeBeacons();
         vm.mockCall(
-            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
         );
-        SafeTx[] memory txs = harness.callAuthorBundle();
+        SafeTx[] memory txs = harness.callAuthorBundle(beacons);
         assertEq(txs.length, 1);
-        assertEq(txs[0].to, beacons[1]);
+        assertEq(txs[0].to, beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]);
     }
 
     /// A beacon in neither the 0.1.1 nor 0.1.30 state is unknown drift.
     function testAuthoringRefusesUnknownDrift() external {
         mockPreUpgradeBeacons();
-        vm.mockCall(beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(address(0xBAD)));
-        vm.expectRevert(abi.encodeWithSelector(BeaconInUnknownState.selector, beacons[0], address(0xBAD)));
-        harness.callAuthorBundle();
+        vm.mockCall(
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(address(0xBAD))
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BeaconInUnknownState.selector, beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX], address(0xBAD)
+            )
+        );
+        harness.callAuthorBundle(beacons);
     }
 
     /// A fully-upgraded chain refuses to author anything.
     function testAuthoringRefusesWhenAlreadyUpgraded() external {
         mockPreUpgradeBeacons();
         vm.mockCall(
-            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
         );
         vm.mockCall(
-            beacons[1],
+            beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
             abi.encodeCall(IBeacon.implementation, ()),
             abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30)
         );
         vm.expectRevert(FleetAlreadyUpgraded.selector);
-        harness.callAuthorBundle();
+        harness.callAuthorBundle(beacons);
     }
 }

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+
+import {
+    UpgradeTargetNotDeployed,
+    BeaconInUnknownState,
+    FleetAlreadyUpgraded,
+    IUpgradeableBeaconLike
+} from "../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
+import {UpgradeFleetHarness} from "./UpgradeFleetHarness.sol";
+import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
+import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {SafeTx} from "../../src/lib/LibSafeOps.sol";
+
+/// @title UpgradeFleetTest
+/// @notice Guard coverage for `20260825-upgrade-fleet-to-0-1-30` without a
+/// fork: the target-deployed gate, the unknown-drift refusal, the
+/// self-scoping, the already-upgraded refusal, and the exact bundle shape.
+/// The live-fork walk is in `20260825-upgrade-fleet-to-0-1-30.prod.t.sol`.
+contract UpgradeFleetTest is Test {
+    UpgradeFleetHarness internal harness;
+    address[3] internal beacons;
+
+    function setUp() external {
+        vm.chainId(LibSafeInvariants.BASE_CHAIN_ID);
+        harness = new UpgradeFleetHarness();
+        beacons = LibBeaconInvariants.prodBeaconsForChainId(LibSafeInvariants.BASE_CHAIN_ID);
+    }
+
+    /// @notice Mock both gated beacons in the pre-upgrade (0.1.1) state.
+    function mockPreUpgradeBeacons() internal {
+        vm.etch(beacons[0], hex"fe");
+        vm.etch(beacons[1], hex"fe");
+        vm.mockCall(
+            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_1)
+        );
+        vm.mockCall(
+            beacons[1], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1)
+        );
+    }
+
+    /// The target gate refuses a codeless (or wrong-codehash) 0.1.30 impl.
+    function testTargetGateRefusesUndeployedImpl() external {
+        vm.expectRevert(abi.encodeWithSelector(UpgradeTargetNotDeployed.selector, LibProdDeployV4.STOX_RECEIPT_0_1_30));
+        harness.callAssertTargetDeployed(
+            LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30
+        );
+    }
+
+    /// The target gate accepts the frozen 0.1.30 runtime at the pin.
+    function testTargetGateAcceptsTheFrozenRuntime() external {
+        vm.etch(LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_RUNTIME_CODE_0_1_30);
+        harness.callAssertTargetDeployed(
+            LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30
+        );
+    }
+
+    /// The pre-upgrade state authors both `upgradeTo` transactions.
+    function testAuthoringProducesBothUpgrades() external {
+        mockPreUpgradeBeacons();
+        SafeTx[] memory txs = harness.callAuthorBundle(beacons);
+        assertEq(txs.length, 2);
+        assertEq(txs[0].to, beacons[0]);
+        assertEq(txs[0].data, abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_0_1_30)));
+        assertEq(txs[1].to, beacons[1]);
+        assertEq(
+            txs[1].data, abi.encodeCall(IUpgradeableBeaconLike.upgradeTo, (LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30))
+        );
+    }
+
+    /// A half-executed upgrade self-scopes to the remaining beacon.
+    function testAuthoringSelfScopesAPartialUpgrade() external {
+        mockPreUpgradeBeacons();
+        vm.mockCall(
+            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
+        );
+        SafeTx[] memory txs = harness.callAuthorBundle(beacons);
+        assertEq(txs.length, 1);
+        assertEq(txs[0].to, beacons[1]);
+    }
+
+    /// A beacon in neither the 0.1.1 nor 0.1.30 state is unknown drift.
+    function testAuthoringRefusesUnknownDrift() external {
+        mockPreUpgradeBeacons();
+        vm.mockCall(beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(address(0xBAD)));
+        vm.expectRevert(abi.encodeWithSelector(BeaconInUnknownState.selector, beacons[0], address(0xBAD)));
+        harness.callAuthorBundle(beacons);
+    }
+
+    /// A fully-upgraded chain refuses to author anything.
+    function testAuthoringRefusesWhenAlreadyUpgraded() external {
+        mockPreUpgradeBeacons();
+        vm.mockCall(
+            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
+        );
+        vm.mockCall(
+            beacons[1],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30)
+        );
+        vm.expectRevert(FleetAlreadyUpgraded.selector);
+        harness.callAuthorBundle(beacons);
+    }
+}

--- a/test/script/20260831-enable-orchestrator-roles.prod.t.sol
+++ b/test/script/20260831-enable-orchestrator-roles.prod.t.sol
@@ -69,8 +69,10 @@ contract EnableOrchestratorRolesProdTest is Test {
         }
 
         address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
-        bool fleetUpgraded = IBeacon(beacons[0]).implementation() == LibProdDeployV4.STOX_RECEIPT_0_1_30
-            && IBeacon(beacons[1]).implementation() == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30;
+        bool fleetUpgraded = IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
+                == LibProdDeployV4.STOX_RECEIPT_0_1_30
+            && IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation()
+                == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30;
         if (!fleetUpgraded) {
             if (block.timestamp >= ENABLE_DEADLINE) {
                 revert OrchestratorEnableOverdue(label);
@@ -80,9 +82,9 @@ contract EnableOrchestratorRolesProdTest is Test {
             vm.expectRevert(
                 abi.encodeWithSelector(
                     FleetNotUpgraded.selector,
-                    beacons[0],
+                    beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
                     LibProdDeployV4.STOX_RECEIPT_0_1_30,
-                    IBeacon(beacons[0]).implementation()
+                    IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
                 )
             );
             script.run();

--- a/test/script/20260831-enable-orchestrator-roles.t.sol
+++ b/test/script/20260831-enable-orchestrator-roles.t.sol
@@ -41,13 +41,15 @@ contract EnableOrchestratorRolesTest is Test {
     /// 0.1.30 receipt/vault impls (the post-fleet-upgrade state).
     function mockUpgradedFleet() internal {
         address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(LibSafeInvariants.BASE_CHAIN_ID);
-        vm.etch(beacons[0], hex"fe");
-        vm.etch(beacons[1], hex"fe");
+        vm.etch(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX], hex"fe");
+        vm.etch(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX], hex"fe");
         vm.mockCall(
-            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
         );
         vm.mockCall(
-            beacons[1],
+            beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
             abi.encodeCall(IBeacon.implementation, ()),
             abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30)
         );
@@ -91,14 +93,16 @@ contract EnableOrchestratorRolesTest is Test {
     /// impls, naming the beacon and both impls.
     function testFleetGateRefusesUnupgradedBeacons() external {
         address[3] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(LibSafeInvariants.BASE_CHAIN_ID);
-        vm.etch(beacons[0], hex"fe");
+        vm.etch(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX], hex"fe");
         vm.mockCall(
-            beacons[0], abi.encodeCall(IBeacon.implementation, ()), abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_1)
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_1)
         );
         vm.expectRevert(
             abi.encodeWithSelector(
                 FleetNotUpgraded.selector,
-                beacons[0],
+                beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
                 LibProdDeployV4.STOX_RECEIPT_0_1_30,
                 LibProdDeployV4.STOX_RECEIPT_0_1_1
             )

--- a/test/script/UpgradeFleetHarness.sol
+++ b/test/script/UpgradeFleetHarness.sol
@@ -14,7 +14,7 @@ contract UpgradeFleetHarness is UpgradeFleetTo0_1_30 {
     }
 
     /// @notice The script's `authorBundle()`, externally callable.
-    function callAuthorBundle() external view returns (SafeTx[] memory) {
-        return authorBundle();
+    function callAuthorBundle(address[3] memory beacons) external view returns (SafeTx[] memory) {
+        return authorBundle(beacons);
     }
 }

--- a/test/script/UpgradeFleetHarness.sol
+++ b/test/script/UpgradeFleetHarness.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {UpgradeFleetTo0_1_30} from "../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
+import {SafeTx} from "../../src/lib/LibSafeOps.sol";
+
+/// @dev Exposes the script's internals so the guard tests can drive them
+/// directly.
+contract UpgradeFleetHarness is UpgradeFleetTo0_1_30 {
+    /// @notice The script's `assertTargetDeployed()`, externally callable.
+    function callAssertTargetDeployed(address impl, bytes32 codehash) external view {
+        assertTargetDeployed(impl, codehash);
+    }
+
+    /// @notice The script's `authorBundle()`, externally callable.
+    function callAuthorBundle(address[3] memory beacons) external view returns (SafeTx[] memory) {
+        return authorBundle(beacons);
+    }
+}

--- a/test/script/UpgradeFleetHarness.sol
+++ b/test/script/UpgradeFleetHarness.sol
@@ -4,17 +4,36 @@ pragma solidity =0.8.25;
 
 import {UpgradeFleetTo0_1_30} from "../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
 import {SafeTx} from "../../src/lib/LibSafeOps.sol";
+import {TokenInstance} from "../../src/lib/LibTokenInvariants.sol";
 
 /// @dev Exposes the script's internals so the guard tests can drive them
 /// directly.
 contract UpgradeFleetHarness is UpgradeFleetTo0_1_30 {
-    /// @notice The script's `assertTargetDeployed()`, externally callable.
-    function callAssertTargetDeployed(address impl, bytes32 codehash) external view {
-        assertTargetDeployed(impl, codehash);
-    }
-
     /// @notice The script's `authorBundle()`, externally callable.
     function callAuthorBundle(address[3] memory beacons) external view returns (SafeTx[] memory) {
         return authorBundle(beacons);
+    }
+
+    /// @notice The script's `artifactPath()`, externally callable.
+    function callArtifactPath() external view returns (string memory) {
+        return artifactPath();
+    }
+
+    /// @notice The script's `snapshotTokenState()`, externally callable.
+    function callSnapshotTokenState(TokenInstance[] memory tokens)
+        external
+        view
+        returns (uint256[] memory, bytes32[] memory)
+    {
+        return snapshotTokenState(tokens);
+    }
+
+    /// @notice The script's `assertTokenStatePreserved()`, externally callable.
+    function callAssertTokenStatePreserved(
+        TokenInstance[] memory tokens,
+        uint256[] memory supplies,
+        bytes32[] memory metaHashes
+    ) external view {
+        assertTokenStatePreserved(tokens, supplies, metaHashes);
     }
 }

--- a/test/script/UpgradeFleetHarness.sol
+++ b/test/script/UpgradeFleetHarness.sol
@@ -14,7 +14,7 @@ contract UpgradeFleetHarness is UpgradeFleetTo0_1_30 {
     }
 
     /// @notice The script's `authorBundle()`, externally callable.
-    function callAuthorBundle(address[3] memory beacons) external view returns (SafeTx[] memory) {
-        return authorBundle(beacons);
+    function callAuthorBundle() external view returns (SafeTx[] memory) {
+        return authorBundle();
     }
 }

--- a/test/src/concrete/deploy/EthereumBeaconOwnership.t.sol
+++ b/test/src/concrete/deploy/EthereumBeaconOwnership.t.sol
@@ -6,6 +6,10 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibProdBeacons0_1_1} from "../../../../src/lib/LibProdBeacons0_1_1.sol";
 import {LibProdDeployV1} from "../../../../src/lib/LibProdDeployV1.sol";
 import {LibSafeInvariants} from "../../../../src/lib/LibSafeInvariants.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {LibMigrationInvariant} from "../../../../src/lib/LibMigrationInvariant.sol";
+import {LibProdDeployV4} from "../../../../src/generated/LibProdDeployV4.sol";
+import {FLEET_UPGRADE_DEADLINE} from "../../../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
 import {LibBeaconInvariants} from "../../../../src/lib/LibBeaconInvariants.sol";
 import {LibStoxDeployNetworks} from "../../../../src/lib/LibStoxDeployNetworks.sol";
 
@@ -33,8 +37,26 @@ contract EthereumBeaconOwnershipTest is Test {
         vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
         address[3] memory beacons = LibProdBeacons0_1_1.beacons();
         address[3] memory impls = LibProdBeacons0_1_1.implementations();
-        for (uint256 i = 0; i < beacons.length; i++) {
-            LibBeaconInvariants.assertBeaconInvariants(beacons[i], safe, impls[i]);
-        }
+        // The wrapped-token-vault beacon (index 2) still serves its 0.1.1
+        // impl; the receipt + receipt-vault beacons ride the fleet-upgrade
+        // migration window (20260825-upgrade-fleet-to-0-1-30): 0.1.1 OR
+        // 0.1.30 until the deadline, 0.1.30 only after.
+        LibBeaconInvariants.assertBeaconInvariants(beacons[2], safe, impls[2]);
+        LibBeaconInvariants.assertBeaconInvariants(beacons[0], safe, IBeacon(beacons[0]).implementation());
+        LibBeaconInvariants.assertBeaconInvariants(beacons[1], safe, IBeacon(beacons[1]).implementation());
+        LibMigrationInvariant.assertMigration(
+            "in-use receipt beacon implementation()",
+            IBeacon(beacons[0]).implementation(),
+            LibProdDeployV4.STOX_RECEIPT_0_1_1,
+            LibProdDeployV4.STOX_RECEIPT_0_1_30,
+            FLEET_UPGRADE_DEADLINE
+        );
+        LibMigrationInvariant.assertMigration(
+            "in-use receipt-vault beacon implementation()",
+            IBeacon(beacons[1]).implementation(),
+            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1,
+            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+            FLEET_UPGRADE_DEADLINE
+        );
     }
 }

--- a/test/src/concrete/deploy/EthereumBeaconOwnership.t.sol
+++ b/test/src/concrete/deploy/EthereumBeaconOwnership.t.sol
@@ -37,23 +37,35 @@ contract EthereumBeaconOwnershipTest is Test {
         vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
         address[3] memory beacons = LibProdBeacons0_1_1.beacons();
         address[3] memory impls = LibProdBeacons0_1_1.implementations();
-        // The wrapped-token-vault beacon (index 2) still serves its 0.1.1
+        // The wrapped-token-vault beacon still serves its 0.1.1
         // impl; the receipt + receipt-vault beacons ride the fleet-upgrade
         // migration window (20260825-upgrade-fleet-to-0-1-30): 0.1.1 OR
         // 0.1.30 until the deadline, 0.1.30 only after.
-        LibBeaconInvariants.assertBeaconInvariants(beacons[2], safe, impls[2]);
-        LibBeaconInvariants.assertBeaconInvariants(beacons[0], safe, IBeacon(beacons[0]).implementation());
-        LibBeaconInvariants.assertBeaconInvariants(beacons[1], safe, IBeacon(beacons[1]).implementation());
+        LibBeaconInvariants.assertBeaconInvariants(
+            beacons[LibBeaconInvariants.WRAPPED_TOKEN_VAULT_BEACON_INDEX],
+            safe,
+            impls[LibBeaconInvariants.WRAPPED_TOKEN_VAULT_BEACON_INDEX]
+        );
+        LibBeaconInvariants.assertBeaconInvariants(
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            safe,
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
+        );
+        LibBeaconInvariants.assertBeaconInvariants(
+            beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
+            safe,
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation()
+        );
         LibMigrationInvariant.assertMigration(
             "in-use receipt beacon implementation()",
-            IBeacon(beacons[0]).implementation(),
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation(),
             LibProdDeployV4.STOX_RECEIPT_0_1_1,
             LibProdDeployV4.STOX_RECEIPT_0_1_30,
             FLEET_UPGRADE_DEADLINE
         );
         LibMigrationInvariant.assertMigration(
             "in-use receipt-vault beacon implementation()",
-            IBeacon(beacons[1]).implementation(),
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation(),
             LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1,
             LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
             FLEET_UPGRADE_DEADLINE

--- a/test/src/concrete/deploy/HyperEvmBeaconOwnership.t.sol
+++ b/test/src/concrete/deploy/HyperEvmBeaconOwnership.t.sol
@@ -5,6 +5,10 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibProdBeacons0_1_1} from "../../../../src/lib/LibProdBeacons0_1_1.sol";
 import {LibSafeInvariants} from "../../../../src/lib/LibSafeInvariants.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {LibMigrationInvariant} from "../../../../src/lib/LibMigrationInvariant.sol";
+import {LibProdDeployV4} from "../../../../src/generated/LibProdDeployV4.sol";
+import {FLEET_UPGRADE_DEADLINE} from "../../../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
 import {LibBeaconInvariants} from "../../../../src/lib/LibBeaconInvariants.sol";
 import {LibStoxDeployNetworks} from "../../../../src/lib/LibStoxDeployNetworks.sol";
 
@@ -30,8 +34,26 @@ contract HyperEvmBeaconOwnershipTest is Test {
         vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
         address[3] memory beacons = LibProdBeacons0_1_1.beacons();
         address[3] memory impls = LibProdBeacons0_1_1.implementations();
-        for (uint256 i = 0; i < beacons.length; i++) {
-            LibBeaconInvariants.assertBeaconInvariants(beacons[i], safe, impls[i]);
-        }
+        // The wrapped-token-vault beacon (index 2) still serves its 0.1.1
+        // impl; the receipt + receipt-vault beacons ride the fleet-upgrade
+        // migration window (20260825-upgrade-fleet-to-0-1-30): 0.1.1 OR
+        // 0.1.30 until the deadline, 0.1.30 only after.
+        LibBeaconInvariants.assertBeaconInvariants(beacons[2], safe, impls[2]);
+        LibBeaconInvariants.assertBeaconInvariants(beacons[0], safe, IBeacon(beacons[0]).implementation());
+        LibBeaconInvariants.assertBeaconInvariants(beacons[1], safe, IBeacon(beacons[1]).implementation());
+        LibMigrationInvariant.assertMigration(
+            "in-use receipt beacon implementation()",
+            IBeacon(beacons[0]).implementation(),
+            LibProdDeployV4.STOX_RECEIPT_0_1_1,
+            LibProdDeployV4.STOX_RECEIPT_0_1_30,
+            FLEET_UPGRADE_DEADLINE
+        );
+        LibMigrationInvariant.assertMigration(
+            "in-use receipt-vault beacon implementation()",
+            IBeacon(beacons[1]).implementation(),
+            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1,
+            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+            FLEET_UPGRADE_DEADLINE
+        );
     }
 }

--- a/test/src/concrete/deploy/HyperEvmBeaconOwnership.t.sol
+++ b/test/src/concrete/deploy/HyperEvmBeaconOwnership.t.sol
@@ -34,23 +34,35 @@ contract HyperEvmBeaconOwnershipTest is Test {
         vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
         address[3] memory beacons = LibProdBeacons0_1_1.beacons();
         address[3] memory impls = LibProdBeacons0_1_1.implementations();
-        // The wrapped-token-vault beacon (index 2) still serves its 0.1.1
+        // The wrapped-token-vault beacon still serves its 0.1.1
         // impl; the receipt + receipt-vault beacons ride the fleet-upgrade
         // migration window (20260825-upgrade-fleet-to-0-1-30): 0.1.1 OR
         // 0.1.30 until the deadline, 0.1.30 only after.
-        LibBeaconInvariants.assertBeaconInvariants(beacons[2], safe, impls[2]);
-        LibBeaconInvariants.assertBeaconInvariants(beacons[0], safe, IBeacon(beacons[0]).implementation());
-        LibBeaconInvariants.assertBeaconInvariants(beacons[1], safe, IBeacon(beacons[1]).implementation());
+        LibBeaconInvariants.assertBeaconInvariants(
+            beacons[LibBeaconInvariants.WRAPPED_TOKEN_VAULT_BEACON_INDEX],
+            safe,
+            impls[LibBeaconInvariants.WRAPPED_TOKEN_VAULT_BEACON_INDEX]
+        );
+        LibBeaconInvariants.assertBeaconInvariants(
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            safe,
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
+        );
+        LibBeaconInvariants.assertBeaconInvariants(
+            beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
+            safe,
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation()
+        );
         LibMigrationInvariant.assertMigration(
             "in-use receipt beacon implementation()",
-            IBeacon(beacons[0]).implementation(),
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation(),
             LibProdDeployV4.STOX_RECEIPT_0_1_1,
             LibProdDeployV4.STOX_RECEIPT_0_1_30,
             FLEET_UPGRADE_DEADLINE
         );
         LibMigrationInvariant.assertMigration(
             "in-use receipt-vault beacon implementation()",
-            IBeacon(beacons[1]).implementation(),
+            IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation(),
             LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1,
             LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
             FLEET_UPGRADE_DEADLINE

--- a/test/src/concrete/deploy/StoxCrossChainParity.t.sol
+++ b/test/src/concrete/deploy/StoxCrossChainParity.t.sol
@@ -12,6 +12,8 @@ import {IGnosisSafe} from "../../../../src/interface/IGnosisSafe.sol";
 import {IOwnable} from "../../../../src/interface/IOwnable.sol";
 import {LibAuthoriserInvariants} from "../../../../src/lib/LibAuthoriserInvariants.sol";
 import {LibProdDeployV2BaseOverrides} from "../../../../src/lib/LibProdDeployV2BaseOverrides.sol";
+import {LibMigrationInvariant} from "../../../../src/lib/LibMigrationInvariant.sol";
+import {FLEET_UPGRADE_DEADLINE} from "../../../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
 import {LibProdDeployV4} from "../../../../src/generated/LibProdDeployV4.sol";
 import {LibSafeInvariants} from "../../../../src/lib/LibSafeInvariants.sol";
 import {LibStoxDeployNetworks} from "../../../../src/lib/LibStoxDeployNetworks.sol";
@@ -450,15 +452,19 @@ contract StoxCrossChainParityTest is Test {
             // the same pins `LibProdBeaconsBase/Ethereum.implementations()`
             // resolve. When a beacon upgrade migration moves production,
             // these pins move with it.
-            assertEq(
+            LibMigrationInvariant.assertMigration(
+                string.concat(label, " in-use receipt-vault beacon implementation()"),
                 IBeacon(beacon).implementation(),
                 LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1,
-                string.concat(label, " receipt-vault beacon does not serve the audited production impl")
+                LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+                FLEET_UPGRADE_DEADLINE
             );
-            assertEq(
+            LibMigrationInvariant.assertMigration(
+                string.concat(label, " in-use receipt beacon implementation()"),
                 IBeacon(receiptBeacon).implementation(),
                 LibProdDeployV4.STOX_RECEIPT_0_1_1,
-                string.concat(label, " receipt beacon does not serve the audited production impl")
+                LibProdDeployV4.STOX_RECEIPT_0_1_30,
+                FLEET_UPGRADE_DEADLINE
             );
             assertCleanV4Lineage(beacon);
             assertCleanV4Lineage(receiptBeacon);

--- a/test/src/concrete/deploy/StoxProdV4.t.sol
+++ b/test/src/concrete/deploy/StoxProdV4.t.sol
@@ -3,6 +3,8 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibMigrationInvariant} from "../../../../src/lib/LibMigrationInvariant.sol";
+import {FLEET_UPGRADE_DEADLINE} from "../../../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
 import {LibProdDeployV4} from "../../../../src/generated/LibProdDeployV4.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 import {LibStoxDeployNetworks} from "../../../../src/lib/LibStoxDeployNetworks.sol";
@@ -49,7 +51,7 @@ contract StoxProdV4Test is Test {
     /// tests. On Base the 0.1.1-address beacons checked here are an unadopted
     /// deploy artifact whose owner is irrelevant; on Ethereum they ARE the
     /// in-use beacons and the per-chain assert covers them.
-    function checkProd_0_1_1OnChain() internal view {
+    function checkProd_0_1_1OnChain(bool oarvBeaconsAreInUse) internal view {
         assertTrue(LibProdDeployV4.STOX_RECEIPT_0_1_1.code.length > 0, "V4 StoxReceipt not deployed");
         assertEq(LibProdDeployV4.STOX_RECEIPT_0_1_1.codehash, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_1);
         assertEq(LibProdDeployV4.STOX_RECEIPT_0_1_1.code, LibProdDeployV4.STOX_RECEIPT_RUNTIME_CODE_0_1_1);
@@ -173,18 +175,41 @@ contract StoxProdV4Test is Test {
         );
 
         IBeacon receiptBeacon = oarvDeployer.iReceiptBeacon();
-        assertEq(
-            receiptBeacon.implementation(),
-            LibProdDeployV4.STOX_RECEIPT_0_1_1,
-            "V4 OARV receipt beacon implementation mismatch"
-        );
-
         IBeacon vaultBeacon = oarvDeployer.iOffchainAssetReceiptVaultBeacon();
-        assertEq(
-            vaultBeacon.implementation(),
-            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1,
-            "V4 OARV vault beacon implementation mismatch"
-        );
+        if (oarvBeaconsAreInUse) {
+            // On the bootstrap chains these ARE the in-use production
+            // beacons, so they ride the fleet-upgrade migration window
+            // (20260825-upgrade-fleet-to-0-1-30): 0.1.1 OR 0.1.30 until the
+            // deadline, 0.1.30 only after.
+            LibMigrationInvariant.assertMigration(
+                "OARV receipt beacon implementation()",
+                receiptBeacon.implementation(),
+                LibProdDeployV4.STOX_RECEIPT_0_1_1,
+                LibProdDeployV4.STOX_RECEIPT_0_1_30,
+                FLEET_UPGRADE_DEADLINE
+            );
+            LibMigrationInvariant.assertMigration(
+                "OARV vault beacon implementation()",
+                vaultBeacon.implementation(),
+                LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1,
+                LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+                FLEET_UPGRADE_DEADLINE
+            );
+        } else {
+            // On Base these beacons are unadopted deploy artifacts
+            // (production runs on the V1-address beacons) — never
+            // repointed, frozen at the 0.1.1 impls their constructor baked.
+            assertEq(
+                receiptBeacon.implementation(),
+                LibProdDeployV4.STOX_RECEIPT_0_1_1,
+                "V4 OARV receipt beacon implementation mismatch"
+            );
+            assertEq(
+                vaultBeacon.implementation(),
+                LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1,
+                "V4 OARV vault beacon implementation mismatch"
+            );
+        }
     }
 
     /// The Base fork verifies only the frozen audited 0.1.1 set — that is what
@@ -195,7 +220,7 @@ contract StoxProdV4Test is Test {
     /// instead. The in-use beacons MUST be owned by Base's token-owner Safe.
     function testProdDeployBaseV4() external {
         vm.createSelectFork(LibRainDeploy.BASE);
-        checkProd_0_1_1OnChain();
+        checkProd_0_1_1OnChain(false);
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
     }
 
@@ -207,7 +232,7 @@ contract StoxProdV4Test is Test {
     /// Ethereum's token-owner Safe — asserted via the per-chain in-use pin.
     function testProdDeployEthereumV4() external {
         vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
-        checkProd_0_1_1OnChain();
+        checkProd_0_1_1OnChain(true);
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
     }
 
@@ -220,7 +245,7 @@ contract StoxProdV4Test is Test {
     /// the HyperEVM token-owner Safe; green otherwise, catching later drift.
     function testProdDeployHyperEvmV4() external {
         vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
-        checkProd_0_1_1OnChain();
+        checkProd_0_1_1OnChain(true);
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
     }
 }


### PR DESCRIPTION
20260825-upgrade-fleet-to-0-1-30 (run-script registry): authors one
atomic per-chain Safe MultiSend repointing the chain's IN-USE receipt
and receipt-vault beacons (Base's V1 addresses, the bootstrap chains'
0.1.1 set) from the audited 0.1.1 impls to the audited 0.1.30 impls -
the H01 remediation going live, and the state the orchestrator cutover
hard-gates on. The wrapped-token-vault beacon is deliberately not
repointed (optimizer-only delta; separate decision).

Pre-flight: 0.1.30 receipt/vault/facet live at their pins by codehash,
beacons Safe-owned and exactly in the 0.1.1 state (unknown drift
refuses; already-upgraded self-scopes/refuses). The simulation proves,
for EVERY production token on the chain, that totalSupply/symbol/
decimals read identically across the upgrade - the H01 fix must be
invisible in reads. n+1 proves the Safe can downgrade back. Artifact +
MultiSend SafeTxHash + signer-side verify(jsonPath).

The four fork surfaces pinning beacon->impl bindings (both bootstrap
beacon-ownership tests, cross-chain parity, StoxProdV4's shared
checker - now parameterised for Base's unadopted 0.1.1-set artifacts
vs the bootstrap chains' in-use ones) ride a LibMigrationInvariant
window: 0.1.1 OR 0.1.30 until 2026-10-01, 0.1.30 only after, so this
PR merges before the broadcasts and cron red-lines any chain the
upgrade misses. Post-execution pin PR flips LibProdBeacons* impls and
retires the fixtures.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KbsbYN4C4YDa8pu9DdudoX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for preparing and verifying production fleet upgrades to audited version 0.1.30.
  - Upgrade bundles now target only components that still require migration while preserving token data and metadata.
  - Added workflow access for preparing fleet upgrades across supported chains.

- **Validation**
  - Added checks for deployment readiness, ownership, upgrade states, reversibility, and post-upgrade invariants.
  - Updated deployment validation to support the approved transition from version 0.1.1 to 0.1.30.
  - Added safeguards to reject unexpected implementation changes or altered upgrade artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->