### PR TITLE
Pin the executed orchestrator deploys: EXECUTED markers + hard beacon owner

### DIFF
--- a/script/20260818-deploy-orchestrator.s.sol
+++ b/script/20260818-deploy-orchestrator.s.sol
@@ -41,7 +41,12 @@ error InstanceAddressMismatch(address expected, address actual);
 error DeployKeyHoldsAdmin(address instance, address deployer);
 
 /// @title DeployOrchestrator
-/// @notice **PENDING.** Deploys the production `ST0xOrchestrator` instance on
+/// @notice **EXECUTED 2026-08-28** on Base, Ethereum and HyperEVM (three
+/// `manual-broadcast` dispatches; the instance is live at its pin on every
+/// chain with that chain's token-owner Safe holding `DEFAULT_ADMIN_ROLE`).
+/// Re-dispatch refuses `OrchestratorAlreadyDeployed`.
+///
+/// Deploys the production `ST0xOrchestrator` instance on
 /// whichever chain this is dispatched against and lands its
 /// `DEFAULT_ADMIN_ROLE` on that chain's token-owner Safe — one deploy-key
 /// broadcast, no Safe signature.

--- a/script/20260818-migrate-orchestrator-beacon-owner.s.sol
+++ b/script/20260818-migrate-orchestrator-beacon-owner.s.sol
@@ -14,7 +14,12 @@ import {LibOrchestratorInvariants} from "../src/lib/LibOrchestratorInvariants.so
 import {LibSafeOps} from "../src/lib/LibSafeOps.sol";
 
 /// @title MigrateOrchestratorBeaconOwner
-/// @notice **PENDING.** Transfers ownership of the ST0x orchestrator beacon
+/// @notice **EXECUTED 2026-09-04** on Base (tx
+/// 0x73f7017d08502fdf16e1fbb0794c26f095c19bb87707b6d61c0260e09d9101cd),
+/// Ethereum and HyperEVM — the beacon reports each chain's token-owner
+/// Safe as owner. Re-running reverts at the owner pre-flight.
+///
+/// Transfers ownership of the ST0x orchestrator beacon
 /// (`LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON`) on whichever chain
 /// this is broadcast against, from the deploy EOA
 /// (`LibProdDeployV4.BEACON_INITIAL_OWNER`, rainlang.eth) to that chain's
@@ -43,7 +48,7 @@ import {LibSafeOps} from "../src/lib/LibSafeOps.sol";
 /// (`20260818-deploy-orchestrator`): beacon ownership gates `upgradeTo`,
 /// not `deploy()`. The live-fork invariant
 /// (`LibOrchestratorInvariants.assertBeaconSet`) accepts either owner until
-/// `ST0X_ORCHESTRATOR_BEACON_OWNER_MIGRATION_DEADLINE` and only the Safe
+/// executed end-state (Safe-owned) and only the Safe
 /// after it, so cron red-lines any chain this migration misses.
 ///
 /// The flow is the beacon-owner-migration standard shape:

--- a/src/lib/LibOrchestratorInvariants.sol
+++ b/src/lib/LibOrchestratorInvariants.sol
@@ -6,7 +6,6 @@ import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
 import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 import {LibProdDeployV4} from "../generated/LibProdDeployV4.sol";
-import {LibMigrationInvariant} from "./LibMigrationInvariant.sol";
 import {IST0xOrchestratorV1} from "../interface/IST0xOrchestratorV1.sol";
 
 /// @notice The orchestrator beacon-set deployer has no runtime code at its
@@ -25,6 +24,14 @@ error OrchestratorBeaconMismatch(address expected, address actual);
 /// @param expected The pinned 0.1.30 implementation.
 /// @param actual The implementation the beacon reports.
 error OrchestratorBeaconImplMismatch(address expected, address actual);
+
+/// @notice The orchestrator beacon's owner is not the chain's token-owner
+/// Safe. The `20260818-migrate-orchestrator-beacon-owner` migration
+/// executed on every chain (2026-09-04), so any other owner — including a
+/// transfer back to the deploy EOA — is unsanctioned drift.
+/// @param expected The chain's token-owner Safe.
+/// @param actual The owner the beacon reports.
+error OrchestratorBeaconOwnerMismatch(address expected, address actual);
 
 /// @notice The pinned orchestrator instance has no runtime code on the
 /// active chain.
