### PR TITLE
Make --legacy a dispatch input on the suite deploy workflows

### DIFF
--- a/.github/workflows/manual-sol-artifacts-0-1-1.yaml
+++ b/.github/workflows/manual-sol-artifacts-0-1-1.yaml
@@ -41,16 +41,27 @@ on:
           - stox-offchain-asset-receipt-vault-beacon-set-deployer
           # 5. Unified deployer (depends on the two set-deployers above).
           - stox-unified-deployer
+      legacy:
+        description: >-
+          Send type-0 transactions. HyperEVM's RPC rejects forge's EIP-1559
+          fee-history estimation, so a run that has to BROADCAST on HyperEVM
+          needs this. Robinhood Chain rejects it the other way round: its
+          gas-price oracle quotes below the block base fee, so a type-0 run
+          there fails with "max fee per gas less than block base fee". A
+          network where the suite already has code is skipped before any fee
+          estimation, so a bootstrap run onto new chains only needs the flag
+          set for the chains it will actually land on.
+        required: false
+        type: boolean
+        default: true
 jobs:
   deploy:
     uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
     with:
       suite: ${{ inputs.suite }}
-      # HyperEVM's RPC rejects forge's EIP-1559 fee-history estimation, and
       # `--legacy` is one flag over the whole `forge script` run, so it cannot
-      # vary per network within a run. Type-0 is valid on every network the
-      # script ships to, so it is unconditional.
-      legacy: true
+      # vary per network within a run; see the input for when to set it.
+      legacy: ${{ inputs.legacy }}
       # Ship the stored 0.1.1 creation bytecode, not current source.
       script: script/DeployProdV4_0_1_1.sol:Deploy
       # The 0.1.1 bytecode of the contracts that changed by 0.1.3 does not match

--- a/.github/workflows/manual-sol-artifacts-0-1-30.yaml
+++ b/.github/workflows/manual-sol-artifacts-0-1-30.yaml
@@ -42,16 +42,27 @@ on:
           # 6. Orchestrator beacon-set deployer (its constructor bakes a beacon
           #    over the orchestrator impl above).
           - st0x-orchestrator-beacon-set-deployer
+      legacy:
+        description: >-
+          Send type-0 transactions. HyperEVM's RPC rejects forge's EIP-1559
+          fee-history estimation, so a run that has to BROADCAST on HyperEVM
+          needs this. Robinhood Chain rejects it the other way round: its
+          gas-price oracle quotes below the block base fee, so a type-0 run
+          there fails with "max fee per gas less than block base fee". A
+          network where the suite already has code is skipped before any fee
+          estimation, so a bootstrap run onto new chains only needs the flag
+          set for the chains it will actually land on.
+        required: false
+        type: boolean
+        default: true
 jobs:
   deploy:
     uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
     with:
       suite: ${{ inputs.suite }}
-      # HyperEVM's RPC rejects forge's EIP-1559 fee-history estimation, and
       # `--legacy` is one flag over the whole `forge script` run, so it cannot
-      # vary per network within a run. Type-0 is valid on every network the
-      # script ships to, so it is unconditional.
-      legacy: true
+      # vary per network within a run; see the input for when to set it.
+      legacy: ${{ inputs.legacy }}
       # Ship the stored 0.1.30 creation bytecode, not current source.
       script: script/DeployProdV4_0_1_30.sol:Deploy
       # The current source diverged from 0.1.30 (H01 remediation + optimizer


### PR DESCRIPTION
Both suite deploy workflows hardcoded `legacy: true` (HyperEVM's RPC rejects EIP-1559 fee-history estimation). Robinhood Chain rejects type-0 the other way round: its gas-price oracle quotes below the block base fee, so the first 0.1.1 bootstrap dispatch onto 4663 failed with `max fee per gas less than block base fee` (run 34526629079).

## What changes
- `manual-sol-artifacts-0-1-1.yaml` / `manual-sol-artifacts-0-1-30.yaml`: `legacy` becomes a boolean dispatch input, default `true` (unchanged behaviour for anyone not setting it). A network where the suite already has code is skipped by `deployAndBroadcast` before any fee estimation, so a bootstrap run onto Robinhood + BNB dispatched with `legacy=false` never estimates on HyperEVM.

Dispatched from this branch with `legacy=false` for the Robinhood / BNB bootstrap; no contract change.


Linear: [RAI-2288](https://linear.app/makeitrain/issue/RAI-2288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3
