### PR TITLE
Create the token-owner Safe on a new chain from CI

### DIFF
--- a/.github/workflows/manual-broadcast.yaml
+++ b/.github/workflows/manual-broadcast.yaml
@@ -37,6 +37,7 @@ on:
           - 20260729-deploy-governance-timelock
           - 20260813-execute-timelock-operations
           - 20260818-deploy-orchestrator
+          - 20260910-create-token-owner-safe
       network:
         description: 'Network to broadcast against (default: base)'
         required: true

--- a/script/20260910-create-token-owner-safe.s.sol
+++ b/script/20260910-create-token-owner-safe.s.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+
+import {IGnosisSafe} from "../src/interface/IGnosisSafe.sol";
+import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
+
+/// @notice The canonical Safe v1.4.1 proxy factory, at its deterministic
+/// address on every chain Safe supports. Mirrored as a two-selector interface
+/// here because no dependency in this repo carries the Safe factory ABI.
+interface ISafeProxyFactory {
+    /// @notice Deploy a proxy at `CREATE2(keccak256(keccak256(initializer) ++
+    /// saltNonce))` over the proxy creation code appended with `singleton`,
+    /// then run `initializer` on it. Permissionless: the sender is not part of
+    /// the address derivation.
+    function createProxyWithNonce(address singleton, bytes memory initializer, uint256 saltNonce)
+        external
+        returns (address proxy);
+    /// @notice The proxy creation code the factory deploys.
+    function proxyCreationCode() external pure returns (bytes memory);
+}
+
+/// @notice The active chain's Safe pin already has code: the Safe exists and
+/// there is nothing to create (a re-dispatch), or something else occupies the
+/// address (resolve by hand).
+/// @param safe The pinned address.
+error TokenOwnerSafeAlreadyExists(address safe);
+
+/// @notice The address the canonical initializer derives to on this chain is
+/// not the chain's Safe pin. The pin is for a Safe created some other way
+/// (Base's was), or the pin is wrong; either way this script must not create
+/// a stray Safe.
+/// @param pinned The chain's pinned Safe.
+/// @param derived The address the replay would land on.
+error TokenOwnerSafePinNotDerivable(address pinned, address derived);
+
+/// @notice The factory reported a different proxy address than the one it was
+/// asked to derive — the factory at the canonical address is not the v1.4.1
+/// factory this replay was computed against.
+/// @param expected The derived address.
+/// @param actual The address the factory returned.
+error TokenOwnerSafeLandedElsewhere(address expected, address actual);
+
+/// @title CreateTokenOwnerSafe
+/// @notice Creates the ST0x token-owner Safe on a freshly onboarded chain at
+/// its pinned address, by replaying the exact `createProxyWithNonce` call that
+/// created the Ethereum Safe (tx `0x8825d68e…da39`, 2026-07-16): the canonical
+/// v1.4.1 proxy factory, the L1 `Safe` singleton, `Safe.setup` over the six
+/// owners at threshold 1 with the `SafeToL2Setup` migration delegatecall and
+/// the compatibility fallback handler, salt nonce 0. The proxy address is a
+/// pure function of that initializer and the factory, never of the sender, so
+/// the CI deploy key can dispatch this on any chain and land the same
+/// `0x3840aeDa…0329` the Ethereum and HyperEVM Safes occupy.
+///
+/// @dev Dispatch via `Actions → manual-broadcast` with
+/// `script = 20260910-create-token-owner-safe` and `network` set to the new
+/// chain. Self-scoping: it derives the address from the initializer, refuses
+/// unless that equals the chain's `LibSafeInvariants` pin (so it cannot create
+/// a Safe the repo does not expect — Base's pin is not derivable this way and
+/// is refused), and refuses if the pin already has code. It leaves the Safe at
+/// threshold **1**, exactly as the replayed creation did, because the
+/// threshold is not part of the address derivation. Raising it to the policy's
+/// 3-of-6 is an owner action: author it with `MigrateMultisigThreshold`
+/// (`multisig-artifact.yaml`) and execute from any one owner. Every
+/// pin-dependent step (`assertActiveChainTokenOwnerSafe`) gates on the
+/// threshold, so nothing downstream can run against the 1-of-6 window.
+contract CreateTokenOwnerSafe is Script {
+    /// @notice The canonical Safe v1.4.1 proxy factory.
+    address internal constant SAFE_PROXY_FACTORY_1_4_1 = 0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67;
+    /// @notice `SafeToL2Setup` 1.4.1: the `setup` delegatecall target that
+    /// switches a freshly created proxy from the L1 singleton to `SafeL2` when
+    /// the chain is not Ethereum mainnet (a no-op on chain 1), which is why the
+    /// Ethereum Safe runs `Safe` and every other chain's runs `SafeL2` from the
+    /// same initializer.
+    address internal constant SAFE_TO_L2_SETUP_1_4_1 = 0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54;
+    /// @notice Safe's fee collector, the `paymentReceiver` the Safe UI wrote
+    /// into the Ethereum creation. Inert at `payment = 0`, but part of the
+    /// initializer bytes and therefore of the address.
+    address internal constant SAFE_PAYMENT_RECEIVER = 0x5afe7A11E7000000000000000000000000000000;
+    /// @notice The threshold the replayed creation sets. NOT the policy's; see
+    /// the contract NatSpec.
+    uint256 internal constant CREATION_THRESHOLD = 1;
+    /// @notice The salt nonce the Ethereum creation used.
+    uint256 internal constant SALT_NONCE = 0;
+
+    /// @notice The six owners in the order the Ethereum creation listed them.
+    /// Order matters: it is part of the initializer bytes. The set is the
+    /// policy set (`LibSafeInvariants.expectedOwners`, asserted below).
+    /// @return owners The creation-order owner list.
+    function creationOwners() internal pure returns (address[] memory owners) {
+        owners = new address[](6);
+        owners[0] = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_OWNER_5;
+        owners[1] = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_OWNER_1;
+        owners[2] = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_OWNER_2;
+        owners[3] = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_OWNER_3;
+        owners[4] = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_OWNER_4;
+        owners[5] = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_OWNER_6;
+    }
+
+    /// @notice The exact `Safe.setup` calldata of the Ethereum creation.
+    /// @return The initializer bytes.
+    function initializer() internal pure returns (bytes memory) {
+        return abi.encodeWithSignature(
+            "setup(address[],uint256,address,bytes,address,address,uint256,address)",
+            creationOwners(),
+            CREATION_THRESHOLD,
+            SAFE_TO_L2_SETUP_1_4_1,
+            abi.encodeWithSignature("setupToL2(address)", LibSafeInvariants.SAFE_V1_4_1_L2_SINGLETON),
+            LibSafeInvariants.SAFE_V1_4_1_COMPATIBILITY_FALLBACK_HANDLER,
+            address(0),
+            uint256(0),
+            SAFE_PAYMENT_RECEIVER
+        );
+    }
+
+    /// @notice The address `createProxyWithNonce` derives for the initializer
+    /// on this chain: the v1.4.1 factory's `CREATE2` over its proxy creation
+    /// code appended with the L1 singleton, salted with
+    /// `keccak256(keccak256(initializer) ++ saltNonce)`.
+    /// @return The derived proxy address.
+    function derivedSafeAddress() internal view returns (address) {
+        bytes32 salt = keccak256(abi.encodePacked(keccak256(initializer()), SALT_NONCE));
+        bytes memory deploymentData = abi.encodePacked(
+            ISafeProxyFactory(SAFE_PROXY_FACTORY_1_4_1).proxyCreationCode(),
+            uint256(uint160(LibSafeInvariants.SAFE_V1_4_1_L1_SINGLETON))
+        );
+        return address(
+            uint160(
+                uint256(
+                    keccak256(abi.encodePacked(bytes1(0xff), SAFE_PROXY_FACTORY_1_4_1, salt, keccak256(deploymentData)))
+                )
+            )
+        );
+    }
+
+    /// @notice Pre-flight (pin derivable, not yet created), broadcast the
+    /// replay, assert the Safe landed at the pin with the policy's owner set,
+    /// v1.4.1 identity and fallback handler, at the creation threshold.
+    function run() external {
+        address pinned = LibSafeInvariants.safeForChainId(block.chainid);
+        if (pinned.code.length != 0) revert TokenOwnerSafeAlreadyExists(pinned);
+        address derived = derivedSafeAddress();
+        if (derived != pinned) revert TokenOwnerSafePinNotDerivable(pinned, derived);
+
+        console2.log("Creating the token-owner Safe on chain id", block.chainid);
+        console2.log("at:", pinned);
+
+        vm.startBroadcast();
+        address created = ISafeProxyFactory(SAFE_PROXY_FACTORY_1_4_1)
+            .createProxyWithNonce(LibSafeInvariants.SAFE_V1_4_1_L1_SINGLETON, initializer(), SALT_NONCE);
+        vm.stopBroadcast();
+        if (created != pinned) revert TokenOwnerSafeLandedElsewhere(pinned, created);
+
+        // Post-state: the policy in every respect the creation controls.
+        IGnosisSafe safe = IGnosisSafe(pinned);
+        LibSafeInvariants.assertImmutableInvariants(safe);
+        LibSafeInvariants.assertOwnerSetUnordered(safe, LibSafeInvariants.expectedOwners());
+        LibSafeInvariants.assertThreshold(safe, CREATION_THRESHOLD);
+
+        console2.log("Token-owner Safe created at the pin. Threshold is 1 of 6: raise it to");
+        console2.log("3 via MigrateMultisigThreshold before any pin-dependent dispatch.");
+    }
+}

