### PR TITLE
Robinhood Chain + BNB Smart Chain invariant surface: placeholder token tables, parity legs, prod fork pins

### DIFF
--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -1058,6 +1058,61 @@ library LibTokenInvariants {
         tokens[40] = TokenInstance("FTF", address(0), address(0), address(0));
     }
 
+    /// @notice Returns the production token instance triples on BNB Smart
+    /// Chain (chain id 56) — Base's underlyings in Base row order, so the
+    /// tables pair by index as well as by key (the cross-chain parity pin
+    /// asserts the alignment).
+    ///
+    /// **ALL PLACEHOLDERS** (`address(0)`) until the BNB Smart Chain token
+    /// deployment (`20260807-deploy-missing-tokens` on `bsc`) executes and
+    /// the post-execution pin PR hydrates every entry in one reviewed
+    /// change; all-or-nothing, as for every other chain's table.
+    /// @return tokens The 41 production token instances on BNB Smart Chain.
+    function productionTokensBsc() internal pure returns (TokenInstance[] memory tokens) {
+        tokens = new TokenInstance[](41);
+        tokens[0] = TokenInstance("MSTR", address(0), address(0), address(0));
+        tokens[1] = TokenInstance("TSLA", address(0), address(0), address(0));
+        tokens[2] = TokenInstance("COIN", address(0), address(0), address(0));
+        tokens[3] = TokenInstance("SPYM", address(0), address(0), address(0));
+        tokens[4] = TokenInstance("SIVR", address(0), address(0), address(0));
+        tokens[5] = TokenInstance("CRCL", address(0), address(0), address(0));
+        tokens[6] = TokenInstance("NVDA", address(0), address(0), address(0));
+        tokens[7] = TokenInstance("IAU", address(0), address(0), address(0));
+        tokens[8] = TokenInstance("PPLT", address(0), address(0), address(0));
+        tokens[9] = TokenInstance("AMZN", address(0), address(0), address(0));
+        tokens[10] = TokenInstance("BMNR", address(0), address(0), address(0));
+        tokens[11] = TokenInstance("IBHG", address(0), address(0), address(0));
+        tokens[12] = TokenInstance("SGOV", address(0), address(0), address(0));
+        tokens[13] = TokenInstance("QQQM", address(0), address(0), address(0));
+        tokens[14] = TokenInstance("VWO", address(0), address(0), address(0));
+        tokens[15] = TokenInstance("ARKK", address(0), address(0), address(0));
+        tokens[16] = TokenInstance("SPCX", address(0), address(0), address(0));
+        tokens[17] = TokenInstance("CEG", address(0), address(0), address(0));
+        tokens[18] = TokenInstance("DRAM", address(0), address(0), address(0));
+        tokens[19] = TokenInstance("TSM", address(0), address(0), address(0));
+        tokens[20] = TokenInstance("SKHY", address(0), address(0), address(0));
+        tokens[21] = TokenInstance("ASML", address(0), address(0), address(0));
+        tokens[22] = TokenInstance("MU", address(0), address(0), address(0));
+        tokens[23] = TokenInstance("AMD", address(0), address(0), address(0));
+        tokens[24] = TokenInstance("AVGO", address(0), address(0), address(0));
+        tokens[25] = TokenInstance("AMAT", address(0), address(0), address(0));
+        tokens[26] = TokenInstance("LRCX", address(0), address(0), address(0));
+        tokens[27] = TokenInstance("TTWO", address(0), address(0), address(0));
+        tokens[28] = TokenInstance("RKLB", address(0), address(0), address(0));
+        tokens[29] = TokenInstance("GOOGL", address(0), address(0), address(0));
+        tokens[30] = TokenInstance("AAPL", address(0), address(0), address(0));
+        tokens[31] = TokenInstance("MSFT", address(0), address(0), address(0));
+        tokens[32] = TokenInstance("LLY", address(0), address(0), address(0));
+        tokens[33] = TokenInstance("PTY", address(0), address(0), address(0));
+        tokens[34] = TokenInstance("INTC", address(0), address(0), address(0));
+        tokens[35] = TokenInstance("HOOD", address(0), address(0), address(0));
+        tokens[36] = TokenInstance("ORCL", address(0), address(0), address(0));
+        tokens[37] = TokenInstance("SMCI", address(0), address(0), address(0));
+        tokens[38] = TokenInstance("BABA", address(0), address(0), address(0));
+        tokens[39] = TokenInstance("TQQQ", address(0), address(0), address(0));
+        tokens[40] = TokenInstance("FTF", address(0), address(0), address(0));
+    }
+
     /// @notice Returns the 29 production receipt vault addresses on Base, in
     /// the order they were deployed. Provided so consumers (e.g. invariant
     /// assertions, migration scripts) can iterate without hardcoding the

