### PR TITLE
Pin the orchestrator's DEPOSIT/WITHDRAW grants on the V4 authoriser

### DIFF
--- a/script/20260619-deploy-v4-authoriser-clone.s.sol
+++ b/script/20260619-deploy-v4-authoriser-clone.s.sol
@@ -81,7 +81,7 @@ error GrantsSliceOutOfRange(uint256 startIndex, uint256 sliceLength, uint256 gra
 ///      DEPOSIT / WITHDRAW; two override: SCHEDULE_CORPORATE_ACTION /
 ///      CANCEL_CORPORATE_ACTION) therefore land on the deployer, not the
 ///      Safe.
-///   2. Grants the six non-admin roles enumerated in
+///   2. Grants the non-admin roles enumerated in
 ///      `LibAuthoriserInvariants.expectedGrants()` (indices
 ///      `MIRROR_START_INDEX ..`) to their pinned grantees. These are the
 ///      operational `DEPOSIT` / `WITHDRAW` / `CERTIFY` provisions.
@@ -126,13 +126,13 @@ contract DeployV4AuthoriserClone is Script {
     /// seven `_ADMIN` grants (five auto-granted by the base `initialize`
     /// on the freshly-cloned V4 authoriser, plus the two corporate-action
     /// admins the ST0x override adds — all transferred to the Safe by
-    /// steps 3-4). Indices 7..12 are the operational grants (`DEPOSIT` /
-    /// `WITHDRAW` / `CERTIFY` × Safe + service signer) this script mirrors
-    /// in.
+    /// steps 3-4). Indices 7..14 are the operational grants (`DEPOSIT` /
+    /// `WITHDRAW` / `CERTIFY` × Safe + service signer, `DEPOSIT` /
+    /// `WITHDRAW` × orchestrator) this script mirrors in.
     uint256 internal constant MIRROR_START_INDEX = 7;
 
     /// @notice The number of non-admin grants this script mirrors in.
-    uint256 internal constant MIRROR_COUNT = 6;
+    uint256 internal constant MIRROR_COUNT = 8;
 
     /// @notice The number of `_ADMIN` roles the base + ST0x-override
     /// `initialize` auto-grant to `initialAdmin` (five base + two
@@ -225,8 +225,7 @@ contract DeployV4AuthoriserClone is Script {
 
         IAccessControl acl = IAccessControl(clone);
 
-        // Step 2: mirror the six non-admin operational grants
-        // (`DEPOSIT` / `WITHDRAW` / `CERTIFY` × service + Safe).
+        // Step 2: mirror the non-admin operational grants.
         for (uint256 i = 0; i < MIRROR_COUNT; i++) {
             RoleGrant memory grant = allGrants[MIRROR_START_INDEX + i];
             acl.grantRole(grant.role, grant.grantee);
@@ -292,9 +291,9 @@ contract DeployV4AuthoriserClone is Script {
         address safe = LibSafeInvariants.safeForChainId(block.chainid);
         RoleGrant[] memory allGrants = LibAuthoriserInvariants.expectedGrants(safe);
 
-        // Every `(role, grantee)` in the chain's 13-entry grant map holds:
-        // all seven `_ADMIN` roles on the Safe (swapped there in step 3) AND
-        // the six operational grants from step 2, in one sweep.
+        // Every `(role, grantee)` in the chain's grant map holds: all seven
+        // `_ADMIN` roles on the Safe (swapped there in step 3) AND the
+        // operational grants from step 2, in one sweep.
         for (uint256 i = 0; i < allGrants.length; i++) {
             if (!acl.hasRole(allGrants[i].role, allGrants[i].grantee)) {
                 revert ExpectedGrantMissing(allGrants[i].role, allGrants[i].grantee);

--- a/script/20260623-upgrade-receipt-vaults-to-v4.s.sol
+++ b/script/20260623-upgrade-receipt-vaults-to-v4.s.sol
@@ -304,12 +304,10 @@ contract UpgradeReceiptVaultsToV4 is Script {
                 V4_AUTHORISER_CLONE, LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH, cloneCodehash
             );
         }
-        // The master `expectedGrants()` map holds on the clone — 13 entries
-        // covering all seven `_ADMIN` roles on the Safe (including the two
-        // V4-only corporate-action admins; without them the swapped clone
-        // can't admin corporate actions, so this is the enforcement point
-        // that must reject a mis-configured clone) plus the six operational
-        // action roles.
+        // The master `expectedGrants()` map holds on the clone, including
+        // the two V4-only corporate-action admins on the Safe (without them
+        // the swapped clone can't admin corporate actions, so this is the
+        // enforcement point that must reject a mis-configured clone).
         IAccessControl cloneAcl = IAccessControl(V4_AUTHORISER_CLONE);
         RoleGrant[] memory expected = LibAuthoriserInvariants.expectedGrants();
         for (uint256 i = 0; i < expected.length; i++) {

--- a/script/20260729-migrate-governance-to-timelock.s.sol
+++ b/script/20260729-migrate-governance-to-timelock.s.sol
@@ -175,8 +175,8 @@ error GovernanceLoopNotProven(bytes32 id);
 ///    timelock pin is hydrated and `assertTimelockState` passes (codehash,
 ///    48h delay, Safe as sole proposer/canceller/executor,
 ///    self-administration, no open roles); the chain's V4 authoriser clone
-///    carries the pinned codehash and its six operational grants (service
-///    signer + Safe action roles) are intact.
+///    carries the pinned codehash and its operational grants (service
+///    signer, Safe and orchestrator action roles) are intact.
 /// 2. **Select** — still-Safe-owned vaults, still-Safe-owned beacons and
 ///    still-Safe-held `_ADMIN` roles, from live chain state.
 /// 3. **Build** — grants, then vault transfers, then beacon transfers,

--- a/script/20260831-enable-orchestrator-roles.s.sol
+++ b/script/20260831-enable-orchestrator-roles.s.sol
@@ -75,10 +75,10 @@ error OrchestratorRolesAlreadyEnabled();
 /// authored, and a fully-enabled chain refuses
 /// (`OrchestratorRolesAlreadyEnabled`).
 ///
-/// The post-execution pin PR ADDS the orchestrator's DEPOSIT/WITHDRAW rows
-/// to the authoriser grant map (nothing is removed — the signer's rows
-/// stay until the retire script executes) and retires this script's
-/// fixtures.
+/// The orchestrator's DEPOSIT/WITHDRAW rows are pinned in the authoriser
+/// grant map (nothing is removed — the signer's rows stay until the retire
+/// script executes), so the pre-flight map check refuses a chain that has
+/// not executed: authoring is closed on every chain.
 contract EnableOrchestratorRoles is Script {
     /// @notice The service signer whose direct vault access moves behind
     /// the orchestrator.

--- a/src/lib/LibAuthoriserInvariants.sol
+++ b/src/lib/LibAuthoriserInvariants.sol
@@ -148,6 +148,12 @@ library LibAuthoriserInvariants {
     /// state.
     address internal constant GRANTEE_SERVICE_3D0C = 0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE;
 
+    /// @notice The production orchestrator instance, granted `DEPOSIT` and
+    /// `WITHDRAW` on each chain's authoriser by
+    /// `20260831-enable-orchestrator-roles` so the service signer can mint
+    /// and burn through it. Same address on every chain.
+    address internal constant GRANTEE_ORCHESTRATOR = LibProdDeployV4.ST0X_ORCHESTRATOR_INSTANCE;
+
     /// @notice The full `(role, grantee)` map in effect on the Base
     /// production authoriser. Delegates to the Safe-parametric overload with
     /// Base's token-owner Safe.
@@ -189,7 +195,7 @@ library LibAuthoriserInvariants {
         pure
         returns (RoleGrant[] memory grants)
     {
-        grants = new RoleGrant[](13);
+        grants = new RoleGrant[](15);
 
         // Init grants (block 41715184 on Base) — the admin holder receives
         // every `_ADMIN` (the Safe at init; the governance timelock once the
@@ -218,6 +224,12 @@ library LibAuthoriserInvariants {
         grants[10] = RoleGrant(keccak256("DEPOSIT"), GRANTEE_SERVICE_3D0C);
         grants[11] = RoleGrant(keccak256("WITHDRAW"), GRANTEE_SERVICE_3D0C);
         grants[12] = RoleGrant(keccak256("CERTIFY"), GRANTEE_SERVICE_3D0C);
+
+        // Orchestrator vault access, granted by the 20260831 enable bundle;
+        // the signer's direct rows above stay until the retire bundle
+        // executes.
+        grants[13] = RoleGrant(keccak256("DEPOSIT"), GRANTEE_ORCHESTRATOR);
+        grants[14] = RoleGrant(keccak256("WITHDRAW"), GRANTEE_ORCHESTRATOR);
     }
 
     /// @notice Assert every pinned `(role, grantee)` pair in
@@ -253,8 +265,9 @@ library LibAuthoriserInvariants {
     /// @notice Assert every `(role, grantee)` pair from
     /// `expectedGrants(tokenOwnerSafe, adminHolder)` is held on the supplied
     /// authoriser, that no named principal — the Safe, the admin holder,
-    /// the service signer — holds `DEFAULT_ADMIN_ROLE`, and that when the
-    /// admin holder is distinct from the Safe, the Safe retains NO `_ADMIN`
+    /// the service signer, the orchestrator — holds `DEFAULT_ADMIN_ROLE`,
+    /// and that when the admin holder is distinct from the Safe, the Safe
+    /// retains NO `_ADMIN`
     /// entry (exclusive holding — a retained copy would let the Safe mutate
     /// the grant map without the admin holder's delay). This is the
     /// post-timelock-migration assertion surface: the migration script's
@@ -280,6 +293,9 @@ library LibAuthoriserInvariants {
         }
         if (acl.hasRole(DEFAULT_ADMIN_ROLE, GRANTEE_SERVICE_3D0C)) {
             revert UnexpectedDefaultAdmin(authoriser, GRANTEE_SERVICE_3D0C);
+        }
+        if (acl.hasRole(DEFAULT_ADMIN_ROLE, GRANTEE_ORCHESTRATOR)) {
+            revert UnexpectedDefaultAdmin(authoriser, GRANTEE_ORCHESTRATOR);
         }
         assertRetiredSignerAbsent(acl, authoriser);
         RoleGrant[] memory grants = expectedGrants(tokenOwnerSafe, adminHolder);

--- a/test/script/20260619-deploy-v4-authoriser-clone.t.sol
+++ b/test/script/20260619-deploy-v4-authoriser-clone.t.sol
@@ -92,9 +92,9 @@ contract DeployV4AuthoriserCloneTest is Test {
         RoleGrant[] memory allGrants = LibAuthoriserInvariants.expectedGrants();
         bytes32[7] memory adminRoles = _autoGrantedAdminRoles();
 
-        // Step 2: mirror the six operational grants (indices 7..12 of the
-        // master map) under the deployer (who holds every `_ADMIN` role
-        // from init).
+        // Step 2: mirror the operational grants (indices 7.. of the master
+        // map) under the deployer (who holds every `_ADMIN` role from
+        // init).
         for (uint256 i = 7; i < allGrants.length; i++) {
             vm.prank(deployer, deployer);
             acl.grantRole(allGrants[i].role, allGrants[i].grantee);
@@ -215,7 +215,7 @@ contract DeployV4AuthoriserCloneTest is Test {
         RoleGrant[] memory allGrants = LibAuthoriserInvariants.expectedGrants();
         bytes32[7] memory adminRoles = _autoGrantedAdminRoles();
 
-        // Step 2: mirror the operational grants (indices 7..12).
+        // Step 2: mirror the operational grants (indices 7..).
         for (uint256 i = 7; i < allGrants.length; i++) {
             if (i == skipMirrorIndex) continue;
             vm.prank(deployer, deployer);
@@ -256,6 +256,21 @@ contract DeployV4AuthoriserCloneTest is Test {
         selectBaseFork();
         RoleGrant[] memory allGrants = LibAuthoriserInvariants.expectedGrants();
         uint256 skipped = 7;
+        address clone = _deployAndConfigure(false, skipped, type(uint256).max);
+        vm.expectRevert(
+            abi.encodeWithSelector(ExpectedGrantMissing.selector, allGrants[skipped].role, allGrants[skipped].grantee)
+        );
+        harness.callAssertPostState(clone, deployer, v4Impl);
+    }
+
+    /// @notice `_assertPostState` reverts `ExpectedGrantMissing` when an
+    /// orchestrator grant is absent: the mirror slice covers the
+    /// orchestrator rows, so a fresh clone without them is refused.
+    function testAssertPostStateRejectsMissingOrchestratorGrant() external {
+        selectBaseFork();
+        RoleGrant[] memory allGrants = LibAuthoriserInvariants.expectedGrants();
+        uint256 skipped = 13;
+        assertEq(allGrants[skipped].grantee, LibAuthoriserInvariants.GRANTEE_ORCHESTRATOR);
         address clone = _deployAndConfigure(false, skipped, type(uint256).max);
         vm.expectRevert(
             abi.encodeWithSelector(ExpectedGrantMissing.selector, allGrants[skipped].role, allGrants[skipped].grantee)
@@ -335,7 +350,7 @@ contract DeployV4AuthoriserCloneTest is Test {
         selectBaseFork();
         RoleGrant[] memory allGrants = LibAuthoriserInvariants.expectedGrants();
         assertEq(harness.mirrorStartIndex(), 7, "MIRROR_START_INDEX drifted from the happy-path replica");
-        assertEq(harness.mirrorCount(), 6, "MIRROR_COUNT drifted from the happy-path replica");
+        assertEq(harness.mirrorCount(), 8, "MIRROR_COUNT drifted from the happy-path replica");
         assertEq(
             harness.mirrorStartIndex() + harness.mirrorCount(),
             allGrants.length,

--- a/test/script/20260706-deploy-tokens-ethereum.t.sol
+++ b/test/script/20260706-deploy-tokens-ethereum.t.sol
@@ -12,8 +12,7 @@ import {
 } from "../../script/20260706-deploy-tokens-ethereum.s.sol";
 import {LibTokenInvariants, TokenInstance} from "../../src/lib/LibTokenInvariants.sol";
 import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
-import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
-import {LibAuthoriserInvariants, RoleGrant} from "../../src/lib/LibAuthoriserInvariants.sol";
+import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
@@ -156,13 +155,6 @@ contract DeployTokensEthereumTest is Test {
             clone.codehash, LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH, "Ethereum clone codehash mismatch"
         );
 
-        RoleGrant[] memory grants =
-            LibAuthoriserInvariants.expectedGrants(LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM);
-        for (uint256 i = 0; i < grants.length; i++) {
-            assertTrue(
-                IAccessControl(clone).hasRole(grants[i].role, grants[i].grantee),
-                "Ethereum clone missing expected grant"
-            );
-        }
+        LibAuthoriserInvariants.assertExpectedGrants(clone, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM);
     }
 }

--- a/test/script/20260831-enable-orchestrator-roles.prod.t.sol
+++ b/test/script/20260831-enable-orchestrator-roles.prod.t.sol
@@ -4,117 +4,34 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {console2} from "forge-std-1.16.1/src/console2.sol";
-import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
 import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 
-import {FleetNotUpgraded, OrchestratorRolesAlreadyEnabled} from "../../script/20260831-enable-orchestrator-roles.s.sol";
+import {OrchestratorRolesAlreadyEnabled} from "../../script/20260831-enable-orchestrator-roles.s.sol";
 import {EnableOrchestratorRolesHarness} from "./EnableOrchestratorRolesHarness.sol";
-import {
-    LibOrchestratorInvariants,
-    OrchestratorInstanceMissing,
-    OrchestratorSetDeployerMissing
-} from "../../src/lib/LibOrchestratorInvariants.sol";
+import {LibOrchestratorInvariants} from "../../src/lib/LibOrchestratorInvariants.sol";
 import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
-import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
-import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
 
-/// @notice The enable deadline passed with this chain still pending.
-/// Run the outstanding dispatches, extend the deadline, or delete the
-/// invariant.
-/// @param label The chain still pending.
-error OrchestratorEnableOverdue(string label);
-
 /// @title EnableOrchestratorRolesProdTest
-/// @notice PROD coverage for the orchestrator enable: what production IS on each
-/// chain, read from a real fork with no mocks, walking the rollout states:
-///
-/// 1. **Orchestrator world pending** (every chain today): `run()`'s
-///    pre-flight refuses at the 0.1.30 beacon-set read
-///    (`OrchestratorSetDeployerMissing`) — the closure + instance dispatches
-///    come first.
-/// 2. **Fleet pending** (orchestrator live, production beacons still on
-///    pre-0.1.30 impls): pins the `FleetNotUpgraded` interlock — the rule
-///    that vault access is granted only after the fleet upgrade (RAI-2125).
-/// 3. **Ready** (fleet upgraded, not cut over): drives `run()` end to end
-///    on the fork — bundle authored, simulated, post-state and n+1 proven.
-/// 4. **Executed** (the parallel burn-in state): the orchestrator holds
-///    vault access, the signer holds MINT/BURN on it AND keeps its direct
-///    roles (the fallback path the retire script removes later); plus the
-///    re-authoring refusal.
-///
-/// States 1–3 stop passing at `ENABLE_DEADLINE`; state 4 is steady and
-/// never expires.
+/// @notice PROD coverage for the orchestrator enable: what production IS on
+/// each chain, read from a real fork with no mocks. The enable has executed
+/// on every chain, so each fork is in the parallel burn-in state: the fleet
+/// interlock passes, the orchestrator holds vault access, the signer holds
+/// MINT/BURN on it AND keeps its direct roles (the fallback path the retire
+/// script removes later), and re-authoring refuses.
 contract EnableOrchestratorRolesProdTest is Test {
-    /// @notice Unix timestamp (2026-10-01T00:00:00Z) past which a chain
-    /// still in a pending state fails instead of logging PENDING. Shared
-    /// with the orchestrator rollout deadline — the cutover is its last
-    /// step.
-    uint256 internal constant ENABLE_DEADLINE = 1_790_812_800;
-
-    /// @notice Walk the active fork's cutover state (see the contract
-    /// NatSpec) and assert it.
+    /// @notice Assert the active fork's executed state (see the contract
+    /// NatSpec).
     /// @param label Human chain name, surfaced in logs and messages.
-    function assertEnableRollout(string memory label) internal {
+    function assertEnableExecuted(string memory label) internal {
         EnableOrchestratorRolesHarness script = new EnableOrchestratorRolesHarness();
-        address setDeployer = LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30;
         address orchestrator = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
 
-        if (setDeployer.code.length == 0 || orchestrator.code.length == 0) {
-            if (block.timestamp >= ENABLE_DEADLINE) {
-                revert OrchestratorEnableOverdue(label);
-            }
-            console2.log(string.concat("PENDING [", label, "]: 0.1.30 orchestrator world not deployed"));
-            console2.log("-> manual-sol-artifacts-0-1-30 suites, then 20260818-deploy-orchestrator, come first");
-            // run() reads the beacon set before the instance, so whichever
-            // is missing first decides the revert.
-            if (setDeployer.code.length == 0) {
-                vm.expectRevert(abi.encodeWithSelector(OrchestratorSetDeployerMissing.selector, setDeployer));
-            } else {
-                vm.expectRevert(abi.encodeWithSelector(OrchestratorInstanceMissing.selector, orchestrator));
-            }
-            script.run();
-            return;
-        }
-
-        address[4] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
-        bool fleetUpgraded = IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
-                == LibProdDeployV4.STOX_RECEIPT_0_1_30
-            && IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation()
-                == LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30;
-        if (!fleetUpgraded) {
-            if (block.timestamp >= ENABLE_DEADLINE) {
-                revert OrchestratorEnableOverdue(label);
-            }
-            console2.log(string.concat("PENDING [", label, "]: fleet not upgraded to 0.1.30 - cutover gated"));
-            console2.log("-> execute the fleet beacon-repoint through governance first");
-            vm.expectRevert(
-                abi.encodeWithSelector(
-                    FleetNotUpgraded.selector,
-                    beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
-                    LibProdDeployV4.STOX_RECEIPT_0_1_30,
-                    IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation()
-                )
-            );
-            script.run();
-            return;
-        }
+        script.callAssertFleetUpgraded();
 
         IAccessControl acl = IAccessControl(script.callActiveChainAuthoriser());
-        bool enabled = acl.hasRole(keccak256("DEPOSIT"), orchestrator);
-        if (!enabled) {
-            if (block.timestamp >= ENABLE_DEADLINE) {
-                revert OrchestratorEnableOverdue(label);
-            }
-            console2.log(string.concat("PENDING [", label, "]: ready - driving the authoring end to end"));
-            script.run();
-            return;
-        }
-
-        // Executed steady state — the parallel burn-in: the orchestrator
-        // holds vault access AND the signer keeps its direct roles until
-        // the retire script removes them.
+        assertTrue(acl.hasRole(keccak256("DEPOSIT"), orchestrator), string.concat(label, ": orchestrator DEPOSIT"));
         assertTrue(acl.hasRole(keccak256("WITHDRAW"), orchestrator), string.concat(label, ": orchestrator WITHDRAW"));
         IAccessControl orch = IAccessControl(orchestrator);
         assertTrue(
@@ -134,18 +51,18 @@ contract EnableOrchestratorRolesProdTest is Test {
         script.run();
     }
 
-    function testEnableRolloutBase() external {
+    function testEnableExecutedBase() external {
         vm.createSelectFork(LibRainDeploy.BASE);
-        assertEnableRollout("base");
+        assertEnableExecuted("base");
     }
 
-    function testEnableRolloutEthereum() external {
+    function testEnableExecutedEthereum() external {
         vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
-        assertEnableRollout("ethereum");
+        assertEnableExecuted("ethereum");
     }
 
-    function testEnableRolloutHyperEvm() external {
+    function testEnableExecutedHyperEvm() external {
         vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
-        assertEnableRollout("hyperevm");
+        assertEnableExecuted("hyperevm");
     }
 }

--- a/test/script/20260831-enable-orchestrator-roles.t.sol
+++ b/test/script/20260831-enable-orchestrator-roles.t.sol
@@ -12,7 +12,7 @@ import {
     OrchestratorRolesAlreadyEnabled
 } from "../../script/20260831-enable-orchestrator-roles.s.sol";
 import {EnableOrchestratorRolesHarness} from "./EnableOrchestratorRolesHarness.sol";
-import {LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
+import {ExpectedGrantMissing, LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
 import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
@@ -22,7 +22,7 @@ import {SafeTx} from "../../src/lib/LibSafeOps.sol";
 /// @notice Guard coverage for `20260831-enable-orchestrator-roles` without
 /// a full replica: the fleet-upgrade interlock, the orchestrator-admin
 /// refusal, the self-scoping, and the already-executed refusal are each
-/// shown to fire. The live-fork walk of the rollout states is in
+/// shown to fire. The live-fork read of the executed state is in
 /// `20260831-enable-orchestrator-roles.prod.t.sol`.
 contract EnableOrchestratorRolesTest is Test {
     EnableOrchestratorRolesHarness internal harness;
@@ -55,16 +55,18 @@ contract EnableOrchestratorRolesTest is Test {
         );
     }
 
-    /// @notice Mock the canonical grant map fully held on the authoriser,
-    /// with no principal holding `DEFAULT_ADMIN_ROLE`, and the Safe holding
-    /// orchestrator admin. `hasRole` defaults are then narrowed per test.
+    /// @notice Mock the canonical grant map (orchestrator rows included)
+    /// fully held on the authoriser, with no principal holding
+    /// `DEFAULT_ADMIN_ROLE`, and the Safe holding orchestrator admin with
+    /// the signer's orchestrator roles not yet granted. `hasRole` defaults
+    /// are then narrowed per test.
     function mockHealthyPrincipals() internal {
         vm.etch(AUTHORISER, hex"fe");
         vm.etch(ORCHESTRATOR, hex"fe");
         // Default every authoriser hasRole probe to true, then carve out the
         // DEFAULT_ADMIN probes the map assertion requires to be false.
         vm.mockCall(AUTHORISER, abi.encodeWithSelector(IAccessControl.hasRole.selector), abi.encode(true));
-        address[4] memory admins = [SAFE, SAFE, LibAuthoriserInvariants.GRANTEE_SERVICE_1C66, SIGNER];
+        address[5] memory admins = [SAFE, SAFE, LibAuthoriserInvariants.GRANTEE_SERVICE_1C66, SIGNER, ORCHESTRATOR];
         for (uint256 i = 0; i < admins.length; i++) {
             vm.mockCall(AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), admins[i])), abi.encode(false));
         }
@@ -77,16 +79,9 @@ contract EnableOrchestratorRolesTest is Test {
                 abi.encode(false)
             );
         }
-        // Orchestrator: Safe is admin; signer holds nothing yet; the
-        // orchestrator itself holds no direct vault roles yet.
+        // Orchestrator: Safe is admin; signer holds nothing yet.
         vm.mockCall(ORCHESTRATOR, abi.encodeWithSelector(IAccessControl.hasRole.selector), abi.encode(false));
         vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), SAFE)), abi.encode(true));
-        bytes32[2] memory vaultRoles = [keccak256("DEPOSIT"), keccak256("WITHDRAW")];
-        for (uint256 i = 0; i < vaultRoles.length; i++) {
-            vm.mockCall(
-                AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (vaultRoles[i], ORCHESTRATOR)), abi.encode(false)
-            );
-        }
     }
 
     /// The fleet-upgrade interlock refuses beacons still on pre-0.1.30
@@ -125,47 +120,37 @@ contract EnableOrchestratorRolesTest is Test {
         harness.callAuthorBundle(AUTHORISER, ORCHESTRATOR, SAFE);
     }
 
-    /// The fresh pre-enable state authors all four transactions in the
-    /// fixed order: grant orchestrator both vault roles, grant the signer
-    /// both orchestrator roles. NO revokes — the signer's direct roles stay
-    /// for the parallel burn-in window.
-    function testAuthoringProducesTheFullFourTxBundle() external {
-        mockHealthyPrincipals();
-        SafeTx[] memory txs = harness.callAuthorBundle(AUTHORISER, ORCHESTRATOR, SAFE);
-        assertEq(txs.length, 4);
-        assertEq(txs[0].to, AUTHORISER);
-        assertEq(txs[0].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("DEPOSIT"), ORCHESTRATOR)));
-        assertEq(txs[1].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("WITHDRAW"), ORCHESTRATOR)));
-        assertEq(txs[2].to, ORCHESTRATOR);
-        assertEq(txs[2].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("MINT"), SIGNER)));
-        assertEq(txs[3].to, ORCHESTRATOR);
-        assertEq(txs[3].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("BURN"), SIGNER)));
-    }
-
-    /// A partially-executed cutover self-scopes: an orchestrator grant that
-    /// already landed is not re-authored (the canonical map is untouched by
-    /// EXTRA holders, so the map gate still passes).
-    function testAuthoringSelfScopesLandedOrchestratorGrants() external {
+    /// A pre-enable authoriser — the orchestrator's vault rows absent — is
+    /// refused by the map gate: the rows are pinned, so authoring is
+    /// closed everywhere the enable has not executed.
+    function testAuthoringRefusesAPreEnableMap() external {
         mockHealthyPrincipals();
         vm.mockCall(
-            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("DEPOSIT"), ORCHESTRATOR)), abi.encode(true)
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("DEPOSIT"), ORCHESTRATOR)), abi.encode(false)
         );
-        SafeTx[] memory txs = harness.callAuthorBundle(AUTHORISER, ORCHESTRATOR, SAFE);
-        assertEq(txs.length, 3);
-        assertEq(txs[0].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("WITHDRAW"), ORCHESTRATOR)));
+        vm.expectRevert(
+            abi.encodeWithSelector(ExpectedGrantMissing.selector, AUTHORISER, keccak256("DEPOSIT"), ORCHESTRATOR)
+        );
+        harness.callAuthorBundle(AUTHORISER, ORCHESTRATOR, SAFE);
     }
 
-    /// A fully-enabled chain refuses to author anything — and because the
-    /// enable removes no map rows, this refusal is reachable immediately
-    /// after execution, before any pin PR.
+    /// With the authoriser half landed, authoring self-scopes to the
+    /// orchestrator half in the fixed order: grant the signer MINT, then
+    /// BURN. NO revokes — the signer's direct roles stay for the parallel
+    /// burn-in window.
+    function testAuthoringSelfScopesToTheOrchestratorHalf() external {
+        mockHealthyPrincipals();
+        SafeTx[] memory txs = harness.callAuthorBundle(AUTHORISER, ORCHESTRATOR, SAFE);
+        assertEq(txs.length, 2);
+        assertEq(txs[0].to, ORCHESTRATOR);
+        assertEq(txs[0].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("MINT"), SIGNER)));
+        assertEq(txs[1].to, ORCHESTRATOR);
+        assertEq(txs[1].data, abi.encodeCall(IAccessControl.grantRole, (keccak256("BURN"), SIGNER)));
+    }
+
+    /// A fully-enabled chain refuses to author anything.
     function testRefusesWhenAlreadyEnabled() external {
         mockHealthyPrincipals();
-        vm.mockCall(
-            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("DEPOSIT"), ORCHESTRATOR)), abi.encode(true)
-        );
-        vm.mockCall(
-            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("WITHDRAW"), ORCHESTRATOR)), abi.encode(true)
-        );
         vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (keccak256("MINT"), SIGNER)), abi.encode(true));
         vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (keccak256("BURN"), SIGNER)), abi.encode(true));
         vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), SAFE)), abi.encode(true));

