### PR TITLE
Retire bundle: signer's direct vault roles, after the burn-in

### DIFF
--- a/.github/workflows/run-script.yaml
+++ b/.github/workflows/run-script.yaml
@@ -34,6 +34,7 @@ on:
           - 20260813-timelock-rehearsal-schedule
           - 20260813-timelock-rehearsal-cancel
           - 20260831-enable-orchestrator-roles
+          - 20260831-retire-direct-signer-roles
           - 20260825-upgrade-fleet-to-0-1-30
       network:
         description: 'Network to author against (default: base)'

--- a/script/20260831-enable-orchestrator-roles.s.sol
+++ b/script/20260831-enable-orchestrator-roles.s.sol
@@ -16,15 +16,6 @@ import {LibBeaconInvariants} from "../src/lib/LibBeaconInvariants.sol";
 import {LibOrchestratorInvariants} from "../src/lib/LibOrchestratorInvariants.sol";
 import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
 
-/// @notice Dispatched against a chain without a hydrated authoriser pin.
-/// @param chainId The active chain id.
-error UnsupportedChainForEnable(uint256 chainId);
-
-/// @notice The active chain's V4 authoriser is not ready (unpinned, no code,
-/// or the wrong codehash).
-/// @param authoriser The authoriser address inspected.
-error AuthoriserNotReadyForEnable(address authoriser);
-
 /// @notice The chain's production token beacons do not point at the audited
 /// 0.1.30 implementations the orchestrator was built for. The fleet upgrade
 /// must execute BEFORE the orchestrator gains vault access — the
@@ -109,27 +100,6 @@ contract EnableOrchestratorRoles is Script {
     /// @return path The artifact path for the ACTIVE chain.
     function artifactPath() internal view virtual returns (string memory path) {
         path = string.concat("out/20260831-enable-orchestrator-roles-", vm.toString(block.chainid), ".json");
-    }
-
-    /// @notice The active chain's hydrated V4 authoriser, asserted deployed
-    /// with the shared EIP-1167 codehash.
-    /// @return authoriser The validated authoriser address.
-    function activeChainAuthoriser() internal view returns (address authoriser) {
-        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
-        } else if (block.chainid == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
-        } else if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
-        } else {
-            revert UnsupportedChainForEnable(block.chainid);
-        }
-        if (
-            authoriser == address(0) || authoriser.code.length == 0
-                || authoriser.codehash != LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
-        ) {
-            revert AuthoriserNotReadyForEnable(authoriser);
-        }
     }
 
     /// @notice The fleet-upgrade interlock: the active chain's in-use
