### PR TITLE
Add an rpc_throttle input to manual-broadcast for public archive RPCs

### DIFF
--- a/.github/workflows/manual-broadcast.yaml
+++ b/.github/workflows/manual-broadcast.yaml
@@ -80,6 +80,17 @@ on:
         required: false
         type: boolean
         default: false
+      rpc_throttle:
+        description: >-
+          Throttle forge's fork RPC usage for a rate-limited public archive
+          endpoint: caps the assumed compute units per second at 60 and retries
+          rate-limit responses (30 retries, 2s initial backoff) instead of
+          aborting the run. Needed for long broadcasts (the 41-token copy) on
+          chains where the only archive RPC available is a public one (BNB
+          Smart Chain: blastapi 429s under forge's default request rate).
+        required: false
+        type: boolean
+        default: false
 jobs:
   broadcast:
     name: Broadcast operational script
@@ -120,6 +131,7 @@ jobs:
           SCRIPT: ${{ inputs.script }}
           NETWORK: ${{ inputs.network }}
           LEGACY: ${{ inputs.legacy }}
+          RPC_THROTTLE: ${{ inputs.rpc_throttle }}
           # PRIVATE_KEY is only available inside this step — matching
           # `manual-sol-artifacts-0-1-1.yaml`. The workflow file itself does not
           # persist it anywhere else.
@@ -138,8 +150,13 @@ jobs:
           if [[ "${NETWORK}" == "hyperevm" || "${LEGACY}" == "true" ]]; then
             LEGACY_ARGS+=(--legacy)
           fi
+          THROTTLE_ARGS=()
+          if [[ "${RPC_THROTTLE}" == "true" ]]; then
+            THROTTLE_ARGS+=(--compute-units-per-second 60 --fork-retries 30 --fork-retry-backoff 2000)
+          fi
           nix develop --command forge script "script/${SCRIPT}.s.sol" \
             "${LEGACY_ARGS[@]}" \
+            "${THROTTLE_ARGS[@]}" \
             --sig 'run()' \
             --rpc-url "${NETWORK}" \
             --no-storage-caching \


### PR DESCRIPTION
The BNB Smart Chain 41-token copy has no keyed archive RPC available to us; the only public archive endpoint (`bsc-mainnet.public.blastapi.io`) answers `429 Rate limit reached` under forge's default fork request rate and the run aborts in pre-flight (runs 34543105537, 34545216894). The dataseed / publicnode BSC endpoints are not archive at all, and a long `forge script` keeps reading state at its pinned start block.

## What changes
- `rpc_throttle` boolean dispatch input, default `false`. When on, forge gets `--compute-units-per-second 60 --fork-retries 30 --fork-retry-backoff 2000`: a lower assumed request budget plus retries on rate-limit responses instead of an abort. No change for existing dispatches.

Dispatched from this branch with `rpc_throttle=true` for the BNB token copy.


Linear: [RAI-2288](https://linear.app/makeitrain/issue/RAI-2288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional RPC throttling setting for manual broadcasts.
  * When enabled, broadcasts use rate-limit-friendly pacing and automatic retries to improve reliability on public archive endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->