### PR TITLE
Robinhood Chain + BNB Smart Chain arms in the chain-keyed operational scripts

### DIFF
--- a/script/20260729-migrate-governance-to-timelock.s.sol
+++ b/script/20260729-migrate-governance-to-timelock.s.sol
@@ -239,6 +239,9 @@ contract MigrateGovernanceToTimelock is Script {
         if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
             return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD;
         }
+        if (block.chainid == LibSafeInvariants.BSC_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC;
+        }
         revert UnsupportedChainForTokenTable(block.chainid);
     }
 
@@ -256,6 +259,9 @@ contract MigrateGovernanceToTimelock is Script {
         }
         if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
             return LibTokenInvariants.productionTokensRobinhood();
+        }
+        if (block.chainid == LibSafeInvariants.BSC_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensBsc();
         }
         revert UnsupportedChainForTokenTable(block.chainid);
     }

--- a/script/20260729-migrate-governance-to-timelock.s.sol
+++ b/script/20260729-migrate-governance-to-timelock.s.sol
@@ -223,7 +223,7 @@ contract MigrateGovernanceToTimelock is Script {
     }
 
     /// @notice The chain's V4 authoriser clone, selected by chain id from
-    /// `LibProdDeployV4`. Both chains' clones proxy the same Zoltu-deployed
+    /// `LibProdDeployV4`. Every chain's clone proxies the same Zoltu-deployed
     /// 0.1.1 impl address, so they share one EIP-1167 codehash pin.
     /// @return The active chain's authoriser clone.
     function activeChainAuthoriser() internal view returns (address) {
@@ -235,6 +235,9 @@ contract MigrateGovernanceToTimelock is Script {
         }
         if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
             return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
+        }
+        if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD;
         }
         revert UnsupportedChainForTokenTable(block.chainid);
     }
@@ -250,6 +253,9 @@ contract MigrateGovernanceToTimelock is Script {
         }
         if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
             return LibTokenInvariants.productionTokensHyperEvm();
+        }
+        if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensRobinhood();
         }
         revert UnsupportedChainForTokenTable(block.chainid);
     }

--- a/script/20260807-deploy-missing-tokens.s.sol
+++ b/script/20260807-deploy-missing-tokens.s.sol
@@ -139,6 +139,9 @@ contract DeployMissingTokens is Script {
         if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
             return LibTokenInvariants.productionTokensHyperEvm();
         }
+        if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensRobinhood();
+        }
         revert UnsupportedTargetChain(block.chainid);
     }
 
@@ -150,6 +153,8 @@ contract DeployMissingTokens is Script {
             authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
         } else if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
             authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
+        } else if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD;
         } else {
             revert UnsupportedTargetChain(block.chainid);
         }

--- a/script/20260807-deploy-missing-tokens.s.sol
+++ b/script/20260807-deploy-missing-tokens.s.sol
@@ -142,6 +142,9 @@ contract DeployMissingTokens is Script {
         if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
             return LibTokenInvariants.productionTokensRobinhood();
         }
+        if (block.chainid == LibSafeInvariants.BSC_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensBsc();
+        }
         revert UnsupportedTargetChain(block.chainid);
     }
 
@@ -155,6 +158,8 @@ contract DeployMissingTokens is Script {
             authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
         } else if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
             authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD;
+        } else if (block.chainid == LibSafeInvariants.BSC_CHAIN_ID) {
+            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC;
         } else {
             revert UnsupportedTargetChain(block.chainid);
         }

--- a/script/20260825-upgrade-fleet-to-0-1-30.s.sol
+++ b/script/20260825-upgrade-fleet-to-0-1-30.s.sol
@@ -169,6 +169,9 @@ contract UpgradeFleetTo0_1_30 is Script {
         if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
             return LibTokenInvariants.productionTokensRobinhood();
         }
+        if (block.chainid == LibSafeInvariants.BSC_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensBsc();
+        }
         revert FleetUpgradeUnsupportedChain(block.chainid);
     }
 

--- a/script/20260825-upgrade-fleet-to-0-1-30.s.sol
+++ b/script/20260825-upgrade-fleet-to-0-1-30.s.sol
@@ -41,6 +41,12 @@ error FleetAlreadyUpgraded();
 /// @param receiptVault The vault whose reads drifted.
 error UpgradeChangedTokenState(address receiptVault);
 
+/// @notice The active chain has no production token table here, so there is
+/// nothing to snapshot or upgrade — a wrong-network dispatch, not a chain
+/// with an empty table.
+/// @param chainId The active chain id.
+error FleetUpgradeUnsupportedChain(uint256 chainId);
+
 /// @title UpgradeFleetTo0_1_30
 /// @notice Authors the per-chain Safe Tx Builder bundle that
 /// upgrades the production token fleet to the audited 0.1.30