--- a/test/script/20260910-create-token-owner-safe.t.sol
+++ b/test/script/20260910-create-token-owner-safe.t.sol
@@ -12,14 +12,7 @@ import {
 import {IGnosisSafe} from "../../src/interface/IGnosisSafe.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
 import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
-
-/// @dev Exposes the script's derivation so the tests can pin it against the
-/// live Safes without broadcasting.
-contract CreateTokenOwnerSafeHarness is CreateTokenOwnerSafe {
-    function callDerivedSafeAddress() external view returns (address) {
-        return derivedSafeAddress();
-    }
-}
+import {CreateTokenOwnerSafeHarness} from "./CreateTokenOwnerSafeHarness.sol";
 
 /// @title CreateTokenOwnerSafeTest
 /// @notice The replayed initializer must derive to the address the live

--- a/test/script/20260910-create-token-owner-safe.t.sol
+++ b/test/script/20260910-create-token-owner-safe.t.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
+import {
+    CreateTokenOwnerSafe,
+    TokenOwnerSafeAlreadyExists,
+    TokenOwnerSafePinNotDerivable
+} from "../../script/20260910-create-token-owner-safe.s.sol";
+import {IGnosisSafe} from "../../src/interface/IGnosisSafe.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
+
+/// @dev Exposes the script's derivation so the tests can pin it against the
+/// live Safes without broadcasting.
+contract CreateTokenOwnerSafeHarness is CreateTokenOwnerSafe {
+    function callDerivedSafeAddress() external view returns (address) {
+        return derivedSafeAddress();
+    }
+}
+
+/// @title CreateTokenOwnerSafeTest
+/// @notice The replayed initializer must derive to the address the live
+/// Safes occupy (proving the reproduction is byte-exact), the script must
+/// refuse every chain it must not touch, and on a fresh chain it must land
+/// the Safe at the pin carrying the policy's owner set.
+contract CreateTokenOwnerSafeTest is Test {
+    /// @notice The derivation reproduces the Ethereum Safe's address — the
+    /// creation this script replays — and HyperEVM's, which was created the
+    /// same way. Both forks also prove the refusal to re-create.
+    function testDerivationMatchesTheLiveSafes() external {
+        CreateTokenOwnerSafeHarness harness = new CreateTokenOwnerSafeHarness();
+
+        vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
+        assertEq(harness.callDerivedSafeAddress(), LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM, "ethereum");
+        CreateTokenOwnerSafe script = new CreateTokenOwnerSafe();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TokenOwnerSafeAlreadyExists.selector, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ETHEREUM
+            )
+        );
+        script.run();
+
+        vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
+        assertEq(harness.callDerivedSafeAddress(), LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_HYPEREVM, "hyperevm");
+    }
+
+    /// @notice Base's Safe was not created by this initializer (a different
+    /// address), so the script refuses Base rather than creating a stray
+    /// Safe there.
+    function testRefusesBase() external {
+        vm.createSelectFork(LibRainDeploy.BASE);
+        CreateTokenOwnerSafeHarness harness = new CreateTokenOwnerSafeHarness();
+        address derived = harness.callDerivedSafeAddress();
+        assertNotEq(derived, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE, "Base pin is not this derivation");
+        CreateTokenOwnerSafe script = new CreateTokenOwnerSafe();
+        // Base's derived address may or may not have code; either refusal is
+        // the right outcome, and the pin check is what makes this test
+        // about derivability rather than occupancy.
+        if (LibSafeInvariants.STOX_TOKEN_OWNER_SAFE.code.length != 0) {
+            vm.expectRevert(
+                abi.encodeWithSelector(TokenOwnerSafeAlreadyExists.selector, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE)
+            );
+        } else {
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    TokenOwnerSafePinNotDerivable.selector, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE, derived
+                )
+            );
+        }
+        script.run();
+    }
+
+    /// @notice On a chain whose pin has no code yet, the replay lands the
+    /// Safe at the pin with the policy's owner set, v1.4.1 identity and
+    /// fallback handler, at the creation threshold of 1 — and a second run
+    /// refuses. Exercised on whichever of the new chains is still bare; a
+    /// chain whose Safe already exists proves the refusal instead.
+    function testCreatesAtThePinOnAFreshChain() external {
+        string[2] memory networks = [LibStoxDeployNetworks.ROBINHOOD, LibStoxDeployNetworks.BSC];
+        address[2] memory pins =
+            [LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ROBINHOOD, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_BSC];
+        for (uint256 i = 0; i < networks.length; i++) {
+            vm.createSelectFork(networks[i]);
+            CreateTokenOwnerSafe script = new CreateTokenOwnerSafe();
+            if (pins[i].code.length != 0) {
+                vm.expectRevert(abi.encodeWithSelector(TokenOwnerSafeAlreadyExists.selector, pins[i]));
+                script.run();
+                continue;
+            }
+            script.run();
+            IGnosisSafe safe = IGnosisSafe(pins[i]);
+            assertGt(pins[i].code.length, 0, networks[i]);
+            LibSafeInvariants.assertImmutableInvariants(safe);
+            LibSafeInvariants.assertOwnerSetUnordered(safe, LibSafeInvariants.expectedOwners());
+            assertEq(safe.getThreshold(), 1, "creation threshold");
+            vm.expectRevert(abi.encodeWithSelector(TokenOwnerSafeAlreadyExists.selector, pins[i]));
+            script.run();
+        }
+    }
+}