@@ -277,7 +247,7 @@ contract EnableOrchestratorRoles is Script {
 
         address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
         IGnosisSafe safe = IGnosisSafe(safeAddr);
-        address authoriser = activeChainAuthoriser();
+        address authoriser = LibAuthoriserInvariants.activeChainAuthoriser();
         IAccessControl acl = IAccessControl(authoriser);
 
         // The 0.1.30 orchestrator world must be live at its pins, with the
@@ -358,7 +328,7 @@ contract EnableOrchestratorRoles is Script {
     function verify(string calldata jsonPath) external view {
         address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
         IGnosisSafe safe = IGnosisSafe(safeAddr);
-        address authoriser = activeChainAuthoriser();
+        address authoriser = LibAuthoriserInvariants.activeChainAuthoriser();
         LibOrchestratorInvariants.assertBeaconSet(safeAddr);
         LibOrchestratorInvariants.assertInstance(safeAddr);
         assertFleetUpgraded();

--- a/script/20260831-retire-direct-signer-roles.s.sol
+++ b/script/20260831-retire-direct-signer-roles.s.sol
@@ -21,15 +21,6 @@ import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
 /// while the orchestrator proves itself off-chain.
 uint256 constant RETIRE_DEADLINE = 1_792_022_400;
 
-/// @notice Dispatched against a chain without a hydrated authoriser pin.
-/// @param chainId The active chain id.
-error UnsupportedChainForRetire(uint256 chainId);
-
-/// @notice The active chain's V4 authoriser is not ready (unpinned, no code,
-/// or the wrong codehash).
-/// @param authoriser The authoriser address inspected.
-error AuthoriserNotReadyForRetire(address authoriser);
-
 /// @notice The orchestrator mint/burn path is not fully enabled on this
 /// chain — retiring the signer's direct roles now would leave NO working
 /// mint/burn path. Execute `20260831-enable-orchestrator-roles` (and give
@@ -87,27 +78,6 @@ contract RetireDirectSignerRoles is Script {
     /// @return path The artifact path for the ACTIVE chain.
     function artifactPath() internal view virtual returns (string memory path) {
         path = string.concat("out/20260831-retire-direct-signer-roles-", vm.toString(block.chainid), ".json");
-    }
-
-    /// @notice The active chain's hydrated V4 authoriser, asserted deployed
-    /// with the shared EIP-1167 codehash.
-    /// @return authoriser The validated authoriser address.
-    function activeChainAuthoriser() internal view returns (address authoriser) {
-        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
-        } else if (block.chainid == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
-        } else if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
-        } else {
-            revert UnsupportedChainForRetire(block.chainid);
-        }
-        if (
-            authoriser == address(0) || authoriser.code.length == 0
-                || authoriser.codehash != LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
-        ) {
-            revert AuthoriserNotReadyForRetire(authoriser);
-        }
     }
 
     /// @notice The burn-in gate: the orchestrator path must be FULLY enabled
@@ -208,7 +178,7 @@ contract RetireDirectSignerRoles is Script {
 
         address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
         IGnosisSafe safe = IGnosisSafe(safeAddr);
-        address authoriser = activeChainAuthoriser();
+        address authoriser = LibAuthoriserInvariants.activeChainAuthoriser();
         IAccessControl acl = IAccessControl(authoriser);
 
         LibOrchestratorInvariants.assertBeaconSet(safeAddr);
@@ -286,7 +256,7 @@ contract RetireDirectSignerRoles is Script {
     function verify(string calldata jsonPath) external view {
         address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
         IGnosisSafe safe = IGnosisSafe(safeAddr);
-        address authoriser = activeChainAuthoriser();
+        address authoriser = LibAuthoriserInvariants.activeChainAuthoriser();
         LibOrchestratorInvariants.assertBeaconSet(safeAddr);
         LibOrchestratorInvariants.assertInstance(safeAddr);
         assertOrchestratorPathEnabled(IAccessControl(authoriser), LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE);

--- a/script/20260831-retire-direct-signer-roles.s.sol
+++ b/script/20260831-retire-direct-signer-roles.s.sol
@@ -261,6 +261,7 @@ contract RetireDirectSignerRoles is Script {
         LibOrchestratorInvariants.assertInstance(safeAddr);
         assertOrchestratorPathEnabled(IAccessControl(authoriser), LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE);
 
+        LibAuthoriserInvariants.assertExpectedGrants(authoriser, safeAddr);
         SafeTx[] memory expected = authorBundle(authoriser, safeAddr);
         LibSafeOps.assertParsedTxsMatch(expected, jsonPath);
 

--- a/script/20260831-retire-direct-signer-roles.s.sol
+++ b/script/20260831-retire-direct-signer-roles.s.sol
@@ -60,6 +60,11 @@ error DirectSignerRolesAlreadyRetired();
 /// chain with no working mint path. Self-scoping; a retired chain refuses
 /// (`DirectSignerRolesAlreadyRetired`).
 ///
+/// Dispatch BEFORE `20260729-migrate-governance-to-timelock` executes on
+/// the chain: the revokes need the vault `_ADMIN`s the Safe holds today,
+/// which that migration hands to the timelock; afterwards this script
+/// refuses (`SafeMissingRoleAdminForRetire`).
+///
 /// The post-execution pin PR removes the signer's `DEPOSIT`/`WITHDRAW`
 /// rows from the canonical grant map, pins their absence (the
 /// Fireblocks-revocation lifecycle), and retires this script's fixtures.

--- a/script/20260831-retire-direct-signer-roles.s.sol
+++ b/script/20260831-retire-direct-signer-roles.s.sol
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+
+import {IGnosisSafe} from "../src/interface/IGnosisSafe.sol";
+import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
+import {LibAuthoriserInvariants, RoleGrant} from "../src/lib/LibAuthoriserInvariants.sol";
+import {LibOrchestratorInvariants} from "../src/lib/LibOrchestratorInvariants.sol";
+import {LibSafeOps, SafeTx} from "../src/lib/LibSafeOps.sol";
+
+/// @dev Unix timestamp (2026-10-15T00:00:00Z) by which the retirement must
+/// have executed on every chain. Deliberately TWO WEEKS after the
+/// fleet/enable deadline: the whole point of the enable/retire split is a
+/// burn-in window where the orchestrator path and the signer's direct path
+/// run in parallel, so the direct path can serve as an emergency fallback
+/// while the orchestrator proves itself off-chain.
+uint256 constant RETIRE_DEADLINE = 1_792_022_400;
+
+/// @notice Dispatched against a chain without a hydrated authoriser pin.
+/// @param chainId The active chain id.
+error UnsupportedChainForRetire(uint256 chainId);
+
+/// @notice The active chain's V4 authoriser is not ready (unpinned, no code,
+/// or the wrong codehash).
+/// @param authoriser The authoriser address inspected.
+error AuthoriserNotReadyForRetire(address authoriser);
+
+/// @notice The orchestrator mint/burn path is not fully enabled on this
+/// chain — retiring the signer's direct roles now would leave NO working
+/// mint/burn path. Execute `20260831-enable-orchestrator-roles` (and give
+/// the orchestrator its burn-in) first.
+/// @param holder The principal missing a role.
+/// @param role The role it must hold before retirement can be authored.
+error OrchestratorPathNotEnabled(address holder, bytes32 role);
+
+/// @notice The Safe does not hold the `_ADMIN` role needed to revoke a
+/// grant in the bundle.
+/// @param adminRole The missing `_ADMIN` role.
+error SafeMissingRoleAdminForRetire(bytes32 adminRole);
+
+/// @notice The signer holds neither direct vault role — the retirement has
+/// executed on this chain and a re-dispatch has nothing to author.
+error DirectSignerRolesAlreadyRetired();
+
+/// @title RetireDirectSignerRoles
+/// @notice **PENDING.** Authors the per-chain Safe Tx Builder bundle that
+/// closes the parallel burn-in window opened by
+/// `20260831-enable-orchestrator-roles`: revoke the service signer's DIRECT
+/// `DEPOSIT` and `WITHDRAW` on the authoriser, leaving the orchestrator as
+/// the only mint/burn path the signer can drive. Run this ONLY once the
+/// orchestrator has proven itself in production — the split from the
+/// enable bundle exists precisely so this step can wait.
+///
+/// Deliberately untouched: the signer's `CERTIFY` (the orchestrator has no
+/// certify surface) and the Safe's own three direct action roles (the
+/// break-glass path).
+///
+/// @dev Dispatch via `Actions → run-script` with
+/// `script = 20260831-retire-direct-signer-roles` per chain; sign and
+/// execute the artifact in the Safe UI. Pre-flight refuses to author unless
+/// the orchestrator path is FULLY enabled on the chain — the orchestrator
+/// holds both vault roles and the signer holds `MINT`/`BURN` on it
+/// (`OrchestratorPathNotEnabled`) — so the retirement can never strand a
+/// chain with no working mint path. Self-scoping; a retired chain refuses
+/// (`DirectSignerRolesAlreadyRetired`).
+///
+/// The post-execution pin PR removes the signer's `DEPOSIT`/`WITHDRAW`
+/// rows from the canonical grant map, pins their absence (the
+/// Fireblocks-revocation lifecycle), and retires this script's fixtures.
+contract RetireDirectSignerRoles is Script {
+    /// @notice The service signer whose direct vault access retires.
+    address internal constant SERVICE_SIGNER = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
+
+    /// @notice The orchestrator's operational roles (audited 0.1.30 source).
+    bytes32 internal constant ORCHESTRATOR_MINT_ROLE = keccak256("MINT");
+    bytes32 internal constant ORCHESTRATOR_BURN_ROLE = keccak256("BURN");
+
+    /// @notice Signer-visible `meta.name` for the emitted bundle.
+    string internal constant BUNDLE_NAME = "ST0x retire: service signer's direct vault roles (orchestrator proven)";
+
+    /// @notice Chain-suffixed artifact path.
+    /// @return path The artifact path for the ACTIVE chain.
+    function artifactPath() internal view virtual returns (string memory path) {
+        path = string.concat("out/20260831-retire-direct-signer-roles-", vm.toString(block.chainid), ".json");
+    }
+
+    /// @notice The active chain's hydrated V4 authoriser, asserted deployed
+    /// with the shared EIP-1167 codehash.
+    /// @return authoriser The validated authoriser address.
+    function activeChainAuthoriser() internal view returns (address authoriser) {
+        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+        } else if (block.chainid == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+        } else if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
+        } else {
+            revert UnsupportedChainForRetire(block.chainid);
+        }
+        if (
+            authoriser == address(0) || authoriser.code.length == 0
+                || authoriser.codehash != LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
+        ) {
+            revert AuthoriserNotReadyForRetire(authoriser);
+        }
+    }
+
+    /// @notice The burn-in gate: the orchestrator path must be FULLY enabled
+    /// before the direct path retires — the orchestrator holds both vault
+    /// roles on the authoriser and the signer holds both operational roles
+    /// on the orchestrator. Reverts `OrchestratorPathNotEnabled` naming the
+    /// first missing (holder, role).
+    /// @param acl The authoriser's access-control surface.
+    /// @param orchestrator The orchestrator instance.
+    function assertOrchestratorPathEnabled(IAccessControl acl, address orchestrator) internal view {
+        if (!acl.hasRole(keccak256("DEPOSIT"), orchestrator)) {
+            revert OrchestratorPathNotEnabled(orchestrator, keccak256("DEPOSIT"));
+        }
+        if (!acl.hasRole(keccak256("WITHDRAW"), orchestrator)) {
+            revert OrchestratorPathNotEnabled(orchestrator, keccak256("WITHDRAW"));
+        }
+        IAccessControl orch = IAccessControl(orchestrator);
+        if (!orch.hasRole(ORCHESTRATOR_MINT_ROLE, SERVICE_SIGNER)) {
+            revert OrchestratorPathNotEnabled(SERVICE_SIGNER, ORCHESTRATOR_MINT_ROLE);
+        }
+        if (!orch.hasRole(ORCHESTRATOR_BURN_ROLE, SERVICE_SIGNER)) {
+            revert OrchestratorPathNotEnabled(SERVICE_SIGNER, ORCHESTRATOR_BURN_ROLE);
+        }
+    }
+
+    /// @notice Pre-flight the principals and self-scope the bundle: one
+    /// `revokeRole` per direct role the signer still holds. Refuses when
+    /// the Safe lacks an `_ADMIN` it needs or when nothing remains
+    /// (`DirectSignerRolesAlreadyRetired`).
+    /// @param authoriser The chain's authoriser clone.
+    /// @param safeAddr The chain's token-owner Safe.
+    /// @return txs The self-scoped revoke transactions.
+    function authorBundle(address authoriser, address safeAddr) internal view returns (SafeTx[] memory txs) {
+        IAccessControl acl = IAccessControl(authoriser);
+
+        if (!acl.hasRole(keccak256("DEPOSIT_ADMIN"), safeAddr)) {
+            revert SafeMissingRoleAdminForRetire(keccak256("DEPOSIT_ADMIN"));
+        }
+        if (!acl.hasRole(keccak256("WITHDRAW_ADMIN"), safeAddr)) {
+            revert SafeMissingRoleAdminForRetire(keccak256("WITHDRAW_ADMIN"));
+        }
+
+        SafeTx[] memory candidates = new SafeTx[](2);
+        uint256 count = 0;
+        bytes32[2] memory roles = [keccak256("DEPOSIT"), keccak256("WITHDRAW")];
+        for (uint256 i = 0; i < roles.length; i++) {
+            if (acl.hasRole(roles[i], SERVICE_SIGNER)) {
+                candidates[count++] = SafeTx({
+                    to: authoriser,
+                    value: 0,
+                    data: abi.encodeCall(IAccessControl.revokeRole, (roles[i], SERVICE_SIGNER)),
+                    operation: 0
+                });
+            }
+        }
+        if (count == 0) {
+            revert DirectSignerRolesAlreadyRetired();
+        }
+        txs = new SafeTx[](count);
+        for (uint256 i = 0; i < count; i++) {
+            txs[i] = candidates[i];
+        }
+    }
+
+    /// @notice Assert the post-retirement state on the active fork: the
+    /// signer holds neither direct vault role, its `CERTIFY` and every
+    /// other canonical row survive, and the orchestrator path is intact.
+    /// @dev The map-wide `assertExpectedGrants` cannot be used: the map
+    /// pins what production IS until this bundle executes (the signer's
+    /// rows are still in it). Row-by-row with the retired rows negated;
+    /// the post-execution pin PR moves this shape into the invariant lib.
+    /// @param acl The authoriser's access-control surface.
+    /// @param orchestrator The orchestrator instance.
+    /// @param safeAddr The chain's token-owner Safe.
+    function assertPostRetireState(IAccessControl acl, address orchestrator, address safeAddr) internal view {
+        require(
+            !acl.hasRole(keccak256("DEPOSIT"), SERVICE_SIGNER) && !acl.hasRole(keccak256("WITHDRAW"), SERVICE_SIGNER),
+            "RetireDirectSignerRoles: signer still holds a direct vault role"
+        );
+        RoleGrant[] memory all = LibAuthoriserInvariants.expectedGrants(safeAddr);
+        for (uint256 i = 0; i < all.length; i++) {
+            bool retiredRow = all[i].grantee == SERVICE_SIGNER
+                && (all[i].role == keccak256("DEPOSIT") || all[i].role == keccak256("WITHDRAW"));
+            if (retiredRow) continue;
+            require(
+                acl.hasRole(all[i].role, all[i].grantee),
+                "RetireDirectSignerRoles: retirement disturbed an unrelated grant"
+            );
+        }
+        assertOrchestratorPathEnabled(acl, orchestrator);
+    }
+
+    /// @notice Author the retirement bundle for the active chain: see the
+    /// contract-level flow. Does not broadcast — execution happens via the
+    /// Safe UI using the emitted artifact.
+    function run() external {
+        // --- Pre-flight ---------------------------------------------------
+
+        address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
+        IGnosisSafe safe = IGnosisSafe(safeAddr);
+        address authoriser = activeChainAuthoriser();
+        IAccessControl acl = IAccessControl(authoriser);
+
+        LibOrchestratorInvariants.assertBeaconSet(safeAddr);
+        LibOrchestratorInvariants.assertInstance(safeAddr);
+        address orchestrator = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
+
+        // The burn-in gate: no retirement without a fully-enabled
+        // orchestrator path.
+        assertOrchestratorPathEnabled(acl, orchestrator);
+
+        // The canonical map must hold exactly before rows leave it.
+        LibAuthoriserInvariants.assertExpectedGrants(authoriser, safeAddr);
+
+        // --- Build the bundle ----------------------------------------------
+
+        SafeTx[] memory txs = authorBundle(authoriser, safeAddr);
+
+        uint256 nonce = safe.nonce();
+        bytes32 bundleSafeTxHash = LibSafeOps.computeMultiSendSafeTxHash(safe, txs, nonce);
+
+        // --- Simulate -----------------------------------------------------
+
+        for (uint256 i = 0; i < txs.length; i++) {
+            LibSafeOps.simulateExternalCall(safe, txs[i].to, txs[i].data);
+        }
+
+        // --- Post-state ---------------------------------------------------
+
+        assertPostRetireState(acl, orchestrator, safeAddr);
+        LibSafeInvariants.assertImmutableInvariants(safe);
+        LibSafeInvariants.assertThreshold(safe, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD);
+
+        // --- Artifact -----------------------------------------------------
+
+        string memory json = LibSafeOps.emitTxBuilderJson(safeAddr, block.chainid, BUNDLE_NAME, txs);
+        vm.writeFile(artifactPath(), json);
+
+        console2.log("==== TX BUILDER JSON BEGIN ====");
+        console2.log(json);
+        console2.log("==== TX BUILDER JSON END ====");
+        console2.log("Bundle MultiSend SafeTxHash:", vm.toString(bundleSafeTxHash));
+        console2.log("Nonce:", nonce);
+        console2.log("Bundle item count:", txs.length);
+        console2.log("Chain:", block.chainid);
+        console2.log("Service signer:", SERVICE_SIGNER);
+
+        // --- n+1 reversal proof --------------------------------------------
+
+        // The retirement is fully reversible under the `_ADMIN`s the Safe
+        // holds: prove the re-grant clears the live threshold, then
+        // re-revoke so the fork ends retired.
+        LibSafeOps.simulateNPlus1(
+            safe,
+            authoriser,
+            abi.encodeCall(IAccessControl.grantRole, (keccak256("DEPOSIT"), SERVICE_SIGNER)),
+            LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_THRESHOLD
+        );
+        require(
+            acl.hasRole(keccak256("DEPOSIT"), SERVICE_SIGNER),
+            "RetireDirectSignerRoles: n+1 re-grant did not restore the role"
+        );
+        LibSafeOps.simulateExternalCall(
+            safe, authoriser, abi.encodeCall(IAccessControl.revokeRole, (keccak256("DEPOSIT"), SERVICE_SIGNER))
+        );
+        console2.log(
+            "n+1 reversal check passed: the Safe can restore (and re-retire) the fallback under the live threshold"
+        );
+    }
+
+    /// @notice Signer-side integrity check for a CI-authored retirement
+    /// artifact, run LOCALLY against a live fork before signing.
+    /// Deliberately NOT in the run-script dispatcher: it takes a local path
+    /// and runs on the signer's machine.
+    /// @param jsonPath Filesystem path to the downloaded Tx Builder JSON.
+    function verify(string calldata jsonPath) external view {
+        address safeAddr = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
+        IGnosisSafe safe = IGnosisSafe(safeAddr);
+        address authoriser = activeChainAuthoriser();
+        LibOrchestratorInvariants.assertBeaconSet(safeAddr);
+        LibOrchestratorInvariants.assertInstance(safeAddr);
+        assertOrchestratorPathEnabled(IAccessControl(authoriser), LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE);
+
+        SafeTx[] memory expected = authorBundle(authoriser, safeAddr);
+        LibSafeOps.assertParsedTxsMatch(expected, jsonPath);
+
+        uint256 nonce = safe.nonce();
+        console2.log("Artifact verified against live state.");
+        console2.log(
+            "Bundle MultiSend SafeTxHash:", vm.toString(LibSafeOps.computeMultiSendSafeTxHash(safe, expected, nonce))
+        );
+        console2.log("Nonce:", nonce);
+    }
+}

--- a/src/lib/LibAuthoriserInvariants.sol
+++ b/src/lib/LibAuthoriserInvariants.sol
@@ -53,6 +53,15 @@ error UnexpectedRetainedAdminGrant(address authoriser, bytes32 role, address hol
 /// @param role The action role the retired signer holds.
 error UnexpectedRetiredSignerGrant(address authoriser, bytes32 role);
 
+/// @notice Dispatched against a chain without a hydrated authoriser pin.
+/// @param chainId The active chain id.
+error UnsupportedChainForAuthoriser(uint256 chainId);
+
+/// @notice The active chain's V4 authoriser is not ready (unpinned, no code,
+/// or the wrong codehash).
+/// @param authoriser The authoriser address inspected.
+error AuthoriserNotReady(address authoriser);
+
 /// @title LibAuthoriserInvariants
 /// @notice Reusable invariants for the ST0x production authoriser on Base:
 /// the grantee constants and the single master `(role, grantee)` map every
@@ -72,6 +81,27 @@ error UnexpectedRetiredSignerGrant(address authoriser, bytes32 role);
 /// and `LibTokenInvariants`; individually callable via `assertAll()` for
 /// the focused authoriser drift detector.
 library LibAuthoriserInvariants {
+    /// @notice The active chain's hydrated V4 authoriser clone, asserted
+    /// deployed with the shared EIP-1167 codehash.
+    /// @return authoriser The validated authoriser address.
+    function activeChainAuthoriser() internal view returns (address authoriser) {
+        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+        } else if (block.chainid == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+        } else if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
+        } else {
+            revert UnsupportedChainForAuthoriser(block.chainid);
+        }
+        if (
+            authoriser == address(0) || authoriser.code.length == 0
+                || authoriser.codehash != LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH
+        ) {
+            revert AuthoriserNotReady(authoriser);
+        }
+    }
+
     /// @notice THE current production authoriser — the single entrypoint
     /// every invariant and script reads. Aliases the V4 clone pinned in
     /// `LibProdDeployV4` (the generated deploy lib is the single source

--- a/test/script/20260831-retire-direct-signer-roles.prod.t.sol
+++ b/test/script/20260831-retire-direct-signer-roles.prod.t.sol
@@ -7,11 +7,8 @@ import {console2} from "forge-std-1.16.1/src/console2.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 
-import {
-    RetireDirectSignerRoles,
-    RETIRE_DEADLINE,
-    OrchestratorPathNotEnabled
-} from "../../script/20260831-retire-direct-signer-roles.s.sol";
+import {RETIRE_DEADLINE, OrchestratorPathNotEnabled} from "../../script/20260831-retire-direct-signer-roles.s.sol";
+import {RetireDirectSignerRolesHarness} from "./RetireDirectSignerRolesHarness.sol";
 import {LibOrchestratorInvariants} from "../../src/lib/LibOrchestratorInvariants.sol";
 import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";

--- a/test/script/20260831-retire-direct-signer-roles.prod.t.sol
+++ b/test/script/20260831-retire-direct-signer-roles.prod.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
+
+import {RetireDirectSignerRoles, RETIRE_DEADLINE} from "../../script/20260831-retire-direct-signer-roles.s.sol";
+import {LibOrchestratorInvariants, OrchestratorSetDeployerMissing} from "../../src/lib/LibOrchestratorInvariants.sol";
+import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
+import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
+
+/// @notice The retirement deadline passed with this chain still pending.
+/// Run the outstanding dispatches, extend the deadline, or delete the
+/// invariant.
+/// @param label The chain still pending.
+error RetirementOverdue(string label);
+
+/// @title RetireDirectSignerRolesProdTest
+/// @notice PROD coverage for the direct-role retirement: what production IS
+/// on each chain, read from a real fork with no mocks, walking the states:
+///
+/// 1. **Orchestrator world pending** (every chain today): `run()`'s
+///    pre-flight refuses at the 0.1.30 beacon-set read.
+/// 2. **Burn-in pending** (orchestrator live but path not fully enabled):
+///    the burn-in gate refuses — retirement can never strand a chain
+///    without a working mint path.
+/// 3. **Burn-in** (path enabled, direct roles still live): drives `run()`
+///    end to end — revokes authored and simulated, post-state and n+1
+///    proven. The window between states 3 and 4 is DELIBERATE: the
+///    fallback path stays until the orchestrator has proven itself.
+/// 4. **Retired**: the signer holds no direct vault roles; asserted
+///    directly.
+///
+/// States 1–3 stop passing at `RETIRE_DEADLINE` (two weeks after the
+/// enable/fleet deadline, honouring the burn-in); state 4 is steady.
+contract RetireDirectSignerRolesProdTest is Test {
+    /// @notice Walk the active fork's retirement state (see the contract
+    /// NatSpec) and assert it.
+    /// @param label Human chain name, surfaced in logs and messages.
+    function assertRetireRollout(string memory label) internal {
+        RetireDirectSignerRoles script = new RetireDirectSignerRoles();
+        address setDeployer = LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30;
+        address orchestrator = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
+        address signer = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
+
+        if (setDeployer.code.length == 0 || orchestrator.code.length == 0) {
+            if (block.timestamp >= RETIRE_DEADLINE) {
+                revert RetirementOverdue(label);
+            }
+            console2.log(string.concat("PENDING [", label, "]: 0.1.30 orchestrator world not deployed"));
+            vm.expectRevert(abi.encodeWithSelector(OrchestratorSetDeployerMissing.selector, setDeployer));
+            script.run();
+            return;
+        }
+
+        IAccessControl acl = IAccessControl(activeAuthoriser());
+        bool pathEnabled = acl.hasRole(keccak256("DEPOSIT"), orchestrator)
+            && acl.hasRole(keccak256("WITHDRAW"), orchestrator)
+            && IAccessControl(orchestrator).hasRole(keccak256("MINT"), signer)
+            && IAccessControl(orchestrator).hasRole(keccak256("BURN"), signer);
+        if (!pathEnabled) {
+            if (block.timestamp >= RETIRE_DEADLINE) {
+                revert RetirementOverdue(label);
+            }
+            console2.log(string.concat("PENDING [", label, "]: orchestrator path not enabled - retirement gated"));
+            console2.log("-> execute 20260831-enable-orchestrator-roles (and its burn-in) first");
+            vm.expectRevert();
+            script.run();
+            return;
+        }
+
+        bool retired = !acl.hasRole(keccak256("DEPOSIT"), signer) && !acl.hasRole(keccak256("WITHDRAW"), signer);
+        if (!retired) {
+            if (block.timestamp >= RETIRE_DEADLINE) {
+                revert RetirementOverdue(label);
+            }
+            console2.log(string.concat("BURN-IN [", label, "]: driving the retirement authoring end to end"));
+            script.run();
+            return;
+        }
+
+        // Retired steady state: the orchestrator is the signer's only path.
+        assertFalse(acl.hasRole(keccak256("DEPOSIT"), signer), string.concat(label, ": signer direct DEPOSIT"));
+        assertFalse(acl.hasRole(keccak256("WITHDRAW"), signer), string.concat(label, ": signer direct WITHDRAW"));
+    }
+
+    /// @notice The active chain's authoriser pin (the script's own guard
+    /// covers validation).
+    function activeAuthoriser() internal view returns (address) {
+        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+        }
+        return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+    }
+
+    function testRetireRolloutBase() external {
+        vm.createSelectFork(LibRainDeploy.BASE);
+        assertRetireRollout("base");
+    }
+
+    function testRetireRolloutEthereum() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
+        assertRetireRollout("ethereum");
+    }
+
+    function testRetireRolloutHyperEvm() external {
+        vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
+        assertRetireRollout("hyperevm");
+    }
+}

--- a/test/script/20260831-retire-direct-signer-roles.prod.t.sol
+++ b/test/script/20260831-retire-direct-signer-roles.prod.t.sol
@@ -7,10 +7,13 @@ import {console2} from "forge-std-1.16.1/src/console2.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 
-import {RetireDirectSignerRoles, RETIRE_DEADLINE} from "../../script/20260831-retire-direct-signer-roles.s.sol";
-import {LibOrchestratorInvariants, OrchestratorSetDeployerMissing} from "../../src/lib/LibOrchestratorInvariants.sol";
+import {
+    RetireDirectSignerRoles,
+    RETIRE_DEADLINE,
+    OrchestratorPathNotEnabled
+} from "../../script/20260831-retire-direct-signer-roles.s.sol";
+import {LibOrchestratorInvariants} from "../../src/lib/LibOrchestratorInvariants.sol";
 import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
-import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
 import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
 
@@ -24,41 +27,29 @@ error RetirementOverdue(string label);
 /// @notice PROD coverage for the direct-role retirement: what production IS
 /// on each chain, read from a real fork with no mocks, walking the states:
 ///
-/// 1. **Orchestrator world pending** (every chain today): `run()`'s
-///    pre-flight refuses at the 0.1.30 beacon-set read.
-/// 2. **Burn-in pending** (orchestrator live but path not fully enabled):
+/// 1. **Burn-in pending** (every chain today: orchestrator live, path not
+///    fully enabled):
 ///    the burn-in gate refuses — retirement can never strand a chain
 ///    without a working mint path.
-/// 3. **Burn-in** (path enabled, direct roles still live): drives `run()`
+/// 2. **Burn-in** (path enabled, direct roles still live): drives `run()`
 ///    end to end — revokes authored and simulated, post-state and n+1
-///    proven. The window between states 3 and 4 is DELIBERATE: the
+///    proven. The window between states 2 and 3 is DELIBERATE: the
 ///    fallback path stays until the orchestrator has proven itself.
-/// 4. **Retired**: the signer holds no direct vault roles; asserted
+/// 3. **Retired**: the signer holds no direct vault roles; asserted
 ///    directly.
 ///
-/// States 1–3 stop passing at `RETIRE_DEADLINE` (two weeks after the
-/// enable/fleet deadline, honouring the burn-in); state 4 is steady.
+/// States 1–2 stop passing at `RETIRE_DEADLINE` (two weeks after the
+/// enable/fleet deadline, honouring the burn-in); state 3 is steady.
 contract RetireDirectSignerRolesProdTest is Test {
     /// @notice Walk the active fork's retirement state (see the contract
     /// NatSpec) and assert it.
     /// @param label Human chain name, surfaced in logs and messages.
     function assertRetireRollout(string memory label) internal {
         RetireDirectSignerRoles script = new RetireDirectSignerRoles();
-        address setDeployer = LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30;
         address orchestrator = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
         address signer = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
 
-        if (setDeployer.code.length == 0 || orchestrator.code.length == 0) {
-            if (block.timestamp >= RETIRE_DEADLINE) {
-                revert RetirementOverdue(label);
-            }
-            console2.log(string.concat("PENDING [", label, "]: 0.1.30 orchestrator world not deployed"));
-            vm.expectRevert(abi.encodeWithSelector(OrchestratorSetDeployerMissing.selector, setDeployer));
-            script.run();
-            return;
-        }
-
-        IAccessControl acl = IAccessControl(activeAuthoriser());
+        IAccessControl acl = IAccessControl(LibAuthoriserInvariants.activeChainAuthoriser());
         bool pathEnabled = acl.hasRole(keccak256("DEPOSIT"), orchestrator)
             && acl.hasRole(keccak256("WITHDRAW"), orchestrator)
             && IAccessControl(orchestrator).hasRole(keccak256("MINT"), signer)
@@ -69,7 +60,8 @@ contract RetireDirectSignerRolesProdTest is Test {
             }
             console2.log(string.concat("PENDING [", label, "]: orchestrator path not enabled - retirement gated"));
             console2.log("-> execute 20260831-enable-orchestrator-roles (and its burn-in) first");
-            vm.expectRevert();
+            (address holder, bytes32 role) = firstMissingGrant(acl, orchestrator, signer);
+            vm.expectRevert(abi.encodeWithSelector(OrchestratorPathNotEnabled.selector, holder, role));
             script.run();
             return;
         }
@@ -89,13 +81,17 @@ contract RetireDirectSignerRolesProdTest is Test {
         assertFalse(acl.hasRole(keccak256("WITHDRAW"), signer), string.concat(label, ": signer direct WITHDRAW"));
     }
 
-    /// @notice The active chain's authoriser pin (the script's own guard
-    /// covers validation).
-    function activeAuthoriser() internal view returns (address) {
-        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
-            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
-        }
-        return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+    /// @notice The first (holder, role) the burn-in gate finds missing, in
+    /// the gate's own order.
+    function firstMissingGrant(IAccessControl acl, address orchestrator, address signer)
+        internal
+        view
+        returns (address, bytes32)
+    {
+        if (!acl.hasRole(keccak256("DEPOSIT"), orchestrator)) return (orchestrator, keccak256("DEPOSIT"));
+        if (!acl.hasRole(keccak256("WITHDRAW"), orchestrator)) return (orchestrator, keccak256("WITHDRAW"));
+        if (!IAccessControl(orchestrator).hasRole(keccak256("MINT"), signer)) return (signer, keccak256("MINT"));
+        return (signer, keccak256("BURN"));
     }
 
     function testRetireRolloutBase() external {

--- a/test/script/20260831-retire-direct-signer-roles.prod.t.sol
+++ b/test/script/20260831-retire-direct-signer-roles.prod.t.sol
@@ -28,9 +28,10 @@ error RetirementOverdue(string label);
 /// on each chain, read from a real fork with no mocks, walking the states:
 ///
 /// 1. **Burn-in pending** (every chain today: orchestrator live, path not
-///    fully enabled):
-///    the burn-in gate refuses — retirement can never strand a chain
-///    without a working mint path.
+///    fully enabled): the burn-in gate refuses — retirement can never
+///    strand a chain without a working mint path. The enable bundle is
+///    then applied as the Safe and `run()` driven end to end, so the
+///    retirement is proven against live state before either executes.
 /// 2. **Burn-in** (path enabled, direct roles still live): drives `run()`
 ///    end to end — revokes authored and simulated, post-state and n+1
 ///    proven. The window between states 2 and 3 is DELIBERATE: the
@@ -63,6 +64,23 @@ contract RetireDirectSignerRolesProdTest is Test {
             (address holder, bytes32 role) = firstMissingGrant(acl, orchestrator, signer);
             vm.expectRevert(abi.encodeWithSelector(OrchestratorPathNotEnabled.selector, holder, role));
             script.run();
+
+            // The enable bundle (20260831-enable-orchestrator-roles) applied as
+            // the Safe, so the retirement is proven end to end against live
+            // state before either has executed.
+            console2.log(
+                string.concat("BURN-IN [", label, "]: simulating the enable bundle, then driving the retirement")
+            );
+            address safe = LibSafeInvariants.safeForChainId(block.chainid);
+            vm.startPrank(safe);
+            acl.grantRole(keccak256("DEPOSIT"), orchestrator);
+            acl.grantRole(keccak256("WITHDRAW"), orchestrator);
+            IAccessControl(orchestrator).grantRole(keccak256("MINT"), signer);
+            IAccessControl(orchestrator).grantRole(keccak256("BURN"), signer);
+            vm.stopPrank();
+            script.run();
+            assertFalse(acl.hasRole(keccak256("DEPOSIT"), signer), string.concat(label, ": signer direct DEPOSIT"));
+            assertFalse(acl.hasRole(keccak256("WITHDRAW"), signer), string.concat(label, ": signer direct WITHDRAW"));
             return;
         }
 

--- a/test/script/20260831-retire-direct-signer-roles.prod.t.sol
+++ b/test/script/20260831-retire-direct-signer-roles.prod.t.sol
@@ -46,7 +46,7 @@ contract RetireDirectSignerRolesProdTest is Test {
     /// NatSpec) and assert it.
     /// @param label Human chain name, surfaced in logs and messages.
     function assertRetireRollout(string memory label) internal {
-        RetireDirectSignerRoles script = new RetireDirectSignerRoles();
+        RetireDirectSignerRolesHarness script = new RetireDirectSignerRolesHarness();
         address orchestrator = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
         address signer = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
 
@@ -78,9 +78,14 @@ contract RetireDirectSignerRolesProdTest is Test {
             IAccessControl(orchestrator).grantRole(keccak256("MINT"), signer);
             IAccessControl(orchestrator).grantRole(keccak256("BURN"), signer);
             vm.stopPrank();
+            // The artifact outlives the state revert, so verify() reads it
+            // against the state a signer would see.
+            uint256 preRun = vm.snapshotState();
             script.run();
             assertFalse(acl.hasRole(keccak256("DEPOSIT"), signer), string.concat(label, ": signer direct DEPOSIT"));
             assertFalse(acl.hasRole(keccak256("WITHDRAW"), signer), string.concat(label, ": signer direct WITHDRAW"));
+            vm.revertToState(preRun);
+            script.verify(script.callArtifactPath());
             return;
         }
 

--- a/test/script/20260831-retire-direct-signer-roles.t.sol
+++ b/test/script/20260831-retire-direct-signer-roles.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+
+import {
+    OrchestratorPathNotEnabled,
+    DirectSignerRolesAlreadyRetired,
+    SafeMissingRoleAdminForRetire
+} from "../../script/20260831-retire-direct-signer-roles.s.sol";
+import {RetireDirectSignerRolesHarness} from "./RetireDirectSignerRolesHarness.sol";
+import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
+import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {SafeTx} from "../../src/lib/LibSafeOps.sol";
+
+/// @title RetireDirectSignerRolesTest
+/// @notice Guard coverage for `20260831-retire-direct-signer-roles` without
+/// a fork: the burn-in gate, the `_ADMIN` refusal, the self-scoping, and
+/// the already-retired refusal. The live-fork walk is in
+/// `20260831-retire-direct-signer-roles.prod.t.sol`.
+contract RetireDirectSignerRolesTest is Test {
+    RetireDirectSignerRolesHarness internal harness;
+
+    address internal constant SAFE = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE;
+    address internal constant AUTHORISER = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+    address internal constant ORCHESTRATOR = LibProdDeployV4.ST0X_ORCHESTRATOR_INSTANCE;
+    address internal constant SIGNER = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
+
+    function setUp() external {
+        vm.chainId(LibSafeInvariants.BASE_CHAIN_ID);
+        harness = new RetireDirectSignerRolesHarness();
+        vm.etch(AUTHORISER, hex"fe");
+        vm.etch(ORCHESTRATOR, hex"fe");
+    }
+
+    /// @notice Mock the fully-enabled burn-in state: orchestrator holds both
+    /// vault roles, signer holds both orchestrator roles AND both direct
+    /// vault roles, Safe holds the `_ADMIN`s.
+    function mockBurnInState() internal {
+        vm.mockCall(AUTHORISER, abi.encodeWithSelector(IAccessControl.hasRole.selector), abi.encode(true));
+        vm.mockCall(ORCHESTRATOR, abi.encodeWithSelector(IAccessControl.hasRole.selector), abi.encode(true));
+    }
+
+    /// The burn-in gate refuses when the orchestrator lacks a vault role,
+    /// naming the missing (holder, role) — retiring would strand the chain.
+    function testGateRefusesWhenOrchestratorLacksVaultAccess() external {
+        mockBurnInState();
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("WITHDRAW"), ORCHESTRATOR)), abi.encode(false)
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(OrchestratorPathNotEnabled.selector, ORCHESTRATOR, keccak256("WITHDRAW"))
+        );
+        harness.callAssertOrchestratorPathEnabled(IAccessControl(AUTHORISER), ORCHESTRATOR);
+    }
+
+    /// The burn-in gate refuses when the signer lacks an orchestrator role.
+    function testGateRefusesWhenSignerLacksOrchestratorRole() external {
+        mockBurnInState();
+        vm.mockCall(
+            ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (keccak256("BURN"), SIGNER)), abi.encode(false)
+        );
+        vm.expectRevert(abi.encodeWithSelector(OrchestratorPathNotEnabled.selector, SIGNER, keccak256("BURN")));
+        harness.callAssertOrchestratorPathEnabled(IAccessControl(AUTHORISER), ORCHESTRATOR);
+    }
+
+    /// The fully-enabled state passes the gate.
+    function testGateAcceptsTheEnabledPath() external {
+        mockBurnInState();
+        harness.callAssertOrchestratorPathEnabled(IAccessControl(AUTHORISER), ORCHESTRATOR);
+    }
+
+    /// Authoring refuses when the Safe lacks a needed `_ADMIN`.
+    function testAuthoringRefusesWithoutRoleAdmin() external {
+        mockBurnInState();
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("WITHDRAW_ADMIN"), SAFE)), abi.encode(false)
+        );
+        vm.expectRevert(abi.encodeWithSelector(SafeMissingRoleAdminForRetire.selector, keccak256("WITHDRAW_ADMIN")));
+        harness.callAuthorBundle(AUTHORISER, SAFE);
+    }
+
+    /// The burn-in state authors both revokes in the fixed order.
+    function testAuthoringProducesBothRevokes() external {
+        mockBurnInState();
+        SafeTx[] memory txs = harness.callAuthorBundle(AUTHORISER, SAFE);
+        assertEq(txs.length, 2);
+        assertEq(txs[0].to, AUTHORISER);
+        assertEq(txs[0].data, abi.encodeCall(IAccessControl.revokeRole, (keccak256("DEPOSIT"), SIGNER)));
+        assertEq(txs[1].data, abi.encodeCall(IAccessControl.revokeRole, (keccak256("WITHDRAW"), SIGNER)));
+    }
+
+    /// A half-retired chain self-scopes to the remaining role.
+    function testAuthoringSelfScopesAPartialRetirement() external {
+        mockBurnInState();
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("DEPOSIT"), SIGNER)), abi.encode(false)
+        );
+        SafeTx[] memory txs = harness.callAuthorBundle(AUTHORISER, SAFE);
+        assertEq(txs.length, 1);
+        assertEq(txs[0].data, abi.encodeCall(IAccessControl.revokeRole, (keccak256("WITHDRAW"), SIGNER)));
+    }
+
+    /// A fully-retired chain refuses to author anything.
+    function testAuthoringRefusesWhenAlreadyRetired() external {
+        mockBurnInState();
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("DEPOSIT"), SIGNER)), abi.encode(false)
+        );
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("WITHDRAW"), SIGNER)), abi.encode(false)
+        );
+        vm.expectRevert(DirectSignerRolesAlreadyRetired.selector);
+        harness.callAuthorBundle(AUTHORISER, SAFE);
+    }
+}