@@ -146,6 +152,9 @@ contract UpgradeFleetTo0_1_30 is Script {
 
     /// @notice The active chain's production token table (empty tables are
     /// valid — a chain carrying no tokens yet has nothing to snapshot).
+    /// Reverts for a chain without a table rather than falling through to
+    /// another chain's: snapshotting the wrong chain's vaults would read
+    /// empty code as preserved state.
     /// @return tokens The chain's token instances.
     function activeChainTokens() internal view returns (TokenInstance[] memory tokens) {
         if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
@@ -154,7 +163,13 @@ contract UpgradeFleetTo0_1_30 is Script {
         if (block.chainid == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
             return LibTokenInvariants.productionTokensEthereum();
         }
-        return LibTokenInvariants.productionTokensHyperEvm();
+        if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensHyperEvm();
+        }
+        if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensRobinhood();
+        }
+        revert FleetUpgradeUnsupportedChain(block.chainid);
     }
 
     /// @notice Snapshot every production token's reported state (receipt

--- a/test/script/20260729-migrate-governance-to-timelock.t.sol
+++ b/test/script/20260729-migrate-governance-to-timelock.t.sol
@@ -58,6 +58,9 @@ contract MigrateGovernanceToTimelockTest is Test {
         if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
             return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
         }
+        if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD;
+        }
         revert("unsupported chain in migration test");
     }
 
@@ -71,6 +74,9 @@ contract MigrateGovernanceToTimelockTest is Test {
         }
         if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
             return LibTokenInvariants.productionTokensHyperEvm();
+        }
+        if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensRobinhood();
         }
         revert("unsupported chain in migration test");
     }

--- a/test/script/20260729-migrate-governance-to-timelock.t.sol
+++ b/test/script/20260729-migrate-governance-to-timelock.t.sol
@@ -61,6 +61,9 @@ contract MigrateGovernanceToTimelockTest is Test {
         if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
             return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD;
         }
+        if (block.chainid == LibSafeInvariants.BSC_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC;
+        }
         revert("unsupported chain in migration test");
     }
 
@@ -77,6 +80,9 @@ contract MigrateGovernanceToTimelockTest is Test {
         }
         if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
             return LibTokenInvariants.productionTokensRobinhood();
+        }
+        if (block.chainid == LibSafeInvariants.BSC_CHAIN_ID) {
+            return LibTokenInvariants.productionTokensBsc();
         }
         revert("unsupported chain in migration test");
     }

--- a/test/script/20260807-deploy-missing-tokens.t.sol
+++ b/test/script/20260807-deploy-missing-tokens.t.sol
@@ -186,6 +186,17 @@ contract DeployMissingTokensTest is Test {
         assertEq(
             robinhood.length, LibTokenInvariants.productionTokensRobinhood().length, "Robinhood Chain table mismatch"
         );
+
+        vm.chainId(LibSafeInvariants.BSC_CHAIN_ID);
+        TokenInstance[] memory bsc = harness.targetTokens();
+        assertEq(bsc.length, LibTokenInvariants.productionTokensBsc().length, "BNB Smart Chain table mismatch");
+    }
+
+    /// @notice Same placeholder refusal for BNB Smart Chain.
+    function testAuthoriserNotReadyWhileTheBscPinIsAPlaceholder() external {
+        vm.chainId(LibSafeInvariants.BSC_CHAIN_ID);
+        vm.expectRevert(abi.encodeWithSelector(AuthoriserNotReady.selector, address(0)));
+        harness.assertAuthoriserReady();
     }
 
     /// @notice Robinhood Chain's clone pin is a placeholder until its

--- a/test/script/20260807-deploy-missing-tokens.t.sol
+++ b/test/script/20260807-deploy-missing-tokens.t.sol
@@ -180,6 +180,21 @@ contract DeployMissingTokensTest is Test {
         vm.chainId(LibSafeInvariants.HYPEREVM_CHAIN_ID);
         TokenInstance[] memory hyperevm = harness.targetTokens();
         assertEq(hyperevm.length, LibTokenInvariants.productionTokensHyperEvm().length, "HyperEVM table mismatch");
+
+        vm.chainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID);
+        TokenInstance[] memory robinhood = harness.targetTokens();
+        assertEq(
+            robinhood.length, LibTokenInvariants.productionTokensRobinhood().length, "Robinhood Chain table mismatch"
+        );
+    }
+
+    /// @notice Robinhood Chain's clone pin is a placeholder until its
+    /// authoriser deploy executes, and a placeholder is refused as not-ready
+    /// — the token deploy cannot wire vaults onto `address(0)`.
+    function testAuthoriserNotReadyWhileTheRobinhoodPinIsAPlaceholder() external {
+        vm.chainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID);
+        vm.expectRevert(abi.encodeWithSelector(AuthoriserNotReady.selector, address(0)));
+        harness.assertAuthoriserReady();
     }
 
     /// @notice `run()` reverts `DeployerNotDeployed` when the 0.1.1 core has

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
@@ -11,7 +11,8 @@ import {IReceiptV3} from "rain-vats-0.1.6/src/interface/IReceiptV3.sol";
 import {
     BeaconInUnknownState,
     FleetAlreadyUpgraded,
-    UpgradeChangedTokenState
+    UpgradeChangedTokenState,
+    FleetUpgradeUnsupportedChain
 } from "../../script/20260825-upgrade-fleet-to-0-1-30.s.sol";
 import {UpgradeFleetHarness} from "./UpgradeFleetHarness.sol";
 import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