--- a/test/src/concrete/deploy/StoxProdV4PostSwap.t.sol
+++ b/test/src/concrete/deploy/StoxProdV4PostSwap.t.sol
@@ -82,7 +82,7 @@ contract StoxProdV4PostSwapTest is Test {
     /// Base-only.
     /// @dev The swap has executed: every production receipt vault reports
     /// the V4 clone. `LibAuthoriserInvariants.assertAll()` asserts the
-    /// clone's pinned codehash and its full 13-entry grant map, so no
+    /// clone's pinned codehash and its full grant map, so no
     /// separate hydration guard or hand-listed admin sweep is needed here.
     function checkPostSwapAuthoriserStateOnBase() internal view {
         LibTokenInvariants.assertUniformAuthoriser(LibAuthoriserInvariants.STOX_PROD_AUTHORISER);

--- a/test/src/lib/LibAuthoriserInvariants.t.sol
+++ b/test/src/lib/LibAuthoriserInvariants.t.sol
@@ -13,6 +13,7 @@ import {
     UnexpectedRetiredSignerGrant,
     AuthoriserImplCodehashMismatch
 } from "../../../src/lib/LibAuthoriserInvariants.sol";
+import {LibSafeInvariants} from "../../../src/lib/LibSafeInvariants.sol";
 import {LibProdDeployV4} from "../../../src/generated/LibProdDeployV4.sol";
 import {LibAuthoriserInvariantsHarness} from "./LibAuthoriserInvariantsHarness.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
@@ -85,15 +86,15 @@ contract LibAuthoriserInvariantsTest is Test {
     }
 
     /// @notice The admin-holder parameterisation: the seven `_ADMIN` entries
-    /// track `adminHolder`, the six operational entries stay split between
-    /// the service signer and the Safe, and the narrower overloads are exact
-    /// collapses of the widest one (so no consumer can drift from the single
-    /// map).
+    /// track `adminHolder`, the eight operational entries stay split between
+    /// the Safe, the service signer and the orchestrator, and the narrower
+    /// overloads are exact collapses of the widest one (so no consumer can
+    /// drift from the single map).
     function testExpectedGrantsAdminHolderParameterisation() external pure {
         address safe = address(0x5AFE);
         address timelock = address(0x7135);
         RoleGrant[] memory grants = LibAuthoriserInvariants.expectedGrants(safe, timelock);
-        assertEq(grants.length, 13);
+        assertEq(grants.length, 15);
         for (uint256 i = 0; i < 7; i++) {
             assertEq(grants[i].grantee, timelock, "admin entries must track adminHolder");
         }
@@ -112,6 +113,12 @@ contract LibAuthoriserInvariantsTest is Test {
                 "service signer entries must be independent of adminHolder"
             );
         }
+        // The orchestrator's vault access: DEPOSIT and WITHDRAW only (no
+        // CERTIFY surface), independent of both parameters.
+        assertEq(grants[13].role, keccak256("DEPOSIT"));
+        assertEq(grants[13].grantee, LibAuthoriserInvariants.GRANTEE_ORCHESTRATOR);
+        assertEq(grants[14].role, keccak256("WITHDRAW"));
+        assertEq(grants[14].grantee, LibAuthoriserInvariants.GRANTEE_ORCHESTRATOR);
 
         // The two-arg overload is the adminHolder == Safe collapse.
         RoleGrant[] memory collapsed = LibAuthoriserInvariants.expectedGrants(safe);
@@ -184,6 +191,47 @@ contract LibAuthoriserInvariantsTest is Test {
             abi.encode(true)
         );
         vm.expectRevert(abi.encodeWithSelector(UnexpectedRetiredSignerGrant.selector, clone, keccak256("WITHDRAW")));
+        harness.callAssertExpectedGrants(clone);
+    }
+
+    /// @notice The orchestrator rows are strict like every other row, under
+    /// every production chain id alike: a revoked orchestrator `WITHDRAW`
+    /// red-lines as `ExpectedGrantMissing` naming the orchestrator. Driven
+    /// on the Base fork with the chain id switched, so the row state is the
+    /// same under each id.
+    function testAssertExpectedGrantsRejectsARevokedOrchestratorGrant() external {
+        selectBaseFork();
+        address clone = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+        address orchestrator = LibAuthoriserInvariants.GRANTEE_ORCHESTRATOR;
+        LibAuthoriserInvariantsHarness harness = new LibAuthoriserInvariantsHarness();
+        vm.mockCall(
+            clone,
+            abi.encodeWithSelector(IAccessControl.hasRole.selector, keccak256("WITHDRAW"), orchestrator),
+            abi.encode(false)
+        );
+        uint256[3] memory chainIds =
+            [LibSafeInvariants.BASE_CHAIN_ID, LibSafeInvariants.ETHEREUM_CHAIN_ID, LibSafeInvariants.HYPEREVM_CHAIN_ID];
+        for (uint256 i = 0; i < chainIds.length; i++) {
+            vm.chainId(chainIds[i]);
+            vm.expectRevert(
+                abi.encodeWithSelector(ExpectedGrantMissing.selector, clone, keccak256("WITHDRAW"), orchestrator)
+            );
+            harness.callAssertExpectedGrants(clone);
+        }
+    }
+
+    /// @notice The orchestrator is a pinned grantee, so it joins the
+    /// `DEFAULT_ADMIN_ROLE` negative: root admin on the orchestrator
+    /// red-lines as `UnexpectedDefaultAdmin` naming it.
+    function testAssertExpectedGrantsRejectsOrchestratorDefaultAdmin() external {
+        selectBaseFork();
+        address clone = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+        address orchestrator = LibAuthoriserInvariants.GRANTEE_ORCHESTRATOR;
+        vm.mockCall(
+            clone, abi.encodeWithSelector(IAccessControl.hasRole.selector, bytes32(0), orchestrator), abi.encode(true)
+        );
+        LibAuthoriserInvariantsHarness harness = new LibAuthoriserInvariantsHarness();
+        vm.expectRevert(abi.encodeWithSelector(UnexpectedDefaultAdmin.selector, clone, orchestrator));
         harness.callAssertExpectedGrants(clone);
     }
 }


