### PR TITLE
Pin the Robinhood Chain and BNB Smart Chain token-owner Safes and governance timelocks

### DIFF
--- a/src/lib/LibSafeInvariants.sol
+++ b/src/lib/LibSafeInvariants.sol
@@ -197,6 +197,9 @@ library LibSafeInvariants {
     /// @notice HyperEVM mainnet chain id.
     uint256 internal constant HYPEREVM_CHAIN_ID = 999;
 
+    /// @notice Robinhood Chain mainnet chain id.
+    uint256 internal constant ROBINHOOD_CHAIN_ID = 4663;
+
     /// @notice The ST0x token-owner Safe on **Base** (the reference chain).
     address internal constant STOX_TOKEN_OWNER_SAFE = 0xe70d821f3462a074e63b42d0AaC6523faAe1d611;
 
@@ -221,6 +224,18 @@ library LibSafeInvariants {
     /// proxy, its own state), asserted against the shared policy by
     /// `assertTokenOwnerSafePolicy` exactly like every other chain's Safe.
     address internal constant STOX_TOKEN_OWNER_SAFE_HYPEREVM = 0x3840aeDaEc8e82f79d8F6a8F6ADCa271E13E0329;
+
+    /// @notice The ST0x token-owner Safe on **Robinhood Chain** (chain id
+    /// 4663).
+    ///
+    /// The SAME address as the Ethereum and HyperEVM Safes, for the same
+    /// reason: created through the canonical Safe proxy factory
+    /// (`0x4e1DCf7A…`, live on 4663 with the canonical codehash) with the
+    /// identical initializer and salt nonce, so the CREATE2 address matches.
+    /// A per-chain deployment with its own state, asserted against the shared
+    /// policy by `assertTokenOwnerSafePolicy` like every other chain's Safe
+    /// (`RobinhoodTokenOwnerSafeParityTest`).
+    address internal constant STOX_TOKEN_OWNER_SAFE_ROBINHOOD = 0x3840aeDaEc8e82f79d8F6a8F6ADCa271E13E0329;
 
     /// @notice The current expected threshold for `STOX_TOKEN_OWNER_SAFE`:
     /// 3-of-6 against the post-rotation owner roster. Scripts and the
@@ -488,6 +503,9 @@ library LibSafeInvariants {
         }
         if (chainId == HYPEREVM_CHAIN_ID) {
             return STOX_TOKEN_OWNER_SAFE_HYPEREVM;
+        }
+        if (chainId == ROBINHOOD_CHAIN_ID) {
+            return STOX_TOKEN_OWNER_SAFE_ROBINHOOD;
         }
         revert UnsupportedChainForTokenOwnerSafe(chainId);
     }

--- a/src/lib/LibSafeInvariants.sol
+++ b/src/lib/LibSafeInvariants.sol
@@ -200,6 +200,9 @@ library LibSafeInvariants {
     /// @notice Robinhood Chain mainnet chain id.
     uint256 internal constant ROBINHOOD_CHAIN_ID = 4663;
 
+    /// @notice BNB Smart Chain mainnet chain id.
+    uint256 internal constant BSC_CHAIN_ID = 56;
+
     /// @notice The ST0x token-owner Safe on **Base** (the reference chain).
     address internal constant STOX_TOKEN_OWNER_SAFE = 0xe70d821f3462a074e63b42d0AaC6523faAe1d611;
 
@@ -236,6 +239,13 @@ library LibSafeInvariants {
     /// policy by `assertTokenOwnerSafePolicy` like every other chain's Safe
     /// (`RobinhoodTokenOwnerSafeParityTest`).
     address internal constant STOX_TOKEN_OWNER_SAFE_ROBINHOOD = 0x3840aeDaEc8e82f79d8F6a8F6ADCa271E13E0329;
+
+    /// @notice The ST0x token-owner Safe on **BNB Smart Chain** (chain id
+    /// 56). The same CREATE2 address again, for the same reason as Robinhood
+    /// Chain's: canonical proxy factory, identical initializer and salt
+    /// nonce (all of which are live on 56 with the canonical codehashes).
+    /// Asserted against the shared policy by `BscTokenOwnerSafeParityTest`.
+    address internal constant STOX_TOKEN_OWNER_SAFE_BSC = 0x3840aeDaEc8e82f79d8F6a8F6ADCa271E13E0329;
 
     /// @notice The current expected threshold for `STOX_TOKEN_OWNER_SAFE`:
     /// 3-of-6 against the post-rotation owner roster. Scripts and the
@@ -506,6 +516,9 @@ library LibSafeInvariants {
         }
         if (chainId == ROBINHOOD_CHAIN_ID) {
             return STOX_TOKEN_OWNER_SAFE_ROBINHOOD;
+        }
+        if (chainId == BSC_CHAIN_ID) {
+            return STOX_TOKEN_OWNER_SAFE_BSC;
         }
         revert UnsupportedChainForTokenOwnerSafe(chainId);
     }

--- a/src/lib/LibTimelockInvariants.sol
+++ b/src/lib/LibTimelockInvariants.sol
@@ -144,6 +144,16 @@ library LibTimelockInvariants {
     /// https://hyperevmscan.io/address/0x831e4e1bb2b9a67c00b7d17f252a18a22cd0bd2b
     address internal constant STOX_GOVERNANCE_TIMELOCK_HYPEREVM = address(0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B);
 
+    /// @notice The ST0x governance timelock on **Robinhood Chain** (chain id
+    /// 4663). Equals `expectedTimelockAddress(STOX_TOKEN_OWNER_SAFE_ROBINHOOD)`.
+    /// @dev Robinhood Chain's token-owner Safe shares the Ethereum / HyperEVM
+    /// ADDRESS, and the Safe is the only constructor argument, so the derived
+    /// timelock address is identical to theirs. Same policy, same init code,
+    /// same CREATE2 address; a separate constant because the deploy is
+    /// per-chain.
+    /// https://robinhoodchain.blockscout.com/address/0x831e4e1bb2b9a67c00b7d17f252a18a22cd0bd2b
+    address internal constant STOX_GOVERNANCE_TIMELOCK_ROBINHOOD = address(0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B);
+
     /// @notice **PLACEHOLDER** for a dedicated canceller principal (a
     /// separate key or Safe that can veto a scheduled operation during the
     /// delay window without being able to propose or execute). Undecided:
@@ -198,6 +208,9 @@ library LibTimelockInvariants {
         }
         if (chainId == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
             return STOX_GOVERNANCE_TIMELOCK_HYPEREVM;
+        }
+        if (chainId == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
+            return STOX_GOVERNANCE_TIMELOCK_ROBINHOOD;
         }
         revert UnsupportedChainForGovernanceTimelock(chainId);
     }

--- a/src/lib/LibTimelockInvariants.sol
+++ b/src/lib/LibTimelockInvariants.sol
@@ -154,6 +154,13 @@ library LibTimelockInvariants {
     /// https://robinhoodchain.blockscout.com/address/0x831e4e1bb2b9a67c00b7d17f252a18a22cd0bd2b
     address internal constant STOX_GOVERNANCE_TIMELOCK_ROBINHOOD = address(0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B);
 
+    /// @notice The ST0x governance timelock on **BNB Smart Chain** (chain id
+    /// 56). Equals `expectedTimelockAddress(STOX_TOKEN_OWNER_SAFE_BSC)`; the
+    /// shared Safe address gives the shared derived address, as on Ethereum,
+    /// HyperEVM and Robinhood Chain.
+    /// https://bscscan.com/address/0x831e4e1bb2b9a67c00b7d17f252a18a22cd0bd2b
+    address internal constant STOX_GOVERNANCE_TIMELOCK_BSC = address(0x831E4e1bB2b9a67C00b7d17F252A18a22cd0bD2B);
+
     /// @notice **PLACEHOLDER** for a dedicated canceller principal (a
     /// separate key or Safe that can veto a scheduled operation during the
     /// delay window without being able to propose or execute). Undecided:
@@ -211,6 +218,9 @@ library LibTimelockInvariants {
         }
         if (chainId == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
             return STOX_GOVERNANCE_TIMELOCK_ROBINHOOD;
+        }
+        if (chainId == LibSafeInvariants.BSC_CHAIN_ID) {
+            return STOX_GOVERNANCE_TIMELOCK_BSC;
         }
         revert UnsupportedChainForGovernanceTimelock(chainId);
     }

--- a/test/script/20260729-deploy-governance-timelock.t.sol
+++ b/test/script/20260729-deploy-governance-timelock.t.sol
@@ -117,6 +117,10 @@ contract DeployGovernanceTimelockTest is Test {
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ROBINHOOD),
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM)
         );
