### PR TITLE
Deploy the orchestrator already enabled on fresh chains, with no Safe signature

### DIFF
--- a/.github/workflows/manual-broadcast.yaml
+++ b/.github/workflows/manual-broadcast.yaml
@@ -38,6 +38,7 @@ on:
           - 20260813-execute-timelock-operations
           - 20260818-deploy-orchestrator
           - 20260910-create-token-owner-safe
+          - 20260910-deploy-orchestrator-enabled
       network:
         description: 'Network to broadcast against (default: base)'
         required: true

--- a/script/20260910-deploy-orchestrator-enabled.s.sol
+++ b/script/20260910-deploy-orchestrator-enabled.s.sol
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {LibProdDeployV4} from "../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../src/lib/LibSafeInvariants.sol";
+import {LibAuthoriserInvariants} from "../src/lib/LibAuthoriserInvariants.sol";
+import {LibBeaconInvariants} from "../src/lib/LibBeaconInvariants.sol";
+import {LibClosureInvariants} from "../src/lib/LibClosureInvariants.sol";
+import {LibOrchestratorInvariants} from "../src/lib/LibOrchestratorInvariants.sol";
+import {IST0xOrchestratorBeaconSetDeployerV1} from "../src/interface/IST0xOrchestratorBeaconSetDeployerV1.sol";
+import {
+    OrchestratorAlreadyDeployed,
+    UnexpectedSetDeployerNonce,
+    InstanceAddressMismatch
+} from "./20260818-deploy-orchestrator.s.sol";
+import {FleetNotUpgraded} from "./20260831-enable-orchestrator-roles.s.sol";
+
+/// @notice The CI deploy key still holds a role on the deployed instance
+/// after the hand-off. The deploy key is the transient admin ONLY for the
+/// grants inside this broadcast; anything left on it afterwards means the
+/// hand-off did not land and the instance is not in the pinned end state.
+/// @param instance The orchestrator instance inspected.
+/// @param role The role the deploy key unexpectedly holds.
+/// @param deployer The deploy key that must hold nothing.
+error DeployKeyHoldsRole(address instance, bytes32 role, address deployer);
+
+/// @notice The service signer does not hold one of the orchestrator's
+/// operational roles after the broadcast — the enabled end state this
+/// script exists to land.
+/// @param instance The orchestrator instance inspected.
+/// @param role The missing operational role.
+error SignerMissingOrchestratorRole(address instance, bytes32 role);
+
+/// @title DeployOrchestratorEnabled
+/// @notice Deploys the production `ST0xOrchestrator` instance on a freshly
+/// bootstrapped chain AND lands it in the enabled end state — the service
+/// signer holding `MINT_ROLE` / `BURN_ROLE` on it, the chain's token-owner
+/// Safe holding `DEFAULT_ADMIN_ROLE` — in one deploy-key broadcast, with no
+/// Safe signature.
+///
+/// The successor of `20260818-deploy-orchestrator` +
+/// `20260831-enable-orchestrator-roles` for chains that bootstrap AFTER the
+/// orchestrator shipped. On Base / Ethereum / HyperEVM the instance was
+/// deployed with the Safe as admin from birth, so the operational grants
+/// had to be a Safe-signed bundle. On a fresh chain the same end state is
+/// reachable through the deploy-then-hand-off ceremony the V4 authoriser
+/// clone already uses (`20260619-deploy-v4-authoriser-clone`): the deploy
+/// key is passed to `deploy(owner)` as the transient `DEFAULT_ADMIN_ROLE`
+/// holder, performs the two signer grants, grants admin to the Safe, and
+/// renounces its own admin — all inside one broadcast, with the post-state
+/// proving the key holds nothing afterwards.
+///
+/// The instance address is unchanged by the ceremony: it is the beacon-set
+/// deployer's `CREATE` at account nonce 2, a function of the (Zoltu) deployer
+/// alone, never of the `owner` argument — so the same
+/// `LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE` pin lands on every
+/// chain, and the authoriser ceremony can (and does) grant that address its
+/// vault roles before the instance exists.
+///
+/// The authoriser half of the enable bundle needs no action here: the V4
+/// authoriser ceremony mirrors the canonical grant map
+/// (`LibAuthoriserInvariants.expectedGrants`), which carries the
+/// orchestrator's `DEPOSIT` / `WITHDRAW` rows, so on a fresh chain the
+/// orchestrator is vault-authorised from the ceremony. Pre-flight asserts
+/// the full map holds, and the post-state re-asserts it, so nothing about
+/// the authoriser moves in this broadcast.
+///
+/// @dev Dispatch via `Actions → manual-broadcast` with
+/// `script = 20260910-deploy-orchestrator-enabled` and `network` set to the
+/// target chain. One dispatch covers one chain. Pre-requisites per chain, in
+/// order: the audited 0.1.30 closure live (`manual-sol-artifacts-0-1-30`);
+/// the V4 authoriser clone deployed AND its pin hydrated; the token beacons
+/// upgraded to 0.1.30 and Safe-owned
+/// (`20260909-upgrade-and-migrate-token-beacons`). Pre-flight enforces each
+/// by codehash / live read, refuses a chain whose instance already exists
+/// (`OrchestratorAlreadyDeployed` — the existing chains keep their
+/// Safe-signed history and are never re-run through this script), and
+/// carries the RAI-2125 interlock: the fleet must serve 0.1.30 before the
+/// orchestrator gains a mint path, which the orchestrator's own vault-logic
+/// lock cannot see on the in-use beacons.
+///
+/// After this script, `20260831-enable-orchestrator-roles` refuses the
+/// chain (`OrchestratorRolesAlreadyEnabled`) — every item it would author
+/// already holds — and the chain is at parity with the three existing
+/// chains' executed enable bundles.
+contract DeployOrchestratorEnabled is Script {
+    /// @notice The service signer that mints/burns THROUGH the orchestrator.
+    address internal constant SERVICE_SIGNER = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
+
+    /// @notice The orchestrator's operational roles (audited 0.1.30 source).
+    bytes32 internal constant ORCHESTRATOR_MINT_ROLE = keccak256("MINT");
+    bytes32 internal constant ORCHESTRATOR_BURN_ROLE = keccak256("BURN");
+    bytes32 internal constant ORCHESTRATOR_EMERGENCY_ROLE = keccak256("EMERGENCY");
+
+    /// @notice Assert the full audited 0.1.30 orchestrator closure is live on
+    /// the active chain, by codehash, in dependency order. Mirrors
+    /// `20260818-deploy-orchestrator`.
+    function _assertClosureReady() internal view {
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30,
+            LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_CODEHASH_0_1_30
+        );
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.STOX_RECEIPT_0_1_30, LibProdDeployV4.STOX_RECEIPT_CODEHASH_0_1_30
+        );
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30, LibProdDeployV4.STOX_RECEIPT_VAULT_CODEHASH_0_1_30
+        );
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_0_1_30,
+            LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER_CODEHASH_0_1_30
+        );
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.ST0X_ORCHESTRATOR_0_1_30, LibProdDeployV4.ST0X_ORCHESTRATOR_CODEHASH_0_1_30
+        );
+        LibClosureInvariants.assertClosureContract(
+            LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30,
+            LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_CODEHASH_0_1_30
+        );
+    }
+
+    /// @notice Assert the beacon-set deployer is in the fresh-deploy state
+    /// the instance pin's nonce-2 derivation assumes: no code at the pinned
+    /// instance and the deployer's account nonce still at 2. Mirrors
+    /// `20260818-deploy-orchestrator`.
+    /// @param setDeployer The beacon-set deployer to inspect.
+    function _assertNoInstanceYet(address setDeployer) internal view {
+        address instance = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
+        if (instance.code.length != 0) {
+            revert OrchestratorAlreadyDeployed(instance);
+        }
+        uint64 nonce = vm.getNonce(setDeployer);
+        if (nonce != 2) {
+            revert UnexpectedSetDeployerNonce(setDeployer, nonce);
+        }
+    }
+
+    /// @notice The RAI-2125 interlock: the chain's in-use receipt and
+    /// receipt-vault beacons must already serve the audited 0.1.30 impls
+    /// before the orchestrator gains a mint path. Mirrors
+    /// `20260831-enable-orchestrator-roles`; on a fresh chain this is what
+    /// `20260909-upgrade-and-migrate-token-beacons` lands.
+    function _assertFleetUpgraded() internal view {
+        address[4] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
+        address receiptImpl = IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation();
+        if (receiptImpl != LibProdDeployV4.STOX_RECEIPT_0_1_30) {
+            revert FleetNotUpgraded(
+                beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX], LibProdDeployV4.STOX_RECEIPT_0_1_30, receiptImpl
+            );
+        }
+        address vaultImpl = IBeacon(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX]).implementation();
+        if (vaultImpl != LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30) {
+            revert FleetNotUpgraded(
+                beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
+                LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+                vaultImpl
+            );
+        }
+    }
+
+    /// @notice Assert the enabled end state landed exactly as pinned: the
+    /// instance at its pin, beacon set intact, the Safe holding
+    /// `DEFAULT_ADMIN_ROLE`, the vault-logic lock passing, the service signer
+    /// holding `MINT_ROLE` + `BURN_ROLE`, the deploy key holding NO role,
+    /// and the chain's authoriser still on the canonical grant map (which
+    /// carries the orchestrator's vault access).
+    /// @dev Public so the failure modes can be driven directly from a test —
+    /// an assertion reachable only from inside a broadcast cannot be shown to
+    /// fire. Mirrors `20260818-deploy-orchestrator.assertDeployLanded` plus
+    /// `20260831-enable-orchestrator-roles.assertPostEnableState`.
+    /// @param instance The address `deploy()` returned.
+    /// @param safe The chain's token-owner Safe that must hold admin.
+    /// @param authoriser The chain's V4 authoriser clone.
+    /// @param deployer The deploy key that must hold nothing.
+    function assertEnabledLanded(address instance, address safe, address authoriser, address deployer) public view {
+        if (instance != LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE) {
+            revert InstanceAddressMismatch(LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE, instance);
+        }
+        LibOrchestratorInvariants.assertBeaconSet(safe);
+        LibOrchestratorInvariants.assertInstance(safe);
+
+        IAccessControl orch = IAccessControl(instance);
+        bytes32[4] memory roles =
+            [bytes32(0), ORCHESTRATOR_MINT_ROLE, ORCHESTRATOR_BURN_ROLE, ORCHESTRATOR_EMERGENCY_ROLE];
+        for (uint256 i = 0; i < roles.length; i++) {
+            if (orch.hasRole(roles[i], deployer)) {
+                revert DeployKeyHoldsRole(instance, roles[i], deployer);
+            }
+        }
+        if (!orch.hasRole(ORCHESTRATOR_MINT_ROLE, SERVICE_SIGNER)) {
+            revert SignerMissingOrchestratorRole(instance, ORCHESTRATOR_MINT_ROLE);
+        }
+        if (!orch.hasRole(ORCHESTRATOR_BURN_ROLE, SERVICE_SIGNER)) {
+            revert SignerMissingOrchestratorRole(instance, ORCHESTRATOR_BURN_ROLE);
+        }
+
+        // The authoriser half: untouched by this broadcast, and the
+        // canonical map (orchestrator DEPOSIT / WITHDRAW included) holds.
+        LibAuthoriserInvariants.assertExpectedGrants(authoriser, safe);
+    }
+
+    /// @notice Deploy the production orchestrator instance on the active
+    /// chain with the deploy key as transient admin, grant the service
+    /// signer its operational roles, hand `DEFAULT_ADMIN_ROLE` to the
+    /// token-owner Safe, renounce the deploy key's, and assert the enabled
+    /// end state.
+    function run() external {
+        // --- Pre-flight ---------------------------------------------------
+
+        _assertClosureReady();
+        address safe = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
+        LibOrchestratorInvariants.assertBeaconSet(safe);
+
+        address setDeployer = LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30;
+        _assertNoInstanceYet(setDeployer);
+
+        _assertFleetUpgraded();
+
+        // The authoriser is live at its hydrated pin and on the canonical
+        // map BEFORE the orchestrator exists — the orchestrator's vault
+        // access is the ceremony's, not this script's.
+        address authoriser = LibAuthoriserInvariants.activeChainAuthoriser();
+        LibAuthoriserInvariants.assertExpectedGrants(authoriser, safe);
+
+        // --- Broadcast ----------------------------------------------------
+
+        vm.startBroadcast();
+
+        // Deployer identity — inside `vm.startBroadcast()` msg.sender
+        // resolves to the broadcast address (`--private-key` in production).
+        address deployer = msg.sender;
+
+        console2.log("Deploying ST0xOrchestrator instance (enabled) on chain id", block.chainid);
+        console2.log("beacon-set deployer:", setDeployer);
+        console2.log("deploy key (transient admin, holds nothing after):", deployer);
+        console2.log("DEFAULT_ADMIN_ROLE hand-off target (token-owner Safe):", safe);
+        console2.log("MINT/BURN grantee (service signer):", SERVICE_SIGNER);
+
+        // Step 1: deploy with the deploy key as the transient admin.
+        address instance = IST0xOrchestratorBeaconSetDeployerV1(setDeployer).deploy(deployer);
+        IAccessControl orch = IAccessControl(instance);
+
+        // Step 2: the operational grants the enable bundle would author.
+        orch.grantRole(ORCHESTRATOR_MINT_ROLE, SERVICE_SIGNER);
+        orch.grantRole(ORCHESTRATOR_BURN_ROLE, SERVICE_SIGNER);
+
+        // Step 3: hand admin to the Safe, then drop the deploy key's copy.
+        orch.grantRole(bytes32(0), safe);
+        orch.renounceRole(bytes32(0), deployer);
+
+        assertEnabledLanded(instance, safe, authoriser, deployer);
+
+        vm.stopBroadcast();
+
+        console2.log("==== ORCHESTRATOR DEPLOYED + ENABLED ====");
+        console2.log("instance:", vm.toString(instance));
+        console2.log("Admin is the token-owner Safe; the service signer holds MINT/BURN; the deploy key holds no role.");
+    }
+}

