### PR TITLE
Drop the PENDING / EXECUTED status markers from script NatSpec

### DIFF
--- a/.github/workflows/manual-broadcast.yaml
+++ b/.github/workflows/manual-broadcast.yaml
@@ -27,9 +27,10 @@ on:
           # Each entry is the date-prefixed filename (without `.s.sol`) of a
           # broadcast script under `script/`. Convention:
           # `YYYYMMDD-<kebab-name>`, where the date is the day the script was
-          # added to this dropdown. Execution status (PENDING / EXECUTED)
-          # lives in the script's file-level NatSpec — this dropdown is a
-          # registry of *which* scripts exist, not *whether* they've run.
+          # added to this dropdown. Whether a script has run is the chain's
+          # record (executed scripts refuse re-dispatch in pre-flight, and
+          # pins record what landed) — this dropdown is a registry of *which*
+          # scripts exist, not *whether* they've run.
           - 20260619-deploy-v4-authoriser-clone
           - 20260706-deploy-tokens-ethereum
           - 20260807-deploy-missing-tokens

--- a/.github/workflows/run-script.yaml
+++ b/.github/workflows/run-script.yaml
@@ -15,10 +15,10 @@ on:
           # Each entry is the date-prefixed filename (without `.s.sol`) of a
           # Safe Tx Builder JSON emitting script under `script/`. Convention:
           # `YYYYMMDD-<kebab-name>`, where the date is the day the script was
-          # added to this dropdown. Execution status (PENDING / EXECUTED +
-          # SafeTxHash) lives in the script's file-level NatSpec — this
-          # dropdown is a registry of *which* scripts exist, not *whether*
-          # they've run.
+          # added to this dropdown. Whether a script has run is the chain's
+          # record (executed scripts refuse re-dispatch in pre-flight), not
+          # anything written here — this dropdown is a registry of *which*
+          # scripts exist, not *whether* they've run.
           #
           # Broadcast scripts (dispatched with `--broadcast` from the CI
           # deploy key) live in `manual-broadcast.yaml` instead. The

--- a/docs/TIMELOCK.md
+++ b/docs/TIMELOCK.md
@@ -125,8 +125,7 @@ timelocks live.
    to cross-check in the Safe UI. Then execute. The bundle is atomic: 7 `_ADMIN`
    grants to the timelock → N vault `transferOwnership` → 3 beacon
    `transferOwnership` → 7 Safe renounces.