+        assertEq(
+            LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_BSC),
+            LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM)
+        );
         assertNotEq(
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE),
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM)

--- a/test/script/20260729-deploy-governance-timelock.t.sol
+++ b/test/script/20260729-deploy-governance-timelock.t.sol
@@ -111,6 +111,12 @@ contract DeployGovernanceTimelockTest is Test {
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_HYPEREVM),
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM)
         );
+        // Robinhood Chain's Safe is the same CREATE2 address again, so its
+        // derived timelock joins the shared address.
+        assertEq(
+            LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ROBINHOOD),
+            LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM)
+        );
         assertNotEq(
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE),
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM)

--- a/test/src/concrete/deploy/BscTokenOwnerSafeParity.t.sol
+++ b/test/src/concrete/deploy/BscTokenOwnerSafeParity.t.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {IGnosisSafe} from "../../../../src/interface/IGnosisSafe.sol";
+import {LibSafeInvariants} from "../../../../src/lib/LibSafeInvariants.sol";
+import {LibStoxDeployNetworks} from "../../../../src/lib/LibStoxDeployNetworks.sol";
+
+/// @title BscTokenOwnerSafeParityTest
+/// @notice The BNB Smart Chain ST0x token-owner Safe (the same CREATE2
+/// address as Ethereum's, HyperEVM's and Robinhood Chain's, created through the canonical Safe
+/// proxy factory with the identical initializer — a per-chain deployment
+/// with its own state) must carry the chain-agnostic token-owner policy: the
+/// same owner SET (order-insensitive), threshold, and v1.4.1 identity as
+/// every other chain's Safe. Mirrors `RobinhoodTokenOwnerSafeParityTest`.
+///
+/// @dev RED until the Safe is created on BNB Smart Chain and its threshold
+/// raised to the shared policy's 3-of-6 (RAI-2287, BNB row); green thereafter,
+/// catching later policy drift. Forks unconditionally: CI supplies
+/// `BSC_RPC_URL` from the `RPC_URL_BSC_FORK` secret, so a
+/// missing RPC fails at fork time rather than passing having asserted
+/// nothing.
+contract BscTokenOwnerSafeParityTest is Test {
+    /// The pinned BNB Smart Chain Safe carries the shared token-owner policy
+    /// in every way that matters.
+    function testBscSafeMatchesSharedPolicy() external {
+        address bscSafe = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_BSC;
+
+        vm.createSelectFork(LibStoxDeployNetworks.BSC);
+        LibSafeInvariants.assertTokenOwnerSafePolicy(IGnosisSafe(bscSafe));
+    }
+}