--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -1000,6 +1000,64 @@ library LibTokenInvariants {
         );
     }
 
+    /// @notice Returns the production token instance triples on Robinhood
+    /// Chain (chain id 4663) — Base's underlyings in Base row order, so the
+    /// tables pair by index as well as by key (the cross-chain parity pin
+    /// asserts the alignment).
+    ///
+    /// **ALL PLACEHOLDERS** (`address(0)`) until the Robinhood Chain token
+    /// deployment (`20260807-deploy-missing-tokens` on `robinhood`) executes
+    /// and the post-execution pin PR hydrates every entry in one reviewed
+    /// change. Hydration is all-or-nothing across the table: the multichain
+    /// issuance cutover is lockstep over the full token set, so a partially
+    /// hydrated table is an error state, which the cross-chain parity suite
+    /// rejects rather than half-checks.
+    /// @return tokens The 41 production token instances on Robinhood Chain.
+    function productionTokensRobinhood() internal pure returns (TokenInstance[] memory tokens) {
+        tokens = new TokenInstance[](41);
+        tokens[0] = TokenInstance("MSTR", address(0), address(0), address(0));
+        tokens[1] = TokenInstance("TSLA", address(0), address(0), address(0));
+        tokens[2] = TokenInstance("COIN", address(0), address(0), address(0));
+        tokens[3] = TokenInstance("SPYM", address(0), address(0), address(0));
+        tokens[4] = TokenInstance("SIVR", address(0), address(0), address(0));
+        tokens[5] = TokenInstance("CRCL", address(0), address(0), address(0));
+        tokens[6] = TokenInstance("NVDA", address(0), address(0), address(0));
+        tokens[7] = TokenInstance("IAU", address(0), address(0), address(0));
+        tokens[8] = TokenInstance("PPLT", address(0), address(0), address(0));
+        tokens[9] = TokenInstance("AMZN", address(0), address(0), address(0));
+        tokens[10] = TokenInstance("BMNR", address(0), address(0), address(0));
+        tokens[11] = TokenInstance("IBHG", address(0), address(0), address(0));
+        tokens[12] = TokenInstance("SGOV", address(0), address(0), address(0));
+        tokens[13] = TokenInstance("QQQM", address(0), address(0), address(0));
+        tokens[14] = TokenInstance("VWO", address(0), address(0), address(0));
+        tokens[15] = TokenInstance("ARKK", address(0), address(0), address(0));
+        tokens[16] = TokenInstance("SPCX", address(0), address(0), address(0));
+        tokens[17] = TokenInstance("CEG", address(0), address(0), address(0));
+        tokens[18] = TokenInstance("DRAM", address(0), address(0), address(0));
+        tokens[19] = TokenInstance("TSM", address(0), address(0), address(0));
+        tokens[20] = TokenInstance("SKHY", address(0), address(0), address(0));
+        tokens[21] = TokenInstance("ASML", address(0), address(0), address(0));
+        tokens[22] = TokenInstance("MU", address(0), address(0), address(0));
+        tokens[23] = TokenInstance("AMD", address(0), address(0), address(0));
+        tokens[24] = TokenInstance("AVGO", address(0), address(0), address(0));
+        tokens[25] = TokenInstance("AMAT", address(0), address(0), address(0));
+        tokens[26] = TokenInstance("LRCX", address(0), address(0), address(0));
+        tokens[27] = TokenInstance("TTWO", address(0), address(0), address(0));
+        tokens[28] = TokenInstance("RKLB", address(0), address(0), address(0));
+        tokens[29] = TokenInstance("GOOGL", address(0), address(0), address(0));
+        tokens[30] = TokenInstance("AAPL", address(0), address(0), address(0));
+        tokens[31] = TokenInstance("MSFT", address(0), address(0), address(0));
+        tokens[32] = TokenInstance("LLY", address(0), address(0), address(0));
+        tokens[33] = TokenInstance("PTY", address(0), address(0), address(0));
+        tokens[34] = TokenInstance("INTC", address(0), address(0), address(0));
+        tokens[35] = TokenInstance("HOOD", address(0), address(0), address(0));
+        tokens[36] = TokenInstance("ORCL", address(0), address(0), address(0));
+        tokens[37] = TokenInstance("SMCI", address(0), address(0), address(0));
+        tokens[38] = TokenInstance("BABA", address(0), address(0), address(0));
+        tokens[39] = TokenInstance("TQQQ", address(0), address(0), address(0));
+        tokens[40] = TokenInstance("FTF", address(0), address(0), address(0));
+    }
+
     /// @notice Returns the 29 production receipt vault addresses on Base, in
     /// the order they were deployed. Provided so consumers (e.g. invariant
     /// assertions, migration scripts) can iterate without hardcoding the

