### PR TITLE
Record the 2026-09-11 Robinhood/BSC copy runs in the token tables

### DIFF
--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -1392,12 +1392,20 @@ library LibTokenInvariants {
     /// tables pair by index as well as by key (the cross-chain parity pin
     /// asserts the alignment).
     ///
-    /// Deployed on Robinhood Chain 2026-09-10 by `20260807-deploy-missing-tokens`
-    /// on `robinhood` (manual-broadcast run 34542355140): all 41 tokens via the
-    /// 0.1.1 unified deployer against beacons already on 0.1.30, each wired
-    /// onto this chain's V4 authoriser and handed to its token-owner Safe in
-    /// the same broadcast. Addresses pinned from the run's logged
-    /// (underlying, receipt, receiptVault, wrapped) tuples.
+    /// Deployed on Robinhood Chain by `20260807-deploy-missing-tokens` on
+    /// `robinhood`, in two broadcasts, each via the 0.1.1 unified deployer
+    /// against beacons already on 0.1.30, each token wired onto this chain's
+    /// V4 authoriser and handed to its token-owner Safe in the same
+    /// broadcast. Addresses pinned from each run's logged
+    /// (underlying, receipt, receiptVault, wrapped) tuples:
+    ///
+    ///   rows 0-40   2026-09-10  manual-broadcast run 34542355140 (41 tokens)
+    ///   rows 41-55  2026-09-11  manual-broadcast run 34588739371 (15 tokens)
+    ///
+    /// The second run is the copy of the fifteen Base rows Base itself only
+    /// picked up in #339 (CBRS, the EU batch, MCD/NKE, GRND/DNUT and the
+    /// 2026-09-06 batch); the script diffed Base against this table and
+    /// selected exactly those fifteen.
     /// @return tokens The 56 production token instances on Robinhood Chain.
     function productionTokensRobinhood() internal pure returns (TokenInstance[] memory tokens) {
         tokens = new TokenInstance[](56);
@@ -1747,12 +1755,33 @@ library LibTokenInvariants {
     /// tables pair by index as well as by key (the cross-chain parity pin
     /// asserts the alignment).
     ///
-    /// Deployed on BNB Smart Chain 2026-09-10 by `20260807-deploy-missing-tokens`
-    /// on `bsc` (manual-broadcast run 34545683866): all 41 tokens via the
-    /// 0.1.1 unified deployer against beacons already on 0.1.30, each wired
-    /// onto this chain's V4 authoriser and handed to its token-owner Safe in
-    /// the same broadcast. Addresses pinned from the run's logged
-    /// (underlying, receipt, receiptVault, wrapped) tuples.
+    /// Deployed on BNB Smart Chain by `20260807-deploy-missing-tokens` on
+    /// `bsc`, in two broadcasts, each via the 0.1.1 unified deployer against
+    /// beacons already on 0.1.30, each token wired onto this chain's V4
+    /// authoriser and handed to its token-owner Safe in the same broadcast.
+    /// Addresses pinned from each run's logged
+    /// (underlying, receipt, receiptVault, wrapped) tuples:
+    ///
+    ///   rows 0-40   2026-09-11  manual-broadcast run 34545683866 (41 tokens)
+    ///   rows 41-55  2026-09-11  manual-broadcast run 34589363778 (15 tokens)
+    ///
+    /// An EARLIER run, 34542307257, also broadcast all 41 tokens on this
+    /// chain and was never pinned; its vaults are live, Safe-owned and
+    /// zero-supply, and nothing references them. They are NOT in this table
+    /// and must not be pinned into it by mistake — see issue #364.
+    ///
+    /// Two address facts that look like copy-paste bugs and are not. These
+    /// are nonce-ordered deploys from one key, so equal deployer nonces give
+    /// equal addresses across chains, and this chain's nonce cursor is 41
+    /// ahead of Robinhood's because of run 34542307257:
+    ///
+    ///   - the orphan set from 34542307257 sits at the addresses Robinhood
+    ///     rows 0-40 occupy, and
+    ///   - rows 0-14 HERE sit at the addresses Robinhood rows 41-55 occupy.
+    ///
+    /// Neither is a duplicate pin: each address is a distinct contract on its
+    /// own chain, carrying that chain's own symbol. Rows 41-55 here were
+    /// broadcast past both windows and collide with nothing on Robinhood.
     /// @return tokens The 56 production token instances on BNB Smart Chain.
     function productionTokensBsc() internal pure returns (TokenInstance[] memory tokens) {
         tokens = new TokenInstance[](56);

--- a/test/src/lib/LibProdBeacons0_1_1.t.sol
+++ b/test/src/lib/LibProdBeacons0_1_1.t.sol
@@ -139,8 +139,10 @@ contract LibProdBeacons0_1_1Test is Test {
         assertTokensRunOnPinnedBeacons("HyperEVM", LibTokenInvariants.productionTokensHyperEvm());
     }
 
-    /// @notice Robinhood Chain's production tokens run on the pinned beacons
-    /// once its table hydrates; PENDING until the 41-token deploy lands.
+    /// @notice Robinhood Chain's production tokens run on the pinned beacons.
+    /// The table is fully hydrated (56/56), so this asserts rather than
+    /// skips; the `OrPending` wrapper stays as the guard against a future
+    /// chain's table being half-pinned.
     function testRobinhoodTokensRunOnTheseBeacons() external {
         vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
         assertTokensRunOnPinnedBeaconsOrPending(
@@ -148,8 +150,10 @@ contract LibProdBeacons0_1_1Test is Test {
         );
     }
 
-    /// @notice BNB Smart Chain's production tokens run on the pinned beacons
-    /// once its table hydrates; PENDING until the 41-token deploy lands.
+    /// @notice BNB Smart Chain's production tokens run on the pinned beacons.
+    /// The table is fully hydrated (56/56), so this asserts rather than
+    /// skips; the `OrPending` wrapper stays as the guard against a future
+    /// chain's table being half-pinned.
     function testBscTokensRunOnTheseBeacons() external {
         vm.createSelectFork(LibStoxDeployNetworks.BSC);
         assertTokensRunOnPinnedBeaconsOrPending(

--- a/test/src/lib/LibTokenInvariants.t.sol
+++ b/test/src/lib/LibTokenInvariants.t.sol
@@ -102,8 +102,9 @@ contract LibTokenInvariantsTest is Test {
     }
 
     /// The Robinhood Chain token table mirrors Base row-for-row on the
-    /// `underlying` key. Its addresses are placeholders until the token
-    /// deploy executes there; this guards only the shared shape.
+    /// `underlying` key. This guards only the shared shape; the addresses
+    /// themselves are asserted against the live chain by the cross-chain
+    /// parity pin.
     function testRobinhoodTokenTableMirrorsBaseUnderlyings() external pure {
         TokenInstance[] memory base = LibTokenInvariants.productionTokensBase();
         TokenInstance[] memory robinhood = LibTokenInvariants.productionTokensRobinhood();
@@ -114,7 +115,9 @@ contract LibTokenInvariantsTest is Test {
     }
 
     /// The BNB Smart Chain token table mirrors Base row-for-row on the
-    /// `underlying` key; addresses are placeholders until its token deploy.
+    /// `underlying` key. This guards only the shared shape; the addresses
+    /// themselves are asserted against the live chain by the cross-chain
+    /// parity pin.
     function testBscTokenTableMirrorsBaseUnderlyings() external pure {
         TokenInstance[] memory base = LibTokenInvariants.productionTokensBase();
         TokenInstance[] memory bsc = LibTokenInvariants.productionTokensBsc();


### PR DESCRIPTION
## What this is

A **comments-only** follow-up to #339. No pin is added, removed or reordered — `git diff` touches three doc blocks and nothing else.

## Why

The task I picked up was "extend `productionTokensRobinhood()` / `productionTokensBsc()` from 41 to 56 rows with the 15 tokens copied today". That work is **already on `main`**: #339 (`8ab9c09`) appended rows 41-55 to all five per-chain tables, not just Base, and `rainix-sol` is green on it. What #339 did not do is update the two docstrings, which still read "all 41 tokens" and name only the 2026-09-10 broadcasts. This repo's `CLAUDE.md` treats the address constants as an audit trail, so the provenance of rows 41-55 belongs beside them.

| chain | rows | date | manual-broadcast run |
|---|---|---|---|
| Robinhood (4663) | 0-40 | 2026-09-10 | [34542355140](https://github.com/S01-Issuer/st0x.deploy/actions/runs/34542355140) |
| Robinhood (4663) | 41-55 | 2026-09-11 10:20 UTC | [34588739371](https://github.com/S01-Issuer/st0x.deploy/actions/runs/34588739371) |
| BSC (56) | 0-40 | 2026-09-11 00:15 UTC | [34545683866](https://github.com/S01-Issuer/st0x.deploy/actions/runs/34545683866) |
| BSC (56) | 41-55 | 2026-09-11 10:28 UTC | [34589363778](https://github.com/S01-Issuer/st0x.deploy/actions/runs/34589363778) |

## Verification of what is already pinned

Rows 41-55 of both tables were re-derived from the two run logs (`gh run view <id> --log`, 15 `==== TOKEN DEPLOYED ====` tuples each, both headed `Copying 15 Base tokens onto chain id …`) and they match the merged tables **byte for byte, in Base row order** — CBRS, AIR.PA, BMW.DE, MC.PA, SIE.DE, MBG.DE, RHM.DE, MCD, NKE, GRND, DNUT, PLBY, TR, WEN, FGI.

Every one of the 30 instances was then re-read on the live chains (`cast call`, `https://rpc.mainnet.chain.robinhood.com` and `https://bsc-dataseed.binance.org`) — 30/30 clean:

- `receiptVault.symbol()` == `t<T>` and `wrapper.symbol()` == `wt<T>`
- `wrapper.asset()` == the pinned receipt vault
- `receiptVault.receipt()` == the pinned ERC-1155
- `receiptVault.owner()` == `0x3840aeDaEc8e82f79d8F6a8F6ADCa271E13E0329`
- `receiptVault.authorizer()` == `0x66566cc91dEAf818859bD4b09B7903ac48998157`
- `isCertificationExpired()` == `true` on all 30 (expected: nothing has been certified on either chain yet)

And the two fork tests were run against the live chains from this branch:

```
[PASS] testBscTokensRunOnTheseBeacons()       (gas: 244784)
[PASS] testRobinhoodTokensRunOnTheseBeacons() (gas: 244741)
```

Both now **assert** rather than emit `PENDING` — which is the point of dropping the stale "placeholder" wording from those tests.

## The orphan set, and two address coincidences

The BSC orphan set from run [34542307257](https://github.com/S01-Issuer/st0x.deploy/actions/runs/34542307257) (41 unpinned duplicate vaults, issue #364) is **unaffected by this PR** and stays unpinned.

The brief I was working from asked me to confirm "these 15 have no orphan twins" by checking whether the Robinhood addresses of the 15 have code on BSC. **They do have code on BSC — and that is not an orphan.** The measurements:

- The 15 **Robinhood** vault addresses, read on BSC: all 15 have code (267 bytes), Safe-owned, and report `tMSTR, tTSLA, tCOIN, tSPYM, tSIVR, tCRCL, tNVDA, tIAU, tPPLT, tAMZN, tBMNR, tIBHG, tSGOV, tQQQM, tVWO` — i.e. they are exactly BSC rows **0-14**, already pinned by #361.
- The 15 **BSC** vault addresses, read on Robinhood: all 15 have **zero** code.
- Robinhood rows 0-40, read on BSC: code, right symbol, `totalSupply() == 0`, Safe-owned, referenced by nothing — that is the #364 orphan set.

The explanation is nonce arithmetic, not a bug: these are nonce-ordered deploys from one key, so equal deployer nonces produce equal addresses across chains, and BSC's cursor sits 41 ahead of Robinhood's precisely *because* of run 34542307257. So the orphan set landed on Robinhood rows 0-40's addresses, BSC rows 0-14 landed on Robinhood rows 41-55's addresses, and today's BSC 15 landed past both windows and collide with nothing. Each address is a distinct contract on its own chain carrying its own symbol; nothing is double-pinned, and **the 15 created no new orphans on either chain**.

That reasoning is now in the `productionTokensBsc()` docstring, because a future reader diffing the two tables will otherwise read the overlap as a copy-paste error and "fix" it.

## Checks

- `forge build` clean; `forge fmt --check` clean on all three touched files (the one pre-existing fmt diff is in `src/generated/`, untouched here).
- `testRobinhoodTokenTableMirrorsBaseUnderlyings` / `testBscTokenTableMirrorsBaseUnderlyings` / Ethereum / HyperEVM: 4/4 pass.
- The full fork suite needs the CI archive RPCs — the Base-leg tests 429 on the public endpoint locally, so `rainix-sol` on this branch is the signal for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDVXNvDqgej1B2dYU7pmMA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified deployment records for Robinhood and BNB Smart Chain token broadcasts.
  - Documented the status of fully populated token tables and safeguards for future partial bootstrap states.
  - Updated validation notes to reflect cross-chain consistency checks against live token addresses.

- **Tests**
  - Improved test documentation describing token table coverage and address verification.
  - No test behavior or application functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->