### PR TITLE
Make --legacy a dispatch input on manual-broadcast

### DIFF
--- a/.github/workflows/manual-broadcast.yaml
+++ b/.github/workflows/manual-broadcast.yaml
@@ -70,6 +70,16 @@ on:
 # The `slow` flag makes forge wait for each tx to confirm before sending
 # the next; without it a script that lands a sequence of dependent txs
 # (e.g. deploy → grantRole using the deploy) can race the nonce.
+      legacy:
+        description: >-
+          Send type-0 transactions. Always on for a HyperEVM dispatch. Set it
+          for a multi-chain script (e.g. 20260729-deploy-governance-timelock)
+          only when HyperEVM still lacks the contract and will receive a
+          transaction; leave it off when the run only lands on Robinhood
+          Chain, which rejects type-0 (gas-price oracle below the base fee).
+        required: false
+        type: boolean
+        default: false
 jobs:
   broadcast:
     name: Broadcast operational script
@@ -109,17 +119,23 @@ jobs:
           # arguments and cannot inject shell.
           SCRIPT: ${{ inputs.script }}
           NETWORK: ${{ inputs.network }}
+          LEGACY: ${{ inputs.legacy }}
           # PRIVATE_KEY is only available inside this step — matching
           # `manual-sol-artifacts-0-1-1.yaml`. The workflow file itself does not
           # persist it anywhere else.
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         run: |
-          # HyperEVM's RPC rejects forge's EIP-1559 fee-history estimation;
-          # type-0 transactions work on every network. Multi-chain scripts
-          # broadcast to HyperEVM inside a single run regardless of which
-          # network was dispatched, so they always take the legacy path.
+          # HyperEVM's RPC rejects forge's EIP-1559 fee-history estimation,
+          # so a broadcast that lands on HyperEVM needs type-0. Robinhood
+          # Chain rejects type-0 the other way round (its gas-price oracle
+          # quotes below the block base fee), so `--legacy` cannot be
+          # unconditional for a multi-chain script. A chain the script skips
+          # (code already at the pin) is never fee-estimated, so the flag is
+          # only needed when HyperEVM is actually going to receive a
+          # transaction: always for a HyperEVM dispatch, otherwise per the
+          # `legacy` input.
           LEGACY_ARGS=()
-          if [[ "${NETWORK}" == "hyperevm" || "${SCRIPT}" == "20260729-deploy-governance-timelock" ]]; then
+          if [[ "${NETWORK}" == "hyperevm" || "${LEGACY}" == "true" ]]; then
             LEGACY_ARGS+=(--legacy)
           fi
           nix develop --command forge script "script/${SCRIPT}.s.sol" \


### PR DESCRIPTION
`manual-broadcast` hardwired `--legacy` for `20260729-deploy-governance-timelock` because that script broadcasts to every network in one run and HyperEVM needs type-0. Robinhood Chain rejects type-0 (its gas-price oracle quotes below the block base fee — the failure [#355](https://app.graphite.com/github/pr/S01-Issuer/st0x.deploy/355) fixed for the suite workflows), and HyperEVM already carries the timelock, so it is skipped before any fee estimation.

## What changes
- `legacy` boolean dispatch input, default `false`. `--legacy` is still automatic for a `hyperevm` dispatch; otherwise it follows the input. The per-script rule is gone.

Dispatched from this branch with `legacy=false` for the Robinhood / BNB timelock deploy.


Linear: [RAI-2288](https://linear.app/makeitrain/issue/RAI-2288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3