--- a/test/script/20260910-deploy-orchestrator-enabled.prod.t.sol
+++ b/test/script/20260910-deploy-orchestrator-enabled.prod.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+
+import {DeployOrchestratorEnabled} from "../../script/20260910-deploy-orchestrator-enabled.s.sol";
+import {OrchestratorAlreadyDeployed} from "../../script/20260818-deploy-orchestrator.s.sol";
+import {
+    EnableOrchestratorRoles,
+    FleetNotUpgraded,
+    OrchestratorRolesAlreadyEnabled
+} from "../../script/20260831-enable-orchestrator-roles.s.sol";
+import {ClosureNotDeployed} from "../../src/lib/LibClosureInvariants.sol";
+import {AuthoriserNotReady, LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
+import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
+import {LibOrchestratorInvariants} from "../../src/lib/LibOrchestratorInvariants.sol";
+import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
+
+/// @notice The enabled-orchestrator rollout deadline passed with this chain
+/// still pending. Run the outstanding dispatches, extend the deadline, or
+/// delete the invariant.
+/// @param label The chain still pending.
+error OrchestratorEnabledRolloutOverdue(string label);
+
+/// @title DeployOrchestratorEnabledProdTest
+/// @notice PROD coverage for the enabled orchestrator deploy on the chains
+/// that bootstrap through it, read from a real fork with no mocks, walking
+/// the bootstrap states:
+///
+/// 1. **Closure missing**: the pre-flight refuses on the first closure
+///    contract.
+/// 2. **Authoriser pin unhydrated** (closure live): refuses
+///    `AuthoriserNotReady` — the ceremony + hydration PR come first.
+/// 3. **Fleet on 0.1.1** (authoriser live): refuses `FleetNotUpgraded` —
+///    `20260909-upgrade-and-migrate-token-beacons` comes first.
+/// 4. **Ready**: drives `run()` end to end on the fork — instance at its
+///    pin, Safe admin, signer on MINT/BURN, deploy key clean, canonical
+///    map intact — then proves the Safe-bundle enable script has nothing
+///    left to author (`OrchestratorRolesAlreadyEnabled`).
+/// 5. **Executed**: the steady state above holds on-chain; a re-dispatch
+///    refuses (`OrchestratorAlreadyDeployed`) and so does the enable
+///    script.
+///
+/// States 1-4 stop passing at the rollout deadline; state 5 is steady.
+contract DeployOrchestratorEnabledProdTest is Test {
+    /// @notice Shared with the Robinhood / BNB parity legs.
+    uint256 internal constant ROLLOUT_DEADLINE = 1_796_083_200;
+
+    address internal constant SIGNER = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
+
+    function assertEnabledSteadyState(string memory label) internal view {
+        address instance = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
+        address safe = LibSafeInvariants.assertActiveChainTokenOwnerSafe(block.chainid);
+        LibOrchestratorInvariants.assertBeaconSet(safe);
+        LibOrchestratorInvariants.assertInstance(safe);
+        IAccessControl orch = IAccessControl(instance);
+        assertTrue(orch.hasRole(keccak256("MINT"), SIGNER), string.concat(label, ": signer lacks MINT"));
+        assertTrue(orch.hasRole(keccak256("BURN"), SIGNER), string.concat(label, ": signer lacks BURN"));
+        address authoriser = LibAuthoriserInvariants.activeChainAuthoriser();
+        LibAuthoriserInvariants.assertExpectedGrants(authoriser, safe);
+        assertTrue(
+            IAccessControl(authoriser).hasRole(keccak256("DEPOSIT"), instance),
+            string.concat(label, ": orchestrator lacks DEPOSIT on the authoriser")
+        );
+    }
+
+    function pending(string memory label, string memory what) internal view {
+        if (block.timestamp >= ROLLOUT_DEADLINE) {
+            revert OrchestratorEnabledRolloutOverdue(label);
+        }
+        console2.log(string.concat("PENDING [", label, "]: ", what));
+    }
+
+    function assertRollout(string memory label, address authoriserPin) internal {
+        DeployOrchestratorEnabled script = new DeployOrchestratorEnabled();
+        EnableOrchestratorRoles enable = new EnableOrchestratorRoles();
+        address instance = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
+
+        if (LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30.code.length == 0) {
+            pending(label, "0.1.30 closure not deployed -> dispatch manual-sol-artifacts-0-1-30");
+            vm.expectRevert(
+                abi.encodeWithSelector(ClosureNotDeployed.selector, LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30)
+            );
+            script.run();
+            return;
+        }
+
+        if (instance.code.length != 0) {
+            assertEnabledSteadyState(label);
+            vm.expectRevert(abi.encodeWithSelector(OrchestratorAlreadyDeployed.selector, instance));
+            script.run();
+            vm.expectRevert(OrchestratorRolesAlreadyEnabled.selector);
+            enable.run();
+            return;
+        }
+
+        address[4] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(block.chainid);
+        address receiptImpl = IBeacon(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX]).implementation();
+        if (receiptImpl != LibProdDeployV4.STOX_RECEIPT_0_1_30) {
+            pending(label, "fleet not on 0.1.30 -> run 20260909-upgrade-and-migrate-token-beacons");
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    FleetNotUpgraded.selector,
+                    beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+                    LibProdDeployV4.STOX_RECEIPT_0_1_30,
+                    receiptImpl
+                )
+            );
+            script.run();
+            return;
+        }
+
+        if (authoriserPin == address(0)) {
+            pending(label, "authoriser pin unhydrated -> ceremony + hydration PR");
+            vm.expectRevert(abi.encodeWithSelector(AuthoriserNotReady.selector, address(0)));
+            script.run();
+            return;
+        }
+
+        pending(label, "ready - driving the enabled deploy end to end on the fork");
+        script.run();
+        assertEnabledSteadyState(label);
+        vm.expectRevert(OrchestratorRolesAlreadyEnabled.selector);
+        enable.run();
+    }
+
+    function testOrchestratorEnabledRolloutRobinhood() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
+        assertRollout("robinhood", LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD);
+    }
+
+    function testOrchestratorEnabledRolloutBsc() external {
+        vm.createSelectFork(LibStoxDeployNetworks.BSC);
+        assertRollout("bsc", LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC);
+    }
+}

