### PR TITLE
ci: manual-sol-verify dispatcher for already-deployed contracts

### DIFF
--- a/.github/workflows/manual-sol-artifacts-0-1-1.yaml
+++ b/.github/workflows/manual-sol-artifacts-0-1-1.yaml
@@ -55,7 +55,7 @@ jobs:
       script: script/DeployProdV4_0_1_1.sol:Deploy
       # The 0.1.1 bytecode of the contracts that changed by 0.1.3 does not match
       # current source, so Etherscan verification against current source would
-      # fail the run. Deploy unverified; verify by dispatching `manual-sol-verify.yaml` on the 0.1.1 tag.
+      # fail the run. Deploy unverified; verify by dispatching `manual-sol-verify.yaml` on the v0.1.1 tag.
       verify: false
     # Runs unverified, so it needs only the deployer key and an RPC for every
     # network in LibStoxDeployNetworks.deploymentNetworks. The reusable

--- a/.github/workflows/manual-sol-artifacts-0-1-1.yaml
+++ b/.github/workflows/manual-sol-artifacts-0-1-1.yaml
@@ -55,7 +55,7 @@ jobs:
       script: script/DeployProdV4_0_1_1.sol:Deploy
       # The 0.1.1 bytecode of the contracts that changed by 0.1.3 does not match
       # current source, so Etherscan verification against current source would
-      # fail the run. Deploy unverified; verify manually from the 0.1.1 tag.
+      # fail the run. Deploy unverified; verify by dispatching `manual-sol-verify.yaml` on the 0.1.1 tag.
       verify: false
     # Runs unverified, so it needs only the deployer key and an RPC for every
     # network in LibStoxDeployNetworks.deploymentNetworks. The reusable

--- a/.github/workflows/manual-sol-artifacts-0-1-30.yaml
+++ b/.github/workflows/manual-sol-artifacts-0-1-30.yaml
@@ -56,7 +56,7 @@ jobs:
       script: script/DeployProdV4_0_1_30.sol:Deploy
       # The current source diverged from 0.1.30 (H01 remediation + optimizer
       # change), so Etherscan verification against current source would fail
-      # the run. Deploy unverified; verify manually from the sol-v0.1.30 tag.
+      # the run. Deploy unverified; verify by dispatching `manual-sol-verify.yaml` on the sol-v0.1.30 tag.
       verify: false
     # Runs unverified, so it needs only the deployer key and an RPC for every
     # network in LibStoxDeployNetworks.deploymentNetworks. The reusable

--- a/.github/workflows/manual-sol-verify.yaml
+++ b/.github/workflows/manual-sol-verify.yaml
@@ -2,7 +2,8 @@ name: Manual sol verify
 # Explorer source verification for a contract already on chain. Dispatch it
 # on the ref whose source built the bytecode (the release tag), never on
 # main: `forge verify-contract` compiles the checked-out source with the
-# checked-out `foundry.toml`.
+# checked-out `foundry.toml`. A tag cut before this file existed cannot be
+# dispatched directly: branch off it, add this file, dispatch the branch.
 permissions:
   contents: read
 on:

--- a/.github/workflows/manual-sol-verify.yaml
+++ b/.github/workflows/manual-sol-verify.yaml
@@ -1,0 +1,42 @@
+name: Manual sol verify
+# Explorer source verification for a contract already on chain. Dispatch it
+# on the ref whose source built the bytecode (the release tag), never on
+# main: `forge verify-contract` compiles the checked-out source with the
+# checked-out `foundry.toml`.
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+    inputs:
+      contract:
+        description: 'Fully qualified artifact, e.g. src/concrete/StoxReceiptVault.sol:StoxReceiptVault'
+        required: true
+        type: string
+      address:
+        description: 'Deployed address (Zoltu: one address on every network)'
+        required: true
+        type: string
+      networks:
+        description: 'Whitespace separated foundry chain ids or names'
+        required: true
+        type: string
+        default: '8453 1 999'
+jobs:
+  verify:
+    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-verify.yaml@main
+    with:
+      contract: ${{ inputs.contract }}
+      address: ${{ inputs.address }}
+      networks: ${{ inputs.networks }}
+    # Cross-org caller: `secrets: inherit` does not reach a reusable in another
+    # org, so every explorer key is passed by name.
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      EXPLORER_VERIFICATION_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
+      CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY }}
+      CI_DEPLOY_BASE_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_BASE_ETHERSCAN_API_KEY }}
+      CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY }}
+      CI_DEPLOY_ETHEREUM_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_ETHEREUM_ETHERSCAN_API_KEY }}
+      CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY }}
+      CI_DEPLOY_HYPEREVM_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_HYPEREVM_ETHERSCAN_API_KEY }}
+      CI_DEPLOY_FLARE_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_FLARE_ETHERSCAN_API_KEY }}


### PR DESCRIPTION
Every contract of the 0.1.30 set is unverified on base, ethereum and hyperevm (the beacon impl behind e.g. https://basescan.org/address/0x8Fdf41116F755771Bfe0747D5F8C3711D5DEbfBb is `StoxReceiptVault` 0x52174538…20C7). Both artifact workflows ship `verify: false` with a note to verify from the tag by hand, and nothing in the repo could do that.

This adds a `workflow_dispatch` caller for `rainix-manual-sol-verify` (contract, address, networks) and points the two notes at it. Dispatch it on the release tag's ref so the compiled source matches the bytecode; the same file sits on `2026-09-08-verify-0-1-30` (= `sol-v0.1.30` + this workflow) for the pending 0.1.30 run.

Blocker for the actual run, not for this PR: the org's `CI_DEPLOY_BASE_ETHERSCAN_API_KEY` is a free-tier key that Etherscan V2 rejects for Base ("Free API access is not supported for this chain", run 31402725235), and there is no ethereum/hyperevm key. A paid Etherscan V2 key as `EXPLORER_VERIFICATION_KEY` covers all three.

## QA
- Discriminating tests: n/a - workflow-only diff, no Solidity or test source changes; the proof is the dispatched run on `2026-09-08-verify-0-1-30` linked in the PR comments
- Mutations applied: n/a - no executable source in the diff
- Oracle: `rainix-manual-sol-verify.yaml` input/secret contract at rainix `main`, and the explorer's verification status for the submitted address
- Category check: the gap is "no way to verify an already-deployed contract from its tag"; covered by the dispatcher plus the two note edits that route operators to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oPVApdKM7RogDWJHYSq4N


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered verification workflow for deployed contract artifacts.
  - Supports verification across specified networks using contract artifacts, deployed addresses, and configured explorer credentials.

- **Documentation**
  - Updated deployment workflow guidance to direct verification through the manual verification workflow for relevant release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->