--- a/test/script/20260831-retire-direct-signer-roles.t.sol
+++ b/test/script/20260831-retire-direct-signer-roles.t.sol
@@ -116,4 +116,41 @@ contract RetireDirectSignerRolesTest is Test {
         vm.expectRevert(DirectSignerRolesAlreadyRetired.selector);
         harness.callAuthorBundle(AUTHORISER, SAFE);
     }
+
+    /// @notice Mock the retired state: burn-in with both direct vault roles
+    /// gone from the signer.
+    function mockRetiredState() internal {
+        mockBurnInState();
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("DEPOSIT"), SIGNER)), abi.encode(false)
+        );
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("WITHDRAW"), SIGNER)), abi.encode(false)
+        );
+    }
+
+    /// The retired state passes the post-state check.
+    function testPostStateAcceptsTheRetiredState() external {
+        mockRetiredState();
+        harness.callAssertPostRetireState(IAccessControl(AUTHORISER), ORCHESTRATOR, SAFE);
+    }
+
+    /// A signer still holding a direct vault role fails the post-state check.
+    function testPostStateRefusesALingeringDirectRole() external {
+        mockRetiredState();
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("WITHDRAW"), SIGNER)), abi.encode(true)
+        );
+        vm.expectRevert(bytes("RetireDirectSignerRoles: signer still holds a direct vault role"));
+        harness.callAssertPostRetireState(IAccessControl(AUTHORISER), ORCHESTRATOR, SAFE);
+    }
+
+    /// Any other row of the canonical grant map going missing fails the
+    /// post-state check: the retirement touches exactly two rows.
+    function testPostStateRefusesADisturbedUnrelatedGrant() external {
+        mockRetiredState();
+        vm.mockCall(AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("CERTIFY"), SAFE)), abi.encode(false));
+        vm.expectRevert(bytes("RetireDirectSignerRoles: retirement disturbed an unrelated grant"));
+        harness.callAssertPostRetireState(IAccessControl(AUTHORISER), ORCHESTRATOR, SAFE);
+    }
 }