--- a/test/script/20260910-deploy-orchestrator-enabled.t.sol
+++ b/test/script/20260910-deploy-orchestrator-enabled.t.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessControl.sol";
+import {IBeacon} from "@openzeppelin-contracts-5.6.1/proxy/beacon/IBeacon.sol";
+import {Ownable} from "@openzeppelin-contracts-5.6.1/access/Ownable.sol";
+
+import {
+    DeployKeyHoldsRole,
+    SignerMissingOrchestratorRole
+} from "../../script/20260910-deploy-orchestrator-enabled.s.sol";
+import {OrchestratorAlreadyDeployed, InstanceAddressMismatch} from "../../script/20260818-deploy-orchestrator.s.sol";
+import {FleetNotUpgraded} from "../../script/20260831-enable-orchestrator-roles.s.sol";
+import {DeployOrchestratorEnabledHarness} from "./DeployOrchestratorEnabledHarness.sol";
+import {ClosureNotDeployed} from "../../src/lib/LibClosureInvariants.sol";
+import {ExpectedGrantMissing, LibAuthoriserInvariants} from "../../src/lib/LibAuthoriserInvariants.sol";
+import {LibBeaconInvariants} from "../../src/lib/LibBeaconInvariants.sol";
+import {
+    LibOrchestratorInvariants,
+    ST0xOrchestratorBeaconSetDeployerLike,
+    OrchestratorAdminMissing
+} from "../../src/lib/LibOrchestratorInvariants.sol";
+import {IST0xOrchestratorV1} from "../../src/interface/IST0xOrchestratorV1.sol";
+import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
+import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+
+/// @title DeployOrchestratorEnabledTest
+/// @notice Every gate of the enabled orchestrator deploy, driven with mocks
+/// so each refusal is shown to fire; the end-to-end path runs on a live
+/// fork in the `.prod` suite.
+contract DeployOrchestratorEnabledTest is Test {
+    DeployOrchestratorEnabledHarness internal harness;
+
+    address internal constant SAFE = LibSafeInvariants.STOX_TOKEN_OWNER_SAFE;
+    address internal constant AUTHORISER = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+    address internal constant ORCHESTRATOR = LibProdDeployV4.ST0X_ORCHESTRATOR_INSTANCE;
+    address internal constant SIGNER = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
+    address internal constant DEPLOY_KEY = address(0xDEAD);
+
+    function setUp() external {
+        vm.chainId(LibSafeInvariants.BASE_CHAIN_ID);
+        harness = new DeployOrchestratorEnabledHarness();
+    }
+
+    function mockUpgradedFleet() internal {
+        address[4] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(LibSafeInvariants.BASE_CHAIN_ID);
+        vm.etch(beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX], hex"fe");
+        vm.etch(beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX], hex"fe");
+        vm.mockCall(
+            beacons[LibBeaconInvariants.RECEIPT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_0_1_30)
+        );
+        vm.mockCall(
+            beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30)
+        );
+    }
+
+    function mockBeaconSet() internal {
+        vm.mockCall(
+            LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30,
+            abi.encodeCall(ST0xOrchestratorBeaconSetDeployerLike.iOrchestratorBeacon, ()),
+            abi.encode(LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON)
+        );
+        vm.mockCall(
+            LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON,
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.ST0X_ORCHESTRATOR_0_1_30)
+        );
+        vm.mockCall(
+            LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON, abi.encodeCall(Ownable.owner, ()), abi.encode(SAFE)
+        );
+        vm.etch(LibOrchestratorInvariants.ST0X_ORCHESTRATOR_BEACON, hex"fe");
+    }
+
+    /// @notice The enabled end state: authoriser on the canonical map
+    /// (orchestrator rows included), orchestrator with the Safe as admin and
+    /// the signer on MINT/BURN, the deploy key holding nothing.
+    function mockEnabledState() internal {
+        vm.etch(AUTHORISER, hex"fe");
+        vm.etch(ORCHESTRATOR, hex"fe");
+        vm.mockCall(AUTHORISER, abi.encodeWithSelector(IAccessControl.hasRole.selector), abi.encode(true));
+        address[5] memory admins = [SAFE, SAFE, LibAuthoriserInvariants.GRANTEE_SERVICE_1C66, SIGNER, ORCHESTRATOR];
+        for (uint256 i = 0; i < admins.length; i++) {
+            vm.mockCall(AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), admins[i])), abi.encode(false));
+        }
+        bytes32[3] memory actionRoles = [keccak256("DEPOSIT"), keccak256("WITHDRAW"), keccak256("CERTIFY")];
+        for (uint256 i = 0; i < actionRoles.length; i++) {
+            vm.mockCall(
+                AUTHORISER,
+                abi.encodeCall(IAccessControl.hasRole, (actionRoles[i], LibAuthoriserInvariants.GRANTEE_SERVICE_1C66)),
+                abi.encode(false)
+            );
+        }
+        vm.mockCall(ORCHESTRATOR, abi.encodeWithSelector(IAccessControl.hasRole.selector), abi.encode(false));
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), SAFE)), abi.encode(true));
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (keccak256("MINT"), SIGNER)), abi.encode(true));
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (keccak256("BURN"), SIGNER)), abi.encode(true));
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IST0xOrchestratorV1.vaultLogicIsExpected, ()), abi.encode(true));
+    }
+
+    function testClosureRefusesABlankChain() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(ClosureNotDeployed.selector, LibProdDeployV4.STOX_CORPORATE_ACTIONS_FACET_0_1_30)
+        );
+        harness.assertClosureReady();
+    }
+
+    function testRefusesWhenInstanceAlreadyDeployed() external {
+        vm.etch(ORCHESTRATOR, hex"fe");
+        vm.expectRevert(abi.encodeWithSelector(OrchestratorAlreadyDeployed.selector, ORCHESTRATOR));
+        harness.assertNoInstanceYet(LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30);
+    }
+
+    function testFleetGateRefusesUnupgradedBeacons() external {
+        address[4] memory beacons = LibBeaconInvariants.prodBeaconsForChainId(LibSafeInvariants.BASE_CHAIN_ID);
+        mockUpgradedFleet();
+        vm.mockCall(
+            beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
+            abi.encodeCall(IBeacon.implementation, ()),
+            abi.encode(LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1)
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FleetNotUpgraded.selector,
+                beacons[LibBeaconInvariants.RECEIPT_VAULT_BEACON_INDEX],
+                LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_30,
+                LibProdDeployV4.STOX_RECEIPT_VAULT_0_1_1
+            )
+        );
+        harness.assertFleetUpgraded();
+    }
+
+    function testFleetGateAcceptsUpgradedBeacons() external {
+        mockUpgradedFleet();
+        harness.assertFleetUpgraded();
+    }
+
+    function testLandedRefusesAnUnpinnedInstance() external {
+        vm.expectRevert(abi.encodeWithSelector(InstanceAddressMismatch.selector, ORCHESTRATOR, address(0xBAD)));
+        harness.assertEnabledLanded(address(0xBAD), SAFE, AUTHORISER, DEPLOY_KEY);
+    }
+
+    function testLandedRefusesWhenSafeLacksAdmin() external {
+        mockBeaconSet();
+        mockEnabledState();
+        vm.mockCall(ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (bytes32(0), SAFE)), abi.encode(false));
+        vm.expectRevert(abi.encodeWithSelector(OrchestratorAdminMissing.selector, ORCHESTRATOR, SAFE));
+        harness.assertEnabledLanded(ORCHESTRATOR, SAFE, AUTHORISER, DEPLOY_KEY);
+    }
+
+    /// @notice Any role left on the deploy key — admin OR operational — is a
+    /// failed hand-off. MINT is the one a half-done ceremony is likeliest to
+    /// leave behind.
+    function testLandedRefusesWhenDeployKeyHoldsARole() external {
+        mockBeaconSet();
+        mockEnabledState();
+        vm.mockCall(
+            ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (keccak256("MINT"), DEPLOY_KEY)), abi.encode(true)
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(DeployKeyHoldsRole.selector, ORCHESTRATOR, keccak256("MINT"), DEPLOY_KEY)
+        );
+        harness.assertEnabledLanded(ORCHESTRATOR, SAFE, AUTHORISER, DEPLOY_KEY);
+    }
+
+    function testLandedRefusesWhenSignerLacksBurn() external {
+        mockBeaconSet();
+        mockEnabledState();
+        vm.mockCall(
+            ORCHESTRATOR, abi.encodeCall(IAccessControl.hasRole, (keccak256("BURN"), SIGNER)), abi.encode(false)
+        );
+        vm.expectRevert(abi.encodeWithSelector(SignerMissingOrchestratorRole.selector, ORCHESTRATOR, keccak256("BURN")));
+        harness.assertEnabledLanded(ORCHESTRATOR, SAFE, AUTHORISER, DEPLOY_KEY);
+    }
+
+    /// @notice The orchestrator's vault access is the authoriser ceremony's
+    /// to grant; if the map lacks it the chain is not enabled, whatever the
+    /// orchestrator's own roles say.
+    function testLandedRefusesAnAuthoriserWithoutTheOrchestratorRows() external {
+        mockBeaconSet();
+        mockEnabledState();
+        vm.mockCall(
+            AUTHORISER, abi.encodeCall(IAccessControl.hasRole, (keccak256("WITHDRAW"), ORCHESTRATOR)), abi.encode(false)
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(ExpectedGrantMissing.selector, AUTHORISER, keccak256("WITHDRAW"), ORCHESTRATOR)
+        );
+        harness.assertEnabledLanded(ORCHESTRATOR, SAFE, AUTHORISER, DEPLOY_KEY);
+    }
+
+    function testLandedAcceptsTheEnabledState() external {
+        mockBeaconSet();
+        mockEnabledState();
+        harness.assertEnabledLanded(ORCHESTRATOR, SAFE, AUTHORISER, DEPLOY_KEY);
+    }
+}

