### PR TITLE
Ship the governance timelock to Robinhood Chain and BNB Smart Chain in the one-dispatch deploy

### DIFF
--- a/docs/TIMELOCK.md
+++ b/docs/TIMELOCK.md
@@ -82,12 +82,13 @@ precomputable address —
 Constants (in `src/lib/LibTimelockInvariants.sol`) that future scripts and
 invariants target:
 
-| Constant                            | Holds                                     |
-| ----------------------------------- | ----------------------------------------- |
-| `STOX_GOVERNANCE_TIMELOCK`          | the Base timelock                         |
-| `STOX_GOVERNANCE_TIMELOCK_ETHEREUM` | the Ethereum timelock                     |
-| `STOX_GOVERNANCE_TIMELOCK_HYPEREVM` | the HyperEVM timelock                     |
-| `TIMELOCK_CANCELLER`                | the dedicated canceller, once provisioned |
+| Constant                             | Holds                                     |
+| ------------------------------------ | ----------------------------------------- |
+| `STOX_GOVERNANCE_TIMELOCK`           | the Base timelock                         |
+| `STOX_GOVERNANCE_TIMELOCK_ETHEREUM`  | the Ethereum timelock                     |
+| `STOX_GOVERNANCE_TIMELOCK_HYPEREVM`  | the HyperEVM timelock                     |
+| `STOX_GOVERNANCE_TIMELOCK_ROBINHOOD` | the Robinhood Chain timelock              |
+| `TIMELOCK_CANCELLER`                 | the dedicated canceller, once provisioned |
 
 Every pin is written with its chain arm, derived from the frozen creation
 bytecode and that chain's Safe pin before any deploy —
@@ -95,10 +96,11 @@ bytecode and that chain's Safe pin before any deploy —
 wrong or zeroed pin cannot survive CI. A zero pin is never a legitimate phase:
 every consumer (the deploy pre-flight, the migration authoring, the
 migration-window suite) refuses it as a reverted or never-hydrated arm rather
-than proceeding against a wrong address. All three pins are hydrated and their
-timelocks live.
+than proceeding against a wrong address. The Base, Ethereum and HyperEVM
+timelocks are live at their pins; Robinhood Chain's pin is derived ahead of its
+deploy, per step 1 below.
 
-## Rollout (per chain: Base, Ethereum, HyperEVM)
+## Rollout (per chain: Base, Ethereum, HyperEVM, Robinhood Chain)
 
 1. **Chain arm + pin** — a governed chain's `LibTimelockInvariants` arm is added
    WITH its pin, derived from the frozen creation bytecode and the chain's Safe
@@ -111,7 +113,7 @@ timelocks live.
    landing at its derived address, fully configured by its constructor.
 3. **Author the migration bundle** — Actions → `run-script` →
    `20260729-migrate-governance-to-timelock`, network `base` / `ethereum` /
-   `hyperevm`. Emits the Safe Tx Builder JSON
+   `hyperevm` / `robinhood`. Emits the Safe Tx Builder JSON
    (`out/20260729-governance-timelock-migration-<chainid>.json`) after a full
    pre-flight, simulation, post-state assertion, and an end-to-end schedule →
    48h → execute proof on the fork. The logged MultiSend `SafeTxHash` is the

--- a/docs/TIMELOCK.md
+++ b/docs/TIMELOCK.md
@@ -88,6 +88,7 @@ invariants target:
 | `STOX_GOVERNANCE_TIMELOCK_ETHEREUM`  | the Ethereum timelock                     |
 | `STOX_GOVERNANCE_TIMELOCK_HYPEREVM`  | the HyperEVM timelock                     |
 | `STOX_GOVERNANCE_TIMELOCK_ROBINHOOD` | the Robinhood Chain timelock              |
+| `STOX_GOVERNANCE_TIMELOCK_BSC`       | the BNB Smart Chain timelock              |
 | `TIMELOCK_CANCELLER`                 | the dedicated canceller, once provisioned |
 
 Every pin is written with its chain arm, derived from the frozen creation
@@ -97,10 +98,10 @@ wrong or zeroed pin cannot survive CI. A zero pin is never a legitimate phase:
 every consumer (the deploy pre-flight, the migration authoring, the
 migration-window suite) refuses it as a reverted or never-hydrated arm rather
 than proceeding against a wrong address. The Base, Ethereum and HyperEVM
-timelocks are live at their pins; Robinhood Chain's pin is derived ahead of its
-deploy, per step 1 below.
+timelocks are live at their pins; the Robinhood Chain and BNB Smart Chain pins
+are derived ahead of their deploys, per step 1 below.
 
-## Rollout (per chain: Base, Ethereum, HyperEVM, Robinhood Chain)
+## Rollout (per chain: Base, Ethereum, HyperEVM, Robinhood Chain, BNB Smart Chain)
 
 1. **Chain arm + pin** — a governed chain's `LibTimelockInvariants` arm is added
    WITH its pin, derived from the frozen creation bytecode and the chain's Safe