--- a/test/script/CreateTokenOwnerSafeHarness.sol
+++ b/test/script/CreateTokenOwnerSafeHarness.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {CreateTokenOwnerSafe} from "../../script/20260910-create-token-owner-safe.s.sol";
+
+/// @dev Exposes the script's address derivation so the tests can pin it
+/// against the live Safes without broadcasting.
+contract CreateTokenOwnerSafeHarness is CreateTokenOwnerSafe {
+    /// @notice The script's `derivedSafeAddress()`, externally callable.
+    function callDerivedSafeAddress() external view returns (address) {
+        return derivedSafeAddress();
+    }
+}


### PR DESCRIPTION
Makes token-owner Safe creation on a new chain a `manual-broadcast` dispatch instead of a hand step in the Safe UI.

## What it does
`20260910-create-token-owner-safe` replays the exact `createProxyWithNonce` that created the Ethereum Safe (tx `0x8825d68e…da39`): canonical v1.4.1 proxy factory, L1 `Safe` singleton, `Safe.setup` over the six owners at threshold 1 with the `SafeToL2Setup` delegatecall and the compatibility fallback handler, salt nonce 0. The proxy address is a function of the initializer and the factory only — never the sender — so the CI deploy key lands `0x3840aeDa…0329` on any chain whose canonical Safe contracts are live (Robinhood Chain and BNB Smart Chain both are, verified).