@@ -75,21 +82,12 @@ library LibOrchestratorInvariants {
     /// of truth, emitted by `BuildPointers`).
     address internal constant ST0X_ORCHESTRATOR_INSTANCE = LibProdDeployV4.ST0X_ORCHESTRATOR_INSTANCE;
 
-    /// @notice Unix timestamp (2026-10-01T00:00:00Z) by which
-    /// `20260818-migrate-orchestrator-beacon-owner` must have moved the
-    /// orchestrator beacon's owner from the deploy EOA to the chain's
-    /// token-owner Safe. Until then either owner passes; after it only the
-    /// Safe does (see `LibMigrationInvariant`).
-    uint256 internal constant ST0X_ORCHESTRATOR_BEACON_OWNER_MIGRATION_DEADLINE = 1_790_812_800;
-
     /// @notice Assert the orchestrator beacon set on the active chain: the
     /// 0.1.30 beacon-set deployer is live, reports the pinned beacon, and the
-    /// beacon points at the audited 0.1.30 orchestrator implementation. The
-    /// beacon's owner is asserted through the owner-migration window: the
-    /// deploy EOA (`BEACON_INITIAL_OWNER`, pre) or `chainSafe` (post) until
-    /// the migration deadline, only `chainSafe` after it.
-    /// @param chainSafe The chain's token-owner Safe — the post-migration
-    /// beacon owner.
+    /// beacon points at the audited 0.1.30 orchestrator implementation
+    /// under the chain's token-owner Safe (the executed
+    /// `20260818-migrate-orchestrator-beacon-owner` end-state).
+    /// @param chainSafe The chain's token-owner Safe — the beacon owner.
     function assertBeaconSet(address chainSafe) internal view {
         address setDeployer = LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30;
         if (setDeployer.code.length == 0) {
@@ -106,13 +104,10 @@ library LibOrchestratorInvariants {
             revert OrchestratorBeaconImplMismatch(LibProdDeployV4.ST0X_ORCHESTRATOR_0_1_30, impl);
         }
 
-        LibMigrationInvariant.assertMigration(
-            "ST0X_ORCHESTRATOR_BEACON.owner()",
-            Ownable(beacon).owner(),
-            LibProdDeployV4.BEACON_INITIAL_OWNER,
-            chainSafe,
-            ST0X_ORCHESTRATOR_BEACON_OWNER_MIGRATION_DEADLINE
-        );
+        address owner = Ownable(beacon).owner();
+        if (owner != chainSafe) {
+            revert OrchestratorBeaconOwnerMismatch(chainSafe, owner);
+        }
     }
 
     /// @notice Assert the pinned orchestrator instance on the active chain:

--- a/test/script/20260818-deploy-orchestrator.t.sol
+++ b/test/script/20260818-deploy-orchestrator.t.sol
@@ -15,11 +15,11 @@ import {
 } from "../../script/20260818-deploy-orchestrator.s.sol";
 import {DeployOrchestratorHarness} from "./DeployOrchestratorHarness.sol";
 import {ClosureNotDeployed, ClosureCodehashMismatch} from "../../src/lib/LibClosureInvariants.sol";
-import {MigrationStateDrift} from "../../src/lib/LibMigrationInvariant.sol";
 import {
     LibOrchestratorInvariants,
     ST0xOrchestratorBeaconSetDeployerLike,
-    OrchestratorAdminMissing
+    OrchestratorAdminMissing,
+    OrchestratorBeaconOwnerMismatch
 } from "../../src/lib/LibOrchestratorInvariants.sol";
 import {IST0xOrchestratorV1} from "../../src/interface/IST0xOrchestratorV1.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
@@ -74,9 +74,7 @@ contract DeployOrchestratorTest is Test {
             abi.encode(LibProdDeployV4.ST0X_ORCHESTRATOR_0_1_30)
         );
         vm.mockCall(
-            LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON,
-            abi.encodeCall(Ownable.owner, ()),
-            abi.encode(LibProdDeployV4.BEACON_INITIAL_OWNER)
+            LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON, abi.encodeCall(Ownable.owner, ()), abi.encode(SAFE)
         );
         vm.etch(LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON, hex"fe");
     }
@@ -228,36 +226,20 @@ contract DeployOrchestratorTest is Test {
         harness.assertDeployLanded(LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE, SAFE, DEPLOY_KEY);
     }
 
-    /// The beacon-owner invariant accepts the post-migration state too: a
-    /// beacon already owned by the Safe (after
-    /// `20260818-migrate-orchestrator-beacon-owner`) passes.
-    function testLandedAcceptsASafeOwnedBeacon() external {
-        mockBeaconSet();
-        mockLandedInstance();
-        vm.mockCall(
-            LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON, abi.encodeCall(Ownable.owner, ()), abi.encode(SAFE)
-        );
-        harness.assertDeployLanded(LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE, SAFE, DEPLOY_KEY);
-    }
-
-    /// A beacon owner that is neither the deploy EOA nor the Safe is
-    /// migration-state drift, before or after the deadline.
-    function testLandedRefusesADriftedBeaconOwner() external {
+    /// The beacon-owner migration is EXECUTED (2026-09-04): only the
+    /// chain's Safe passes as beacon owner. A transfer back to the deploy
+    /// EOA — the accepted pre-state during the migration window — now
+    /// refuses like any other drift.
+    function testLandedRefusesANonSafeBeaconOwner() external {
         mockBeaconSet();
         mockLandedInstance();
         vm.mockCall(
             LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON,
             abi.encodeCall(Ownable.owner, ()),
-            abi.encode(address(0xBAD))
+            abi.encode(LibProdDeployV4.BEACON_INITIAL_OWNER)
         );
         vm.expectRevert(
-            abi.encodeWithSelector(
-                MigrationStateDrift.selector,
-                "ST0X_ORCHESTRATOR_BEACON.owner()",
-                bytes32(uint256(uint160(LibProdDeployV4.BEACON_INITIAL_OWNER))),
-                bytes32(uint256(uint160(SAFE))),
-                bytes32(uint256(uint160(address(0xBAD))))
-            )
+            abi.encodeWithSelector(OrchestratorBeaconOwnerMismatch.selector, SAFE, LibProdDeployV4.BEACON_INITIAL_OWNER)
         );
         harness.assertDeployLanded(LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE, SAFE, DEPLOY_KEY);
     }


### PR DESCRIPTION
The 20260818 pair executed on all three chains: the instance deploys
via manual-broadcast on 2026-08-28 and the beacon-owner migration as
the deploy EOA on 2026-09-04 (Base tx 0x73f7017d...01cd; Ethereum and
HyperEVM verified by live owner reads - each chain's token-owner Safe
now owns the orchestrator beacon).

Per the dated-script lifecycle: both scripts flip PENDING -> EXECUTED,
and the beacon-owner acceptance window collapses to the executed
end-state - LibOrchestratorInvariants.assertBeaconSet now hard-requires
the chain Safe (new OrchestratorBeaconOwnerMismatch), so a transfer
back to the deploy EOA red-lines immediately instead of passing until
the migration deadline. Unit mocks and the owner-drift test move to the
executed world; the prod walks flipped state on their own (orchestrator
rollout in executed steady state on all chains, fleet walk now clean
of the ownership gate and proving 41 tokens state-preserving per
chain).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KbsbYN4C4YDa8pu9DdudoX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Orchestrator deployments on Base, Ethereum, and HyperEVM are now documented as live.
  - Token-owner Safes are confirmed as administrators and beacon owners across supported chains.
  - Re-dispatching an already deployed orchestrator is refused.
  - Beacon configuration checks now reject any owner other than the designated token-owner Safe.
- **Documentation**
  - Deployment and ownership migration records now include execution dates, transaction details, and final ownership status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->