### PR TITLE
Treat placeholder token rows as missing in the copy selection

### DIFF
--- a/script/20260807-deploy-missing-tokens.s.sol
+++ b/script/20260807-deploy-missing-tokens.s.sol
@@ -278,14 +278,19 @@ contract DeployMissingTokens is Script {
         }
     }
 
-    /// @notice Whether `tokens` already carries an entry for `underlying`.
+    /// @notice Whether `tokens` already carries a DEPLOYED entry for
+    /// `underlying`. A placeholder row — the ticker listed with a zero
+    /// receipt vault, which is how a new chain's table is authored ahead of
+    /// its deploy so the parity pins can pair by index — is not a token the
+    /// chain has, so it does not count: a chain whose whole table is
+    /// placeholders is the bootstrap case and selects the full Base set.
     /// @param tokens The table to search.
     /// @param underlying The ticker to look for.
-    /// @return True when the ticker is already present.
+    /// @return True when the ticker is present with a deployed receipt vault.
     function _hasUnderlying(TokenInstance[] memory tokens, string memory underlying) internal pure returns (bool) {
         bytes32 target = keccak256(bytes(underlying));
         for (uint256 i = 0; i < tokens.length; i++) {
-            if (keccak256(bytes(tokens[i].underlying)) == target) {
+            if (keccak256(bytes(tokens[i].underlying)) == target && tokens[i].receiptVault != address(0)) {
                 return true;
             }
         }

--- a/test/script/20260807-deploy-missing-tokens.t.sol
+++ b/test/script/20260807-deploy-missing-tokens.t.sol
@@ -102,6 +102,32 @@ contract DeployMissingTokensTest is Test {
         assertEq(missing.length, LibTokenInvariants.productionTokensBase().length, "expected the full Base set");
     }
 
+    /// @notice A target table of PLACEHOLDER rows — every ticker listed with
+    /// zero addresses, the shape a new chain's table takes ahead of its
+    /// deploy so the parity pins can pair by index — selects the whole Base
+    /// set, exactly like an empty table. The 2026-09-10 Robinhood Chain
+    /// dispatch (run 34541560863) refused `NoMissingTokens` because the
+    /// ticker match alone read the placeholders as deployed tokens.
+    function testSelectionTreatsPlaceholderRowsAsMissing() external view {
+        TokenInstance[] memory placeholders = LibTokenInvariants.productionTokensRobinhood();
+        TokenConfig[] memory missing = harness.selectMissing(
+            LibProdTokenConfig.productionTokenConfigs(), LibTokenInvariants.productionTokensBase(), placeholders
+        );
+        assertEq(missing.length, LibTokenInvariants.productionTokensBase().length, "expected the full Base set");
+    }
+
+    /// @notice A half-hydrated target — some rows deployed, the rest still
+    /// placeholders — selects only the placeholder rows.
+    function testSelectionSkipsDeployedRowsAmongPlaceholders() external view {
+        TokenInstance[] memory base = LibTokenInvariants.productionTokensBase();
+        TokenInstance[] memory target = LibTokenInvariants.productionTokensRobinhood();
+        target[0] = base[0];
+        target[base.length - 1] = base[base.length - 1];
+        TokenConfig[] memory missing = harness.selectMissing(LibProdTokenConfig.productionTokenConfigs(), base, target);
+        assertEq(missing.length, base.length - 2, "expected every placeholder row and nothing else");
+        assertEq(missing[0].underlying, base[1].underlying, "first selected row");
+    }
+
     /// @notice A config table running AHEAD of Base is a normal state, not a
     /// drift: rows are authored when a ticker is chosen and Base is pinned
     /// when it is deployed, so the config table leads until the Base deploy


### PR DESCRIPTION
The first Robinhood Chain token dispatch (run 34541560863) refused `NoMissingTokens()`. `_selectMissing` matched the target table by ticker alone, and the Robinhood / BNB tables are authored as 41 placeholder rows (ticker + `address(0)`) so the parity pins can pair by index ahead of the deploy — every placeholder read as an already-deployed token.

## What changes
- `_hasUnderlying` counts a row only when its receipt vault is non-zero. An all-placeholder table is the bootstrap case and selects the full Base set; a half-hydrated table selects exactly its placeholder rows.
- Tests: `testSelectionTreatsPlaceholderRowsAsMissing` (the live Robinhood table selects all 41) and `testSelectionSkipsDeployedRowsAmongPlaceholders`.

The token deploy on both chains is dispatched from this branch.

## Checks
`forge fmt`; `DeployMissingTokensTest` 26/26 green (live forks).


Linear: [RAI-2288](https://linear.app/makeitrain/issue/RAI-2288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3