--- a/test/src/concrete/deploy/GovernanceTimelockMigration.t.sol
+++ b/test/src/concrete/deploy/GovernanceTimelockMigration.t.sol
@@ -191,11 +191,12 @@ contract GovernanceTimelockMigrationTest is Test {
     /// deleting it from this list.
     /// @return ids The candidate chain ids.
     function governedChainCandidates() internal pure returns (uint256[] memory ids) {
-        ids = new uint256[](4);
+        ids = new uint256[](5);
         ids[0] = LibSafeInvariants.BASE_CHAIN_ID;
         ids[1] = LibSafeInvariants.ETHEREUM_CHAIN_ID;
         ids[2] = LibSafeInvariants.HYPEREVM_CHAIN_ID;
         ids[3] = LibSafeInvariants.ROBINHOOD_CHAIN_ID;
+        ids[4] = LibSafeInvariants.BSC_CHAIN_ID;
     }
 
     /// @notice Every chain ST0x governs must be known to the governance

--- a/test/src/concrete/deploy/GovernanceTimelockMigration.t.sol
+++ b/test/src/concrete/deploy/GovernanceTimelockMigration.t.sol
@@ -191,10 +191,11 @@ contract GovernanceTimelockMigrationTest is Test {
     /// deleting it from this list.
     /// @return ids The candidate chain ids.
     function governedChainCandidates() internal pure returns (uint256[] memory ids) {
-        ids = new uint256[](3);
+        ids = new uint256[](4);
         ids[0] = LibSafeInvariants.BASE_CHAIN_ID;
         ids[1] = LibSafeInvariants.ETHEREUM_CHAIN_ID;
         ids[2] = LibSafeInvariants.HYPEREVM_CHAIN_ID;
+        ids[3] = LibSafeInvariants.ROBINHOOD_CHAIN_ID;
     }
 
     /// @notice Every chain ST0x governs must be known to the governance

--- a/test/src/concrete/deploy/RobinhoodTokenOwnerSafeParity.t.sol
+++ b/test/src/concrete/deploy/RobinhoodTokenOwnerSafeParity.t.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {IGnosisSafe} from "../../../../src/interface/IGnosisSafe.sol";
+import {LibSafeInvariants} from "../../../../src/lib/LibSafeInvariants.sol";
+import {LibStoxDeployNetworks} from "../../../../src/lib/LibStoxDeployNetworks.sol";
+
+/// @title RobinhoodTokenOwnerSafeParityTest
+/// @notice The Robinhood Chain ST0x token-owner Safe (the same CREATE2
+/// address as Ethereum's and HyperEVM's, created through the canonical Safe
+/// proxy factory with the identical initializer — a per-chain deployment
+/// with its own state) must carry the chain-agnostic token-owner policy: the
+/// same owner SET (order-insensitive), threshold, and v1.4.1 identity as
+/// every other chain's Safe. Mirrors `HyperEvmTokenOwnerSafeParityTest`.
+///
+/// @dev RED until the Safe is created on Robinhood Chain and its threshold
+/// raised to the shared policy's 3-of-6 (RAI-2287); green thereafter,
+/// catching later policy drift. Forks unconditionally: CI supplies
+/// `ROBINHOOD_RPC_URL` from the `RPC_URL_ROBINHOOD_FORK` secret, so a
+/// missing RPC fails at fork time rather than passing having asserted
+/// nothing.
+contract RobinhoodTokenOwnerSafeParityTest is Test {
+    /// The pinned Robinhood Chain Safe carries the shared token-owner policy
+    /// in every way that matters.
+    function testRobinhoodSafeMatchesSharedPolicy() external {
+        address robinhoodSafe = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ROBINHOOD;
+
+        vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
+        LibSafeInvariants.assertTokenOwnerSafePolicy(IGnosisSafe(robinhoodSafe));
+    }
+}

--- a/test/src/lib/LibTimelockInvariants.t.sol
+++ b/test/src/lib/LibTimelockInvariants.t.sol
@@ -352,6 +352,10 @@ contract LibTimelockInvariantsTest is Test {
             LibTimelockInvariants.STOX_GOVERNANCE_TIMELOCK_HYPEREVM,
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_HYPEREVM)
         );
+        assertEq(
+            LibTimelockInvariants.STOX_GOVERNANCE_TIMELOCK_ROBINHOOD,
+            LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ROBINHOOD)
+        );
     }
 
     /// @notice Every chain with a pinned token-owner Safe resolves through