--- a/test/src/concrete/deploy/StoxCrossChainParity.t.sol
+++ b/test/src/concrete/deploy/StoxCrossChainParity.t.sol
@@ -394,6 +394,11 @@ contract StoxCrossChainParityTest is Test {
     /// deliberately if the bootstrap slips.
     uint256 internal constant ROBINHOOD_PARITY_DEADLINE = 1_796_083_200;
 
+    /// @notice Unix timestamp past which the BNB Smart Chain legs must have
+    /// armed — `2026-12-01T00:00:00Z`, the same placeholder deadline as
+    /// Robinhood Chain's; move it deliberately if the bootstrap slips.
+    uint256 internal constant BSC_PARITY_DEADLINE = 1_796_083_200;
+
     /// @notice Assert every LIVE leg of a chain on the ACTIVE fork, skipping
     /// (with a loud PENDING log) any leg whose pins are still placeholders, and
     /// capture what it read for the cross-chain comparison. The legs are nested
@@ -610,10 +615,20 @@ contract StoxCrossChainParityTest is Test {
             LibTokenInvariants.productionTokensRobinhood()
         );
 
+        // BNB Smart Chain, from the `RPC_URL_BSC_FORK` secret.
+        vm.createSelectFork(LibStoxDeployNetworks.BSC);
+        ChainLegs memory bsc = assertChainLegs(
+            "BNB Smart Chain",
+            LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_BSC,
+            LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC,
+            LibTokenInvariants.productionTokensBsc()
+        );
+
         // ---- Cross-chain comparisons, each gated on both sides being live ----
         assertParityWithBase("Ethereum", base, eth);
         assertParityWithBase("HyperEVM", base, hyper);
         assertParityWithBase("Robinhood Chain", base, robinhood);
+        assertParityWithBase("BNB Smart Chain", base, bsc);
 
         // ---- The suite must prove it actually ran ----
 
@@ -655,6 +670,13 @@ contract StoxCrossChainParityTest is Test {
             assertTrue(robinhood.safeLive, "Robinhood Chain Safe leg still pending past the parity deadline");
             assertTrue(robinhood.cloneLive, "Robinhood Chain authoriser leg still pending past the parity deadline");
             assertTrue(robinhood.tokenLegLive, "Robinhood Chain token leg still pending past the parity deadline");
+        }
+
+        // BNB Smart Chain's legs arm as its bootstrap lands (RAI-2312).
+        if (block.timestamp >= BSC_PARITY_DEADLINE) {
+            assertTrue(bsc.safeLive, "BNB Smart Chain Safe leg still pending past the parity deadline");
+            assertTrue(bsc.cloneLive, "BNB Smart Chain authoriser leg still pending past the parity deadline");
+            assertTrue(bsc.tokenLegLive, "BNB Smart Chain token leg still pending past the parity deadline");
         }
     }
 }