-5. **Post-execution flip PR** — mark the migration script
-   `**EXECUTED YYYY-MM-DD.**`, repoint the strict uniform-ownership invariants
+5. **Post-execution flip PR** — repoint the strict uniform-ownership invariants
    (`LibInvariants.assertAll`, `LibTokenInvariants` consumers,
    `StoxProdV2`/`LibInvariants` fork tests, cross-chain parity, and the
    Safe-expecting beacon-owner asserts — the `StoxProdV4` and

--- a/script/20260623-upgrade-receipt-vaults-to-v4.s.sol
+++ b/script/20260623-upgrade-receipt-vaults-to-v4.s.sol
@@ -68,7 +68,7 @@ error V4AuthoriserCloneExpectedGrantMissing(address clone, bytes32 role, address
 error VaultAuthoriserMismatchPostUpgrade(address vault, address expected, address actual);
 
 /// @title UpgradeReceiptVaultsToV4
-/// @notice **PENDING.** Forge script that authors the receipt-vault V4
+/// @notice Forge script that authors the receipt-vault V4
 /// upgrade plus the authoriser swap onto the corporate-action-aware V4
 /// clone. Dispatch via `Actions → run-script` with
 /// `script = 20260623-upgrade-receipt-vaults-to-v4` and `sig = run()` once

--- a/script/20260706-deploy-tokens-ethereum.s.sol
+++ b/script/20260706-deploy-tokens-ethereum.s.sol
@@ -82,11 +82,10 @@ error AuthoriserNotWired(address receiptVault, address expected, address actual)
 error EthereumSafeNotReady(address safe);
 
 /// @title DeployTokensEthereum
-/// @notice **PENDING.** Deploys the full ST0x production token set on Ethereum
+/// @notice Deploys the full ST0x production token set on Ethereum
 /// mainnet, matched to Base, wires each vault onto the V4 authoriser
 /// authoriser, and hands ownership to the token-owner Safe — all in a single
-/// deploy-key broadcast, no Safe signature. Flips to `**EXECUTED YYYY-MM-DD.**`
-/// in the post-execution pin PR.
+/// deploy-key broadcast, no Safe signature.
 /// @dev Single operation (`run()`), broadcast from the CI deploy key via
 /// `manual-broadcast.yaml`. Mirrors the authoriser deploy pattern (20260619): the
 /// deploy key deploys, configures, then self-relinquishes — the Safe signs

--- a/script/20260722-migrate-beacon-owners-hyperevm.s.sol
+++ b/script/20260722-migrate-beacon-owners-hyperevm.s.sol
@@ -11,9 +11,7 @@ import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
 import {LibBeaconInvariants} from "../src/lib/LibBeaconInvariants.sol";
 
 /// @title MigrateBeaconOwnersHyperEvm
-/// @notice **EXECUTED 2026-07-24** (broadcast from the deploy EOA's CLI;
-/// all three beacons verified Safe-owned with implementations unchanged).
-/// Transfers ownership of the three ST0x production
+/// @notice Transfers ownership of the three ST0x production
 /// beacons on **HyperEVM** (chain id 999) from the deploy EOA
 /// (`LibProdDeployV1.BEACON_INITIAL_OWNER`, rainlang.eth) to the HyperEVM
 /// token-owner Safe (`LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_HYPEREVM`).

--- a/script/20260722-swap-remaining-vault-authorisers.s.sol
+++ b/script/20260722-swap-remaining-vault-authorisers.s.sol
@@ -47,7 +47,7 @@ error SwapCloneCodehashMismatch(address clone, bytes32 expected, bytes32 actual)
 error SwapCloneExpectedGrantMissing(address clone, bytes32 role, address grantee);
 
 /// @title SwapRemainingVaultAuthorisers
-/// @notice **EXECUTED — verified 2026-07-23.** Authors the Safe bundle that
+/// @notice Authors the Safe bundle that
 /// swaps every production receipt vault still gated by the V3 authoriser onto
 /// the V4 authoriser clone (`LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE`).
 /// Dispatch via `Actions → run-script` with

--- a/script/20260722-swap-rklb-authoriser.s.sol
+++ b/script/20260722-swap-rklb-authoriser.s.sol
@@ -44,7 +44,7 @@ error RklbSwapAuthoriserCodehashMismatch(address authoriser, bytes32 expected, b
 error RklbSwapAuthoriserGrantMissing(address authoriser, bytes32 role, address grantee);
 
 /// @title SwapRklbAuthoriser
-/// @notice **EXECUTED 2026-07-23.** Authored the SINGLE-tx Safe bundle that
+/// @notice Authored the SINGLE-tx Safe bundle that
 /// swapped the RKLB receipt vault onto the V4 authoriser
 /// (`LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE`), and the Safe executed
 /// it. `0xf6744Fd94e27c2f58F6110aa9fDC77A87e41766B` now reports

--- a/script/20260723-provision-additional-service-signer.s.sol
+++ b/script/20260723-provision-additional-service-signer.s.sol
@@ -33,10 +33,9 @@ error UnsupportedChainForProvisioning(uint256 chainId);
 error SafeMissingRoleAdmin(bytes32 adminRole);
 
 /// @title ProvisionAdditionalServiceSigner
-/// @notice **EXECUTED — verified 2026-08-05 (Base and Ethereum).** Authors
-/// the Safe bundle that provisions the ADDITIONAL service signer
-/// (`LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C`) on the ACTIVE chain's
-/// V4 authoriser with the canonical post-ceremony grants
+/// @notice Authors the Safe bundle that provisions the ADDITIONAL service
+/// signer (`LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C`) on the ACTIVE
+/// chain's V4 authoriser with the canonical post-ceremony grants
 /// (`additionalServiceGrants()`: `DEPOSIT` / `WITHDRAW` / `CERTIFY` — the
 /// same three action roles the original service signer holds; both signers
 /// are active side by side, nothing is revoked). Dispatch via

--- a/script/20260729-deploy-governance-timelock.s.sol
+++ b/script/20260729-deploy-governance-timelock.s.sol
@@ -58,7 +58,7 @@ error TimelockAddressMismatch(address expected, address actual);
 error DeployerHoldsTimelockRole(bytes32 role, address deployer);
 
 /// @title DeployGovernanceTimelock
-/// @notice **PENDING.** Broadcast script that deploys the ST0x governance
+/// @notice Broadcast script that deploys the ST0x governance
 /// timelock — an unmodified, pre-audited OZ `TimelockController` — on the
 /// active chain via the Zoltu deterministic factory, configured entirely by
 /// its constructor:

--- a/script/20260729-migrate-governance-to-timelock.s.sol
+++ b/script/20260729-migrate-governance-to-timelock.s.sol
@@ -122,7 +122,7 @@ struct MigrationTargets {
 error GovernanceLoopNotProven(bytes32 id);
 
 /// @title MigrateGovernanceToTimelock
-/// @notice **PENDING.** Authors the Safe bundle that hands ST0x governance
+/// @notice Authors the Safe bundle that hands ST0x governance
 /// on the active chain to the governance timelock:
 ///
 ///   1. Grants each of the authoriser's seven `_ADMIN` roles to the

--- a/script/20260813-execute-timelock-operations.s.sol
+++ b/script/20260813-execute-timelock-operations.s.sol
@@ -31,7 +31,7 @@ error OperationNotExecutable(bytes32 id, bool pending, bool ready, bool done);
 error ExecutorHoldsRole(address timelock, address executor);
 
 /// @title ExecuteTimelockOperations
-/// @notice **PENDING.** Executes a matured timelock operation from the CI
+/// @notice Executes a matured timelock operation from the CI
 /// deploy key.
 ///
 /// This is deliberately NOT a Safe-routed script. The timelock grants

--- a/script/20260813-timelock-rehearsal-cancel.s.sol
+++ b/script/20260813-timelock-rehearsal-cancel.s.sol
@@ -23,7 +23,7 @@ error CancelTimelockNotPinned(uint256 chainId);
 error RehearsalNotScheduled(bytes32 id);
 
 /// @title TimelockRehearsalCancel
-/// @notice **PENDING.** Authors the Safe bundle that CANCELS the scheduled
+/// @notice Authors the Safe bundle that CANCELS the scheduled
 /// timelock rehearsal — see `LibTimelockRehearsal` for the operation.
 ///
 /// This is the stage that demonstrates the veto: a scheduled operation can be

--- a/script/20260813-timelock-rehearsal-schedule.s.sol
+++ b/script/20260813-timelock-rehearsal-schedule.s.sol
@@ -31,7 +31,7 @@ error RehearsalAlreadyScheduled(bytes32 id);
 error RehearsalChangedMinDelay(uint256 expected, uint256 actual);
 
 /// @title TimelockRehearsalSchedule
-/// @notice **PENDING.** Authors the Safe bundle that SCHEDULES the timelock
+/// @notice Authors the Safe bundle that SCHEDULES the timelock
 /// rehearsal no-op — see `LibTimelockRehearsal` for what the operation is and
 /// why it was chosen.
 ///

--- a/script/20260818-deploy-orchestrator.s.sol
+++ b/script/20260818-deploy-orchestrator.s.sol
@@ -41,7 +41,7 @@ error InstanceAddressMismatch(address expected, address actual);
 error DeployKeyHoldsAdmin(address instance, address deployer);
 
 /// @title DeployOrchestrator
-/// @notice **PENDING.** Deploys the production `ST0xOrchestrator` instance on
+/// @notice Deploys the production `ST0xOrchestrator` instance on
 /// whichever chain this is dispatched against and lands its
 /// `DEFAULT_ADMIN_ROLE` on that chain's token-owner Safe — one deploy-key
 /// broadcast, no Safe signature.

--- a/script/20260818-migrate-orchestrator-beacon-owner.s.sol
+++ b/script/20260818-migrate-orchestrator-beacon-owner.s.sol
@@ -14,7 +14,7 @@ import {LibOrchestratorInvariants} from "../src/lib/LibOrchestratorInvariants.so
 import {LibSafeOps} from "../src/lib/LibSafeOps.sol";
 
 /// @title MigrateOrchestratorBeaconOwner
-/// @notice **PENDING.** Transfers ownership of the ST0x orchestrator beacon
+/// @notice Transfers ownership of the ST0x orchestrator beacon
 /// (`LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON`) on whichever chain
 /// this is broadcast against, from the deploy EOA
 /// (`LibProdDeployV4.BEACON_INITIAL_OWNER`, rainlang.eth) to that chain's

--- a/script/20260825-upgrade-fleet-to-0-1-30.s.sol
+++ b/script/20260825-upgrade-fleet-to-0-1-30.s.sol
@@ -42,7 +42,7 @@ error FleetAlreadyUpgraded();
 error UpgradeChangedTokenState(address receiptVault);
 
 /// @title UpgradeFleetTo0_1_30
-/// @notice **PENDING.** Authors the per-chain Safe Tx Builder bundle that
+/// @notice Authors the per-chain Safe Tx Builder bundle that
 /// upgrades the production token fleet to the audited 0.1.30
 /// implementations — one atomic MultiSend repointing the chain's IN-USE
 /// receipt beacon and receipt-vault beacon (`upgradeTo`) from the audited

--- a/script/20260831-enable-orchestrator-roles.s.sol
+++ b/script/20260831-enable-orchestrator-roles.s.sol
@@ -43,7 +43,7 @@ error SafeNotOrchestratorAdmin(address orchestrator);
 error OrchestratorRolesAlreadyEnabled();
 
 /// @title EnableOrchestratorRoles
-/// @notice **PENDING.** Authors the per-chain Safe Tx Builder bundle that
+/// @notice Authors the per-chain Safe Tx Builder bundle that
 /// ENABLES the orchestrator mint/burn path, as ONE atomic MultiSend:
 ///
 ///  1. authoriser `grantRole(DEPOSIT, orchestrator)` and

--- a/script/20260831-retire-direct-signer-roles.s.sol
+++ b/script/20260831-retire-direct-signer-roles.s.sol
@@ -39,7 +39,7 @@ error SafeMissingRoleAdminForRetire(bytes32 adminRole);
 error DirectSignerRolesAlreadyRetired();
 
 /// @title RetireDirectSignerRoles
-/// @notice **PENDING.** Authors the per-chain Safe Tx Builder bundle that
+/// @notice Authors the per-chain Safe Tx Builder bundle that
 /// closes the parallel burn-in window opened by
 /// `20260831-enable-orchestrator-roles`: revoke the service signer's DIRECT
 /// `DEPOSIT` and `WITHDRAW` on the authoriser, leaving the orchestrator as


### PR DESCRIPTION
The execution-status marker (`**PENDING.**` / `**EXECUTED <date>**`) at the head of each operational script's file-level `@notice` restated chain state in prose, and rotted: `20260623-upgrade-receipt-vaults-to-v4`, `20260706-deploy-tokens-ethereum`, `20260729-deploy-governance-timelock` and `20260825-upgrade-fleet-to-0-1-30` all read PENDING while executed on chain. The chain is the record — executed scripts refuse re-dispatch in pre-flight with typed errors, and pins record deploys — so this removes the markers and the convention rather than refreshing them.

- Strips the marker, and any sentence whose only content was its lifecycle, from the 17 scripts that carried one. All behavioural and design prose stays; no new comments.
- Rewrites the one sentence in `run-script.yaml` and `manual-broadcast.yaml` that said execution status lives in the NatSpec.
- Drops the marker-flip clause from the `docs/TIMELOCK.md` post-execution step; the invariant-repoint instruction stays.
- No Solidity code changes. `test/src/concrete/StoxReceiptVaultFallbackRouting.t.sol` is untouched (its `PENDING` is the completion-filter enum, unrelated).

Conflict note: #338 flips the same `@notice` lines in `script/20260818-deploy-orchestrator.s.sol` and `script/20260818-migrate-orchestrator-beacon-owner.s.sol` to `EXECUTED`; whichever lands second takes a one-line conflict per file, resolved by keeping the marker-free line.

## QA
- Discriminating tests: n/a — the diff touches only `///` NatSpec lines, YAML comments and Markdown; no behaviour changes, so no test can discriminate base from head. Verified by `git diff -U0 -- script | grep '^[-+]' | grep -v '^[-+]///'` returning nothing.
- Mutations applied: n/a — docs-only diff, no executable lines to mutate.
- Oracle: n/a for test values. The claim that the four scripts named above read PENDING while executed is checked against `main` at 7edf9dd (marker text) and the repo's own pins/pre-flight guards for those scripts.
- Category check: ruling asks (A) remove markers + convention from every script, (B) rewrite the two workflow sentences, (C) drop the TIMELOCK.md flip clause keeping the invariant repoint, (D) remove other mentions in docs/CLAUDE.md/README, (E) no Solidity code changes; covered A (17 scripts, residual grep empty), B, C, E; D had no further hits (CLAUDE.md and README carry no mention of the convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oPVApdKM7RogDWJHYSq4N


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that workflow selections list available scripts, while execution status is determined by on-chain records.
  - Updated rollout guidance to reflect post-execution ownership and invariant changes.
  - Revised deployment and migration script descriptions by removing outdated pending or execution-status labels.
  - No functional behavior or executable logic was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->