--- a/test/script/EnableOrchestratorRolesHarness.sol
+++ b/test/script/EnableOrchestratorRolesHarness.sol
@@ -3,6 +3,7 @@
 pragma solidity =0.8.25;
 
 import {EnableOrchestratorRoles} from "../../script/20260831-enable-orchestrator-roles.s.sol";
+import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
 import {SafeTx} from "../../src/lib/LibSafeOps.sol";
 
 /// @dev Exposes the script's internals so the guard tests can drive them
@@ -24,6 +25,6 @@ contract EnableOrchestratorRolesHarness is EnableOrchestratorRoles {
 
     /// @notice The script's `activeChainAuthoriser()`, externally callable.
     function callActiveChainAuthoriser() external view returns (address) {
-        return activeChainAuthoriser();
+        return LibAuthoriserInvariants.activeChainAuthoriser();
     }
 }

--- a/test/script/RetireDirectSignerRolesHarness.sol
+++ b/test/script/RetireDirectSignerRolesHarness.sol
@@ -20,4 +20,9 @@ contract RetireDirectSignerRolesHarness is RetireDirectSignerRoles {
     function callAuthorBundle(address authoriser, address safeAddr) external view returns (SafeTx[] memory) {
         return authorBundle(authoriser, safeAddr);
     }
+
+    /// @notice The script's `assertPostRetireState()`, externally callable.
+    function callAssertPostRetireState(IAccessControl acl, address orchestrator, address safeAddr) external view {
+        assertPostRetireState(acl, orchestrator, safeAddr);
+    }
 }