## Guards
- Derives the address first and refuses unless it equals the chain's `LibSafeInvariants` pin (`TokenOwnerSafePinNotDerivable`). Base's Safe was created differently, so Base is refused rather than getting a stray Safe.
- Refuses if the pin already has code (`TokenOwnerSafeAlreadyExists`); refuses if the factory returns anything but the derived address.
- Post-state asserts v1.4.1 identity + fallback handler (`assertImmutableInvariants`), the policy's owner set, and threshold **1**.

## What it deliberately does not do
The threshold stays at 1, exactly as the replayed creation set it, because the threshold is part of the initializer and therefore of the address. Raising it to the policy's 3-of-6 is an owner action: author with `MigrateMultisigThreshold` (`multisig-artifact.yaml`), execute from any single owner. Every pin-dependent script gates on `assertActiveChainTokenOwnerSafe`, which asserts the threshold, so nothing downstream can run in the 1-of-6 window.

## Tests (live forks)
- Derivation reproduces the Ethereum and HyperEVM Safes' address; Ethereum refuses re-creation.
- Base refused (pin not derivable).
- Robinhood Chain and BNB Smart Chain forks: the run lands the Safe at the pin with the owner set at threshold 1; a second run refuses.

Stacked on #349 (needs the Robinhood + BNB Safe pins). Slither 0 results, fmt clean.

Linear: [RAI-2287](https://linear.app/makeitrain/issue/RAI-2287) / [RAI-2312](https://linear.app/makeitrain/issue/RAI-2312).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3
