### PR TITLE
Simulate the enabled-orchestrator ceremony under prank in the prod walker

### DIFF
--- a/test/script/20260910-deploy-orchestrator-enabled.prod.t.sol
+++ b/test/script/20260910-deploy-orchestrator-enabled.prod.t.sol
@@ -21,6 +21,7 @@ import {LibOrchestratorInvariants} from "../../src/lib/LibOrchestratorInvariants
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
 import {LibSafeInvariants} from "../../src/lib/LibSafeInvariants.sol";
 import {LibStoxDeployNetworks} from "../../src/lib/LibStoxDeployNetworks.sol";
+import {IST0xOrchestratorBeaconSetDeployerV1} from "../../src/interface/IST0xOrchestratorBeaconSetDeployerV1.sol";
 
 /// @notice The enabled-orchestrator rollout deadline passed with this chain
 /// still pending. Run the outstanding dispatches, extend the deadline, or
@@ -39,7 +40,7 @@ error OrchestratorEnabledRolloutOverdue(string label);
 ///    `AuthoriserNotReady` — the ceremony + hydration PR come first.
 /// 3. **Fleet on 0.1.1** (authoriser live): refuses `FleetNotUpgraded` —
 ///    `20260909-upgrade-and-migrate-token-beacons` comes first.
-/// 4. **Ready**: drives `run()` end to end on the fork — instance at its
+/// 4. **Ready**: simulates the ceremony `run()` performs on the fork — instance at its
 ///    pin, Safe admin, signer on MINT/BURN, deploy key clean, canonical
 ///    map intact — then proves the Safe-bundle enable script has nothing
 ///    left to author (`OrchestratorRolesAlreadyEnabled`).
@@ -123,11 +124,45 @@ contract DeployOrchestratorEnabledProdTest is Test {
             return;
         }
 
-        pending(label, "ready - driving the enabled deploy end to end on the fork");
-        script.run();
+        pending(label, "ready - simulating the enabled deploy ceremony on the fork");
+        simulateCeremony(script, label);
         assertEnabledSteadyState(label);
         vm.expectRevert(OrchestratorRolesAlreadyEnabled.selector);
         enable.run();
+    }
+
+    /// @notice Drive the ceremony `run()` performs, step by step, as a
+    /// synthetic deploy key: `deploy(deployer)`, the two signer grants, the
+    /// admin hand-off to the Safe, the deploy key's renounce — then run the
+    /// script's own `assertEnabledLanded` against the result. Driven inline
+    /// under `vm.prank` because `vm.startBroadcast` (which `run()` wraps
+    /// around the sequence) is mutually exclusive with `vm.prank` in
+    /// `forge test`, and `msg.sender` inside `run()` would be this test
+    /// contract rather than the broadcaster. Mirrors
+    /// `DeployV4AuthoriserCloneTest.testHappyPathLeavesExpectedGrantsAndNoDeployerAdmin`.
+    /// @param script The script whose post-state assertion is exercised.
+    /// @param label Human chain name for messages.
+    function simulateCeremony(DeployOrchestratorEnabled script, string memory label) internal {
+        address deployer = makeAddr("orchestrator-enabled-deploy-key");
+        address safe = LibSafeInvariants.safeForChainId(block.chainid);
+        address authoriser = LibAuthoriserInvariants.activeChainAuthoriser();
+        address setDeployer = LibProdDeployV4.ST0X_ORCHESTRATOR_BEACON_SET_DEPLOYER_0_1_30;
+
+        vm.prank(deployer, deployer);
+        address instance = IST0xOrchestratorBeaconSetDeployerV1(setDeployer).deploy(deployer);
+        assertEq(instance, LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE, string.concat(label, ": instance pin"));
+
+        IAccessControl orch = IAccessControl(instance);
+        vm.prank(deployer, deployer);
+        orch.grantRole(keccak256("MINT"), SIGNER);
+        vm.prank(deployer, deployer);
+        orch.grantRole(keccak256("BURN"), SIGNER);
+        vm.prank(deployer, deployer);
+        orch.grantRole(bytes32(0), safe);
+        vm.prank(deployer, deployer);
+        orch.renounceRole(bytes32(0), deployer);
+
+        script.assertEnabledLanded(instance, safe, authoriser, deployer);
     }
 
     function testOrchestratorEnabledRolloutRobinhood() external {


### PR DESCRIPTION
`DeployOrchestratorEnabledProdTest`'s ready branch called `run()` directly. Under `forge test` `vm.startBroadcast` is a no-op and `msg.sender` inside `run()` is the test contract, so `deploy(deployer)` initialised the instance with the test contract as admin and the first `grantRole` reverted `AccessControlUnauthorizedAccount` — red on Robinhood and BSC the moment the 0.1.30 closure, the fleet repoint and the hydrated authoriser pin all landed today.

## What changes
- The ready branch now drives the ceremony inline as a synthetic deploy key under `vm.prank` (`deploy(deployer)`, MINT/BURN grants to the signer, admin to the Safe, renounce), then runs the script's own `assertEnabledLanded` against the result and proves `20260831-enable-orchestrator-roles` refuses (`OrchestratorRolesAlreadyEnabled`). Same shape as `DeployV4AuthoriserCloneTest.testHappyPathLeavesExpectedGrantsAndNoDeployerAdmin`, for the same reason (`startBroadcast` and `prank` are mutually exclusive in tests).
- Live result: both Robinhood and BSC walk the ready state green — the full ceremony works on live forks of both chains ahead of the real dispatch.

## Checks
`forge fmt`; `DeployOrchestratorEnabledProdTest` 2/2 green on live Robinhood + BSC forks.


Linear: [RAI-2284](https://linear.app/makeitrain/issue/RAI-2284).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3