--- a/test/script/DeployOrchestratorEnabledHarness.sol
+++ b/test/script/DeployOrchestratorEnabledHarness.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 S01 Issuer GmbH
+pragma solidity =0.8.25;
+
+import {DeployOrchestratorEnabled} from "../../script/20260910-deploy-orchestrator-enabled.s.sol";
+
+/// @title DeployOrchestratorEnabledHarness
+/// @notice Exposes the script's internal pre-flight gates so each refusal
+/// can be driven directly from a test.
+contract DeployOrchestratorEnabledHarness is DeployOrchestratorEnabled {
+    function assertClosureReady() external view {
+        _assertClosureReady();
+    }
+
+    function assertNoInstanceYet(address setDeployer) external view {
+        _assertNoInstanceYet(setDeployer);
+    }
+
+    function assertFleetUpgraded() external view {
+        _assertFleetUpgraded();
+    }
+}


### PR DESCRIPTION
On Base / Ethereum / HyperEVM the orchestrator was deployed with the Safe as admin from birth, so granting the service signer `MINT_ROLE` / `BURN_ROLE` had to be a Safe-signed bundle (`20260831-enable-orchestrator-roles`). A chain that bootstraps after the orchestrator shipped can land the same end state in one deploy-key broadcast.

## What changes
- `20260910-deploy-orchestrator-enabled`: the successor of `20260818-deploy-orchestrator` + the enable bundle for fresh chains. `deploy(owner)` with the CI deploy key as transient `DEFAULT_ADMIN_ROLE`, grant the signer MINT/BURN, grant admin to the chain's token-owner Safe, renounce the key's copy — the deploy-then-hand-off ceremony the V4 authoriser clone already uses. The instance address is the beacon-set deployer's nonce-2 `CREATE`, a function of the (Zoltu) deployer and not of the owner argument, so `ST0X_ORCHESTRATOR_INSTANCE` is unchanged and the authoriser ceremony's orchestrator `DEPOSIT`/`WITHDRAW` rows already point at it — the authoriser half of the enable bundle needs no action on a fresh chain.
- Pre-flight: the 0.1.30 closure by codehash and the nonce-2 fresh-deploy state (from the 20260818 script), the RAI-2125 fleet-on-0.1.30 interlock (from the enable script; on a fresh chain this is what `20260909-upgrade-and-migrate-token-beacons` lands), and the canonical authoriser map at the hydrated pin. The three existing chains refuse (`OrchestratorAlreadyDeployed`) — their Safe-signed history is not re-run.
- Post-state (`assertEnabledLanded`, public so every refusal is driven from a test): instance at its pin, beacon set intact, Safe admin, vault-logic lock passing, signer on MINT/BURN, deploy key holding none of admin/MINT/BURN/EMERGENCY (`DeployKeyHoldsRole`), canonical map still intact.
- `DeployOrchestratorEnabledProdTest`: live-fork walkers for Robinhood and BNB through closure-missing → fleet-pending → pin-unhydrated → ready (drives `run()` end to end) → executed, and prove `20260831-enable-orchestrator-roles` has nothing left to author afterwards (`OrchestratorRolesAlreadyEnabled`). Deadline shared with the parity legs.
- Registered in `manual-broadcast.yaml`.

Together with the beacon script in [#345](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/345) this removes every Safe signature from a fresh chain's bootstrap; the only Safe action left is the governance-timelock migration, in the cross-chain window with the other chains.

## Checks
Local: `forge fmt`, `DeployOrchestratorEnabledTest` (10) + `DeployOrchestratorEnabledProdTest` (2, both chains PENDING at closure-missing) green.


Linear: [RAI-2288](https://linear.app/makeitrain/issue/RAI-2288) (parent [RAI-2284](https://linear.app/makeitrain/issue/RAI-2284)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3