@@ -371,6 +375,10 @@ contract LibTimelockInvariantsTest is Test {
         assertEq(
             LibTimelockInvariants.timelockForChainId(LibSafeInvariants.HYPEREVM_CHAIN_ID),
             LibTimelockInvariants.STOX_GOVERNANCE_TIMELOCK_HYPEREVM
+        );
+        assertEq(
+            LibTimelockInvariants.timelockForChainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID),
+            LibTimelockInvariants.STOX_GOVERNANCE_TIMELOCK_ROBINHOOD
         );
     }
 }

--- a/test/src/lib/LibTimelockInvariants.t.sol
+++ b/test/src/lib/LibTimelockInvariants.t.sol
@@ -356,6 +356,10 @@ contract LibTimelockInvariantsTest is Test {
             LibTimelockInvariants.STOX_GOVERNANCE_TIMELOCK_ROBINHOOD,
             LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ROBINHOOD)
         );
+        assertEq(
+            LibTimelockInvariants.STOX_GOVERNANCE_TIMELOCK_BSC,
+            LibTimelockInvariants.expectedTimelockAddress(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_BSC)
+        );
     }
 
     /// @notice Every chain with a pinned token-owner Safe resolves through
@@ -379,6 +383,10 @@ contract LibTimelockInvariantsTest is Test {
         assertEq(
             LibTimelockInvariants.timelockForChainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID),
             LibTimelockInvariants.STOX_GOVERNANCE_TIMELOCK_ROBINHOOD
+        );
+        assertEq(
+            LibTimelockInvariants.timelockForChainId(LibSafeInvariants.BSC_CHAIN_ID),
+            LibTimelockInvariants.STOX_GOVERNANCE_TIMELOCK_BSC
         );
     }
 }