### PR DESCRIPTION
`20260831-enable-orchestrator-roles` has executed on Base, Ethereum and HyperEVM, so every chain's V4 authoriser grants `DEPOSIT` and `WITHDRAW` to `LibProdDeployV4.ST0X_ORCHESTRATOR_INSTANCE` while `LibAuthoriserInvariants.expectedGrants` still pinned a 13-row map without them. This pins the two rows, strict on every chain like the other 13.

- `LibAuthoriserInvariants`: `GRANTEE_ORCHESTRATOR`; map 13 -> 15 rows (`grants[13]` = `DEPOSIT`, `grants[14]` = `WITHDRAW`); the orchestrator joins the `DEFAULT_ADMIN_ROLE` negative. The row loop is unchanged: plain `ExpectedGrantMissing`, no window, no chain-id branch.
- `20260619-deploy-v4-authoriser-clone`: `MIRROR_COUNT` 6 -> 8 so a fresh clone mirrors the orchestrator rows; test asserts 8 and adds `testAssertPostStateRejectsMissingOrchestratorGrant`.
- `20260831-enable-orchestrator-roles`: the "post-execution pin PR" paragraph becomes what the pinned rows mean for the script (its map gate now refuses a pre-enable authoriser, so authoring is closed everywhere); pre/post asserts unchanged. Unit test: the four-tx and landed-`DEPOSIT` fixtures are replaced by the pre-enable refusal (`ExpectedGrantMissing`) and the orchestrator-half self-scope (MINT, BURN); the fleet gate, orchestrator-admin refusal and already-enabled refusal stay. Prod test: the pending walk (states 1-3, `ENABLE_DEADLINE`, `OrchestratorEnableOverdue`) is gone; each fork asserts the executed state — fleet interlock, orchestrator `DEPOSIT`/`WITHDRAW`, signer MINT/BURN, re-authoring refusal.
- `20260706-deploy-tokens-ethereum` test: bespoke row loop -> `assertExpectedGrants(clone, STOX_TOKEN_OWNER_SAFE_ETHEREUM)`.
- Stale "six"/"13-entry" count comments trimmed where they sat next to the changed constants.