--- a/test/script/RetireDirectSignerRolesHarness.sol
+++ b/test/script/RetireDirectSignerRolesHarness.sol
@@ -25,4 +25,9 @@ contract RetireDirectSignerRolesHarness is RetireDirectSignerRoles {
     function callAssertPostRetireState(IAccessControl acl, address orchestrator, address safeAddr) external view {
         assertPostRetireState(acl, orchestrator, safeAddr);
     }
+
+    /// @notice The script's `artifactPath()`, externally callable.
+    function callArtifactPath() external view returns (string memory) {
+        return artifactPath();
+    }
 }

--- a/test/script/RetireDirectSignerRolesHarness.sol
+++ b/test/script/RetireDirectSignerRolesHarness.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+
+import {RetireDirectSignerRoles} from "../../script/20260831-retire-direct-signer-roles.s.sol";
+import {SafeTx} from "../../src/lib/LibSafeOps.sol";
+
+/// @dev Exposes the script's internals so the guard tests can drive them
+/// directly.
+contract RetireDirectSignerRolesHarness is RetireDirectSignerRoles {
+    /// @notice The script's `assertOrchestratorPathEnabled()`, externally
+    /// callable.
+    function callAssertOrchestratorPathEnabled(IAccessControl acl, address orchestrator) external view {
+        assertOrchestratorPathEnabled(acl, orchestrator);
+    }
+
+    /// @notice The script's `authorBundle()`, externally callable.
+    function callAuthorBundle(address authoriser, address safeAddr) external view returns (SafeTx[] memory) {
+        return authorBundle(authoriser, safeAddr);
+    }
+}