--- a/test/src/concrete/deploy/StoxCrossChainParity.t.sol
+++ b/test/src/concrete/deploy/StoxCrossChainParity.t.sol
@@ -388,6 +388,12 @@ contract StoxCrossChainParityTest is Test {
     /// the bootstrap slips.
     uint256 internal constant HYPEREVM_PARITY_DEADLINE = 1_793_491_200;
 
+    /// @notice Unix timestamp past which the Robinhood Chain legs must have
+    /// armed — `2026-12-01T00:00:00Z`, tracking the RAI-2285 bootstrap.
+    /// PLACEHOLDER in the same sense as the other deadlines: move it
+    /// deliberately if the bootstrap slips.
+    uint256 internal constant ROBINHOOD_PARITY_DEADLINE = 1_796_083_200;
+
     /// @notice Assert every LIVE leg of a chain on the ACTIVE fork, skipping
     /// (with a loud PENDING log) any leg whose pins are still placeholders, and
     /// capture what it read for the cross-chain comparison. The legs are nested
@@ -594,9 +600,20 @@ contract StoxCrossChainParityTest is Test {
             LibTokenInvariants.productionTokensHyperEvm()
         );
 
+        // Robinhood Chain forks unconditionally too, from the
+        // `RPC_URL_ROBINHOOD_FORK` secret.
+        vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
+        ChainLegs memory robinhood = assertChainLegs(
+            "Robinhood Chain",
+            LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ROBINHOOD,
+            LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD,
+            LibTokenInvariants.productionTokensRobinhood()
+        );
+
         // ---- Cross-chain comparisons, each gated on both sides being live ----
         assertParityWithBase("Ethereum", base, eth);
         assertParityWithBase("HyperEVM", base, hyper);
+        assertParityWithBase("Robinhood Chain", base, robinhood);
 
         // ---- The suite must prove it actually ran ----
 
@@ -630,6 +647,14 @@ contract StoxCrossChainParityTest is Test {
             assertTrue(hyper.safeLive, "HyperEVM Safe leg still pending past the parity deadline");
             assertTrue(hyper.cloneLive, "HyperEVM authoriser leg still pending past the parity deadline");
             assertTrue(hyper.tokenLegLive, "HyperEVM token leg still pending past the parity deadline");
+        }
+
+        // Robinhood Chain's legs arm as the RAI-2285 bootstrap lands. Same
+        // forcing function again.
+        if (block.timestamp >= ROBINHOOD_PARITY_DEADLINE) {
+            assertTrue(robinhood.safeLive, "Robinhood Chain Safe leg still pending past the parity deadline");
+            assertTrue(robinhood.cloneLive, "Robinhood Chain authoriser leg still pending past the parity deadline");
+            assertTrue(robinhood.tokenLegLive, "Robinhood Chain token leg still pending past the parity deadline");
         }
     }
 }

--- a/test/src/concrete/deploy/StoxProdV4.t.sol
+++ b/test/src/concrete/deploy/StoxProdV4.t.sol
@@ -248,4 +248,16 @@ contract StoxProdV4Test is Test {
         checkProd_0_1_1OnChain(true);
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
     }
+
+    /// Only the audited 0.1.1 production set ships to Robinhood Chain (the
+    /// RAI-2285 bootstrap), mirroring HyperEVM. Forks unconditionally from
+    /// the `RPC_URL_ROBINHOOD_FORK` secret. RED until the audited 0.1.1
+    /// suite lands on Robinhood Chain and its in-use beacons are owned by
+    /// the Robinhood Chain token-owner Safe; green thereafter, catching
+    /// later drift.
+    function testProdDeployRobinhoodV4() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
+        checkProd_0_1_1OnChain(true);
+        LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
+    }
 }

--- a/test/src/concrete/deploy/StoxProdV4.t.sol
+++ b/test/src/concrete/deploy/StoxProdV4.t.sol
@@ -260,4 +260,13 @@ contract StoxProdV4Test is Test {
         checkProd_0_1_1OnChain(true);
         LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
     }
+
+    /// Same pin for BNB Smart Chain (RAI-2312): RED until the audited 0.1.1
+    /// suite lands there and its in-use beacons are owned by the BNB Smart
+    /// Chain token-owner Safe.
+    function testProdDeployBscV4() external {
+        vm.createSelectFork(LibStoxDeployNetworks.BSC);
+        checkProd_0_1_1OnChain(true);
+        LibBeaconInvariants.assertProdBeaconsOwnedByChainSafe(block.chainid);
+    }
 }

--- a/test/src/lib/LibTokenInvariants.t.sol
+++ b/test/src/lib/LibTokenInvariants.t.sol
@@ -89,4 +89,27 @@ contract LibTokenInvariantsTest is Test {
             assertEq(eth[i].underlying, base[i].underlying, "Ethereum token underlying diverges from Base");
         }
     }