No CHANGELOG entry or doc restating the map.

## QA
- Discriminating tests: `testExpectedGrantsAdminHolderParameterisation` (15 rows, rows 13/14 pinned to `(DEPOSIT|WITHDRAW, GRANTEE_ORCHESTRATOR)`, independent of both parameters); `testAssertExpectedGrantsRejectsARevokedOrchestratorGrant` (`WITHDRAW` mocked absent under each of the Base / Ethereum / HyperEVM chain ids -> `ExpectedGrantMissing(clone, WITHDRAW, orchestrator)`); `testAssertExpectedGrantsRejectsOrchestratorDefaultAdmin`; `testAssertPostStateRejectsMissingOrchestratorGrant` and the `MIRROR_COUNT == 8` drift assertion; `testAuthoringRefusesAPreEnableMap`; `EnableOrchestratorRolesProdTest` on all three forks (rows held live).
- Mutations applied: (1) `grants[14]` role `WITHDRAW` -> `CERTIFY`: `testExpectedGrantsAdminHolderParameterisation` fails on the role assertion. (2) `assertExpectedGrants` row loop bound `grants.length` -> `grants.length - 2` (orchestrator rows never asserted): `testAuthoringRefusesAPreEnableMap` fails ("next call did not revert as expected"). Both run locally, lib restored byte-for-byte after each. Not run locally (fork suites, no RPC here): dropping the orchestrator `DEFAULT_ADMIN` negative is covered by `testAssertExpectedGrantsRejectsOrchestratorDefaultAdmin`, and `MIRROR_COUNT` back to 6 by the drift assertion and `testAssertPostStateRejectsMissingOrchestratorGrant` — CI runs them.
- Oracle: live chain state — `hasRole(DEPOSIT|WITHDRAW, ST0X_ORCHESTRATOR_INSTANCE)` on each chain's V4 authoriser clone (Base `0x315b16faa6eE413faBCa877d3851B3818369f0cD`) reads true after the enable executions. The fork suites in CI read that state directly; the absent state is the row mocked false on the Base fork.
- Category check: ruling asks (A) pin the two orchestrator rows, (B) strict on every chain with no `LibMigrationInvariant` window, no deadline constant and no chain-id branch, (C) `MIRROR_COUNT = 8`, (D) enable prod test expects the rows held, (E) no CHANGELOG / map-restating doc; A-D covered by the tests above (B also by `grep -rn "ORCHESTRATOR_ENABLE_DEADLINE\|LibMigrationInvariant" src/lib/LibAuthoriserInvariants.sol` being empty), E by the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oPVApdKM7RogDWJHYSq4N


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added orchestrator permissions for `DEPOSIT` and `WITHDRAW` operations.
  - Expanded grant validation to cover the orchestrator and ensure it cannot hold administrator access.
  - Deployment and upgrade checks now verify the complete grant configuration.

- **Bug Fixes**
  - Prevented authoring from proceeding when required orchestrator permissions are missing.
  - Added safeguards against unexpected administrator privileges for the orchestrator.

- **Documentation**
  - Updated deployment and migration guidance to reflect the expanded permission set and executed-state requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->