### PR TITLE
Assert the hydrated Robinhood/BSC authoriser pins against the live chains

### DIFF
--- a/test/script/20260807-deploy-missing-tokens.t.sol
+++ b/test/script/20260807-deploy-missing-tokens.t.sol
@@ -19,6 +19,7 @@ import {
 } from "../../script/20260807-deploy-missing-tokens.s.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
+import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
 import {LibTokenInvariants, TokenInstance} from "../../src/lib/LibTokenInvariants.sol";
 import {LibProdTokenConfig, TokenConfig} from "../../src/lib/LibProdTokenConfig.sol";
 import {DeployMissingTokensHarness} from "./DeployMissingTokensHarness.sol";
@@ -28,6 +29,11 @@ import {DeployMissingTokensHarness} from "./DeployMissingTokensHarness.sol";
 /// two in-code tables (Base vs the target chain), so it is PURE — testable
 /// without a fork — and the deploy pre-flight reuses the gate chain the
 /// per-chain prod pins already exercise against live state.
+/// @dev The authoriser pre-flight is covered from both sides. The refusals are
+/// fork-free (`vm.chainId` + a pin with nothing, or the wrong thing, at it),
+/// which is what lets them state an exact expected revert; the acceptances are
+/// live head forks, which is what makes the PINS themselves assertable rather
+/// than only the codehash comparison they feed.
 contract DeployMissingTokensTest is Test {
     /// @dev The 0.1.1 authoriser implementation the production V4 authoriser
     /// clones. Written out rather than imported so this test states the
@@ -192,20 +198,39 @@ contract DeployMissingTokensTest is Test {
         assertEq(bsc.length, LibTokenInvariants.productionTokensBsc().length, "BNB Smart Chain table mismatch");
     }
 
-    /// @notice Same placeholder refusal for BNB Smart Chain.
-    function testAuthoriserNotReadyWhileTheBscPinIsAPlaceholder() external {
-        vm.chainId(LibSafeInvariants.BSC_CHAIN_ID);
-        vm.expectRevert(abi.encodeWithSelector(AuthoriserNotReady.selector, address(0)));
-        harness.assertAuthoriserReady();
+    /// @notice Robinhood Chain's V4 authoriser clone is live at its pin, so
+    /// the pre-flight accepts it against the real chain rather than against an
+    /// etched stand-in. This is the check the etched positive below cannot
+    /// make: it proves the PIN is the address the clone actually occupies on
+    /// Robinhood Chain, not merely that some address carrying the audited
+    /// runtime would be accepted.
+    /// @dev Unpinned head fork. Pinning a block would freeze the answer to
+    /// what was true at that block, and a clone selfdestructed or replaced
+    /// afterwards would still read as ready.
+    function testAuthoriserReadyOnTheRobinhoodFork() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
+        assertEq(block.chainid, LibSafeInvariants.ROBINHOOD_CHAIN_ID, "ROBINHOOD_RPC_URL is not Robinhood Chain");
+        // Redeployed on the fork: `setUp`'s harness lives in the pre-fork
+        // state, which `createSelectFork` swaps out from under it.
+        DeployMissingTokensHarness forked = new DeployMissingTokensHarness();
+        assertEq(
+            forked.assertAuthoriserReady(),
+            LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD,
+            "Robinhood Chain authoriser clone rejected on the live fork"
+        );
     }
 
-    /// @notice Robinhood Chain's clone pin is a placeholder until its
-    /// authoriser deploy executes, and a placeholder is refused as not-ready
-    /// — the token deploy cannot wire vaults onto `address(0)`.
-    function testAuthoriserNotReadyWhileTheRobinhoodPinIsAPlaceholder() external {
-        vm.chainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID);
-        vm.expectRevert(abi.encodeWithSelector(AuthoriserNotReady.selector, address(0)));
-        harness.assertAuthoriserReady();
+    /// @notice Same live-fork acceptance for BNB Smart Chain.
+    /// @dev Unpinned head fork, for the same reason as the Robinhood leg.
+    function testAuthoriserReadyOnTheBscFork() external {
+        vm.createSelectFork(LibStoxDeployNetworks.BSC);
+        assertEq(block.chainid, LibSafeInvariants.BSC_CHAIN_ID, "BSC_RPC_URL is not BNB Smart Chain");
+        DeployMissingTokensHarness forked = new DeployMissingTokensHarness();
+        assertEq(
+            forked.assertAuthoriserReady(),
+            LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC,
+            "BNB Smart Chain authoriser clone rejected on the live fork"
+        );
     }
 
     /// @notice `run()` reverts `DeployerNotDeployed` when the 0.1.1 core has


### PR DESCRIPTION
## What

`test/script/20260807-deploy-missing-tokens.t.sol` still asserted that the
Robinhood Chain and BNB Smart Chain V4 authoriser clone pins were
placeholders, expecting `AuthoriserNotReady(address(0))`. Both pins have
since been hydrated to `0x66566cc91dEAf818859bD4b09B7903ac48998157` in
`src/generated/LibProdDeployV4.sol`, so `main` is RED on those two tests.

Replaced them with live head-fork acceptances - one per chain - that drive
the script's own `_assertAuthoriserReady()` pre-flight against the real
chain.

## Why

The two tests were describing a state the repo had left behind, so the only
options were to delete them or to make them assert what is now true. The
positive form is worth strictly more than the placeholder refusal was.

The file already had an etched positive
(`testAuthoriserReadyAcceptsTheAuditedClone`), but etching proves only that
the codehash comparison accepts an EIP-1167 clone of the 0.1.1 authoriser -
it says nothing about whether the PIN is the address that clone actually
occupies on that chain. A live fork is the only thing that can assert the
pin itself. Verified independently with cast before writing the tests:

```
$ cast codehash 0x66566cc91dEAf818859bD4b09B7903ac48998157 --rpc-url <robinhood>
0x2089950d3cc1112dd66a58adcfadeadc490b50053ac67be8bc676b4a2dcd1717
$ cast codehash 0x66566cc91dEAf818859bD4b09B7903ac48998157 --rpc-url <bsc>
0x2089950d3cc1112dd66a58adcfadeadc490b50053ac67be8bc676b4a2dcd1717
```

which is `STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH`.

Each fork leg asserts `block.chainid` before anything else, so a mis-aliased
RPC fails loudly rather than passing against the wrong chain.

The fork-free refusals are untouched and still carry the negative side: a pin
with no code at it (`vm.chainId` + no etch) and a pin carrying the wrong
runtime both still revert `AuthoriserNotReady(<pin>)`, so the acceptances are
not vacuous.

## Checks

`forge test --match-path 'test/script/20260807-deploy-missing-tokens.t.sol'`

Before (on `main`):

```
Suite result: FAILED. 22 passed; 2 failed; 0 skipped; finished in 7.42ms (17.80ms CPU time)
[FAIL: Error != expected error: AuthoriserNotReady(0x66566cc91dEAf818859bD4b09B7903ac48998157) != AuthoriserNotReady(0x0000000000000000000000000000000000000000)] testAuthoriserNotReadyWhileTheBscPinIsAPlaceholder() (gas: 11697)
[FAIL: Error != expected error: AuthoriserNotReady(0x66566cc91dEAf818859bD4b09B7903ac48998157) != AuthoriserNotReady(0x0000000000000000000000000000000000000000)] testAuthoriserNotReadyWhileTheRobinhoodPinIsAPlaceholder() (gas: 11687)
```

After:

```
Suite result: ok. 24 passed; 0 failed; 0 skipped; finished in 5.15s (5.33s CPU time)

Ran 1 test suite in 5.15s (5.15s CPU time): 24 tests passed, 0 failed, 0 skipped (24 total tests)
```

`forge fmt` + `forge build` clean. Full-suite, slither and REUSE runs are on
the stacked PR.

Linear: RAI-2284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated deployment verification for BNB Smart Chain and Robinhood Chain.
  * Added live-fork coverage confirming that the expected V4 authoriser is available on both networks.
  * Replaced placeholder-state rejection checks with acceptance checks against deployed network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->