+
+    /// The HyperEVM token table mirrors Base row-for-row on the `underlying`
+    /// key, for the same reason as Ethereum's.
+    function testHyperEvmTokenTableMirrorsBaseUnderlyings() external pure {
+        TokenInstance[] memory base = LibTokenInvariants.productionTokensBase();
+        TokenInstance[] memory hyper = LibTokenInvariants.productionTokensHyperEvm();
+        assertEq(hyper.length, base.length, "HyperEVM token table length diverges from Base");
+        for (uint256 i = 0; i < base.length; i++) {
+            assertEq(hyper[i].underlying, base[i].underlying, "HyperEVM token underlying diverges from Base");
+        }
+    }
+
+    /// The Robinhood Chain token table mirrors Base row-for-row on the
+    /// `underlying` key. Its addresses are placeholders until the token
+    /// deploy executes there; this guards only the shared shape.
+    function testRobinhoodTokenTableMirrorsBaseUnderlyings() external pure {
+        TokenInstance[] memory base = LibTokenInvariants.productionTokensBase();
+        TokenInstance[] memory robinhood = LibTokenInvariants.productionTokensRobinhood();
+        assertEq(robinhood.length, base.length, "Robinhood Chain token table length diverges from Base");
+        for (uint256 i = 0; i < base.length; i++) {
+            assertEq(robinhood[i].underlying, base[i].underlying, "Robinhood Chain token underlying diverges from Base");
+        }
+    }
 }

--- a/test/src/lib/LibTokenInvariants.t.sol
+++ b/test/src/lib/LibTokenInvariants.t.sol
@@ -112,4 +112,15 @@ contract LibTokenInvariantsTest is Test {
             assertEq(robinhood[i].underlying, base[i].underlying, "Robinhood Chain token underlying diverges from Base");
         }
     }
+
+    /// The BNB Smart Chain token table mirrors Base row-for-row on the
+    /// `underlying` key; addresses are placeholders until its token deploy.
+    function testBscTokenTableMirrorsBaseUnderlyings() external pure {
+        TokenInstance[] memory base = LibTokenInvariants.productionTokensBase();
+        TokenInstance[] memory bsc = LibTokenInvariants.productionTokensBsc();
+        assertEq(bsc.length, base.length, "BNB Smart Chain token table length diverges from Base");
+        for (uint256 i = 0; i < base.length; i++) {
+            assertEq(bsc[i].underlying, base[i].underlying, "BNB Smart Chain token underlying diverges from Base");
+        }
+    }
 }


### PR DESCRIPTION
The Robinhood Chain invariant surface, mirroring HyperEVM's #277.

## What changes
- `LibTokenInvariants.productionTokensRobinhood()`: Base's 41 underlyings in Base row order as **all-zero placeholders**, hydrated all-or-nothing by the post-execution pin PR (the parity suite rejects a partial table). Both non-Base tables now have the row-order mirror test Ethereum's had; HyperEVM's was missing.
- `testCrossChainParity` forks 4663 as its fourth leg. Every leg is a placeholder today, so it logs `PARITY PENDING` and compares nothing; each pin PR arms a leg. `ROBINHOOD_PARITY_DEADLINE` (2026-12-01Z) turns a never-armed leg into a failure, like the Ethereum and HyperEVM deadlines.
- `testProdDeployRobinhoodV4`: the audited 0.1.1 set + Safe-owned beacons on 4663.

## Merge gate
`testProdDeployRobinhoodV4` is RED (`V4 StoxReceipt not deployed`) until the 0.1.1 suites land and the beacons migrate. The parity suite's Safe leg is live as soon as the Safe pin is non-zero (the PR below this one), so `testCrossChainParity` shares that PR's gate: red until the Safe exists on 4663, then its clone and token legs stay pending-and-green until they hydrate.

## BNB Smart Chain (56), added 2026-09-10
Second commit: `productionTokensBsc()` (41 placeholders, mirror test), fifth parity leg + `BSC_PARITY_DEADLINE`, `testProdDeployBscV4`. Same gates as the Robinhood leg.

## Checks
Local: `forge fmt`, mirror tests green; full suite on the stack top 962/969, the reds being the chain-gated forcing tests for both chains (Safe parity, beacon ownership, prod 0.1.1 pin, cross-chain parity Safe leg) plus one public-RPC storage read.


Linear: [RAI-2285](https://linear.app/makeitrain/issue/RAI-2285) (parent [RAI-2284](https://linear.app/makeitrain/issue/RAI-2284)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3