### PR DESCRIPTION
Pins the Robinhood Chain (4663) token-owner Safe and governance timelock, with their `safeForChainId` / `timelockForChainId` arms.

Both pins are the Ethereum / HyperEVM addresses, for the same reason those two match each other: the Safe is created through the canonical Safe proxy factory with the identical initializer and salt nonce, so its CREATE2 address is the same (`0x3840aeDa…0329`), and the Safe is the timelock's only constructor argument, so the Zoltu-derived timelock is the same too (`0x831E4e1b…bD2B`). The timelock pin is written with its arm ahead of the deploy, as `docs/TIMELOCK.md` requires; `testPinsMatchDerivedAddresses` asserts the derivation.

## What changes
- `LibSafeInvariants`: `ROBINHOOD_CHAIN_ID`, `STOX_TOKEN_OWNER_SAFE_ROBINHOOD`, `safeForChainId` arm.
- `LibTimelockInvariants`: `STOX_GOVERNANCE_TIMELOCK_ROBINHOOD`, `timelockForChainId` arm; pin + resolution tests extended.
- `governedChainCandidates()` lists 4663 so the coverage guard holds the timelock arm to the Safe pin.
- New `RobinhoodTokenOwnerSafeParityTest`: forks 4663 and asserts the shared 3-of-6 policy against the pin.

## Merge gate
The parity test is **RED until the Safe exists on 4663 with threshold 3** (ops step 1 of [RAI-2287](https://linear.app/makeitrain/issue/RAI-2287), which has the exact `createProxyWithNonce` replay recipe from the Ethereum creation tx). HyperEVM's Safe pin (#275) merged after the same step; this one should too. A Safe created with any other initializer lands elsewhere and this test says so.

## BNB Smart Chain (56), added 2026-09-10
Second commit: `BSC_CHAIN_ID = 56`, `STOX_TOKEN_OWNER_SAFE_BSC` and `STOX_GOVERNANCE_TIMELOCK_BSC` (the shared CREATE2 / derived addresses — canonical Safe contracts verified present on 56 with the Base codehashes), both arms, 56 in `governedChainCandidates()`, `BscTokenOwnerSafeParityTest` (RED until the Safe exists there, same gate). Parent [RAI-2312](https://linear.app/makeitrain/issue/RAI-2312).

## Checks
Local: pure tests green; the fork test fails today with `SafeProxyCodehashMismatch(0x3840…, expected, 0x0)`, i.e. no code at the pin yet.


Linear: [RAI-2285](https://linear.app/makeitrain/issue/RAI-2285) (parent [RAI-2284](https://linear.app/makeitrain/issue/RAI-2284)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Robinhood Chain and BNB Smart Chain governance configuration.
  * Added pinned token-owner Safes and governance timelocks for both networks.
  * Extended chain-based resolution to recognize both networks.

* **Tests**
  * Added coverage verifying Safe policy parity and derived timelock addresses.
  * Expanded governance coverage checks to include Robinhood Chain and BNB Smart Chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->