### PR DESCRIPTION
Top of stack: #324 (enable) → #325 (fleet) → #334 (governed beacon set) → this.

The **retire half** of the enable/retire split: `20260831-retire-direct-signer-roles` (`run-script` registry, per chain) revokes the service signer's direct `DEPOSIT`/`WITHDRAW` once the orchestrator has proven itself — closing the parallel burn-in window #324 deliberately opens.

- **Burn-in gate** (`OrchestratorPathNotEnabled`): refuses to author unless the orchestrator holds both vault roles AND the signer holds `MINT`/`BURN` on it — retirement can never strand a chain without a working mint path.
- Untouched: the signer's `CERTIFY` and the Safe's break-glass action roles.
- Own deadline **2026-10-15** — two weeks after the enable/fleet deadline, so the burn-in window is honoured by construction rather than by cron pressure.
- Self-scoping, post-sim row-by-row survival check, n+1 proves the Safe can restore the fallback, signer-side `verify()`, Fireblocks-style post-execution pin lifecycle.

Unit 7/7, prod walk 3/3 (today every chain pins the world/enable-pending refusals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbsbYN4C4YDa8pu9DdudoX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workflow option to retire direct signer permissions.
  * Added a controlled process that revokes direct deposit and withdrawal roles after the orchestrator path is enabled.
  * Added safeguards for missing permissions, incomplete setup, already-retired roles, and unexpected access changes.
  * Added verification of transaction bundles and post-retirement state across Base, Ethereum, and HyperEVM.

* **Tests**
  * Added comprehensive unit and live-fork coverage for rollout, retirement, and safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->