@@ -113,7 +114,7 @@ deploy, per step 1 below.
    landing at its derived address, fully configured by its constructor.
 3. **Author the migration bundle** — Actions → `run-script` →
    `20260729-migrate-governance-to-timelock`, network `base` / `ethereum` /
-   `hyperevm` / `robinhood`. Emits the Safe Tx Builder JSON
+   `hyperevm` / `robinhood` / `bsc`. Emits the Safe Tx Builder JSON
    (`out/20260729-governance-timelock-migration-<chainid>.json`) after a full
    pre-flight, simulation, post-state assertion, and an end-to-end schedule →
    48h → execute proof on the fork. The logged MultiSend `SafeTxHash` is the

--- a/script/20260729-deploy-governance-timelock.s.sol
+++ b/script/20260729-deploy-governance-timelock.s.sol
@@ -105,10 +105,11 @@ contract DeployGovernanceTimelock is Script {
     /// @return nets The network names, matching `foundry.toml`'s
     /// `[rpc_endpoints]` aliases.
     function networks() internal pure returns (string[] memory nets) {
-        nets = new string[](3);
+        nets = new string[](4);
         nets[0] = LibRainDeploy.BASE;
         nets[1] = LibStoxDeployNetworks.ETHEREUM;
         nets[2] = LibStoxDeployNetworks.HYPEREVM;
+        nets[3] = LibStoxDeployNetworks.ROBINHOOD;
     }
 
     /// @notice The active chain's governance-timelock pin. Virtual so the

--- a/script/20260729-deploy-governance-timelock.s.sol
+++ b/script/20260729-deploy-governance-timelock.s.sol
@@ -105,11 +105,12 @@ contract DeployGovernanceTimelock is Script {
     /// @return nets The network names, matching `foundry.toml`'s
     /// `[rpc_endpoints]` aliases.
     function networks() internal pure returns (string[] memory nets) {
-        nets = new string[](4);
+        nets = new string[](5);
         nets[0] = LibRainDeploy.BASE;
         nets[1] = LibStoxDeployNetworks.ETHEREUM;
         nets[2] = LibStoxDeployNetworks.HYPEREVM;
         nets[3] = LibStoxDeployNetworks.ROBINHOOD;
+        nets[4] = LibStoxDeployNetworks.BSC;
     }
 
     /// @notice The active chain's governance-timelock pin. Virtual so the

--- a/test/script/20260729-deploy-governance-timelock.t.sol
+++ b/test/script/20260729-deploy-governance-timelock.t.sol
@@ -40,11 +40,12 @@ contract DeployGovernanceTimelockTest is Test {
     /// body, which the per-chain tests below exercise.
     function testNetworksCoversEveryProductionChain() external {
         string[] memory nets = new DeployGovernanceTimelockHarness().callNetworks();
-        assertEq(nets.length, 4);
+        assertEq(nets.length, 5);
         assertEq(nets[0], LibRainDeploy.BASE);
         assertEq(nets[1], LibStoxDeployNetworks.ETHEREUM);
         assertEq(nets[2], LibStoxDeployNetworks.HYPEREVM);
         assertEq(nets[3], LibStoxDeployNetworks.ROBINHOOD);
+        assertEq(nets[4], LibStoxDeployNetworks.BSC);
     }
 
     /// @notice A chain outside the allowlist refuses at pre-flight — the

--- a/test/script/20260729-deploy-governance-timelock.t.sol
+++ b/test/script/20260729-deploy-governance-timelock.t.sol
@@ -40,10 +40,11 @@ contract DeployGovernanceTimelockTest is Test {
     /// body, which the per-chain tests below exercise.
     function testNetworksCoversEveryProductionChain() external {
         string[] memory nets = new DeployGovernanceTimelockHarness().callNetworks();
-        assertEq(nets.length, 3);
+        assertEq(nets.length, 4);
         assertEq(nets[0], LibRainDeploy.BASE);
         assertEq(nets[1], LibStoxDeployNetworks.ETHEREUM);
         assertEq(nets[2], LibStoxDeployNetworks.HYPEREVM);
+        assertEq(nets[3], LibStoxDeployNetworks.ROBINHOOD);
     }
 
     /// @notice A chain outside the allowlist refuses at pre-flight — the


### PR DESCRIPTION
`20260729-deploy-governance-timelock.networks()` gains `robinhood`, so the next `manual-broadcast` dispatch lands the timelock at its derived pin on 4663 and skips-with-assert the three chains already carrying theirs. `docs/TIMELOCK.md` names the fourth chain in the constants table and rollout steps.

The per-chain migration-window fork test and the four `.prod.t.sol` rollout tests for 4663 arrive with the post-execution hydration PR, once the chain carries tokens for them to walk (HyperEVM's arrived the same way).

## BNB Smart Chain (56), added 2026-09-10
Second commit: `bsc` in `networks()`, fifth chain in `docs/TIMELOCK.md`.

## Checks
Local: `forge fmt`, `testNetworksCoversEveryProductionChain` green.


Linear: [RAI-2285](https://linear.app/makeitrain/issue/RAI-2285) (parent [RAI-2284](https://linear.app/makeitrain/issue/RAI-2284)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3