@@ -49,6 +50,29 @@ contract UpgradeFleetTest is Test {
             abi.encodeCall(IBeacon.implementation, ()),
             abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1)
         );
+    }
+
+    /// Each production chain resolves to its own token table, keyed by chain
+    /// id — including a chain whose table is still all placeholders, which is
+    /// a valid (empty) snapshot rather than a wrong-network dispatch.
+    function testActiveChainTokensResolvesPerChain() external {
+        vm.chainId(LibSafeInvariants.BASE_CHAIN_ID);
+        assertEq(harness.callActiveChainTokens().length, 41, "Base table");
+        vm.chainId(LibSafeInvariants.ETHEREUM_CHAIN_ID);
+        assertEq(harness.callActiveChainTokens().length, 41, "Ethereum table");
+        vm.chainId(LibSafeInvariants.HYPEREVM_CHAIN_ID);
+        assertEq(harness.callActiveChainTokens().length, 41, "HyperEVM table");
+        vm.chainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID);
+        assertEq(harness.callActiveChainTokens().length, 41, "Robinhood Chain table");
+    }
+
+    /// A chain with no table is refused rather than handed another chain's
+    /// table: the snapshot would read empty code on every vault and report
+    /// it preserved.
+    function testActiveChainTokensRejectsUnknownChain() external {
+        vm.chainId(123456);
+        vm.expectRevert(abi.encodeWithSelector(FleetUpgradeUnsupportedChain.selector, 123456));
+        harness.callActiveChainTokens();
     }
 
     /// The pre-upgrade state authors both `upgradeTo` transactions.

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
@@ -64,6 +64,8 @@ contract UpgradeFleetTest is Test {
         assertEq(harness.callActiveChainTokens().length, 41, "HyperEVM table");
         vm.chainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID);
         assertEq(harness.callActiveChainTokens().length, 41, "Robinhood Chain table");
+        vm.chainId(LibSafeInvariants.BSC_CHAIN_ID);
+        assertEq(harness.callActiveChainTokens().length, 41, "BNB Smart Chain table");
     }
 
     /// A chain with no table is refused rather than handed another chain's

--- a/test/script/UpgradeFleetHarness.sol
+++ b/test/script/UpgradeFleetHarness.sol
@@ -14,6 +14,11 @@ contract UpgradeFleetHarness is UpgradeFleetTo0_1_30 {
         return authorBundle(beacons);
     }
 
+    /// @notice The script's `activeChainTokens()`, externally callable.
+    function callActiveChainTokens() external view returns (TokenInstance[] memory) {
+        return activeChainTokens();
+    }
+
     /// @notice The script's `artifactPath()`, externally callable.
     function callArtifactPath() external view returns (string memory) {
         return artifactPath();


### PR DESCRIPTION
The three operational scripts that dispatch on a per-chain token table and authoriser pin gain their 4663 arm:
- `20260807-deploy-missing-tokens`: `_targetTokens` + `_assertAuthoriserReady`, the "table and an authoriser pin" its doc promises a new chain needs. The placeholder pin is proven refused (`AuthoriserNotReady(0)`), so the token deploy cannot run ahead of the authoriser clone.
- `20260825-upgrade-fleet-to-0-1-30`: `activeChainTokens`.
- `20260729-migrate-governance-to-timelock`: both resolvers, plus the test helpers that mirror them.

## A latent bug fixed on the way
`activeChainTokens` fell through to **HyperEVM's table for any unknown chain**. A wrong-network dispatch would have snapshotted HyperEVM's vault addresses on a chain where they have no code and reported the state preserved. It now reverts `FleetUpgradeUnsupportedChain`, with the fork-free per-chain / unknown-chain tests the other resolvers already had.

## BNB Smart Chain (56), added 2026-09-10
Second commit: the same three arms, mirrored test helpers, placeholder-refusal test.

## Checks
Local: `forge fmt`, `DeployMissingTokensTest` + `UpgradeFleetTest` green.


Linear: [RAI-2285](https://linear.app/makeitrain/issue/RAI-2285) (parent [RAI-2284](https://linear.app/makeitrain/issue/RAI-2284)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3
