### PR TITLE
Pin tBIRD on Base and copy it to Ethereum, HyperEVM, BSC and Robinhood (56 -> 57)

### DIFF
--- a/src/lib/LibProdTokenConfig.sol
+++ b/src/lib/LibProdTokenConfig.sol
@@ -24,7 +24,7 @@ struct TokenConfig {
 }
 
 /// @title LibProdTokenConfig
-/// @notice The canonical name/symbol table for the 56 ST0x production
+/// @notice The canonical name/symbol table for the 57 ST0x production
 /// tokens, captured verbatim from the live Base receipt vaults so a new
 /// chain's token set can be deployed byte-identical to Base. This is the
 /// deploy-input companion to `LibTokenInvariants` (which holds the deployed
@@ -37,15 +37,18 @@ struct TokenConfig {
 /// @dev Entries are in the same order as
 /// `LibTokenInvariants.productionTokensBase()` so the two tables pair by
 /// index as well as by `underlying` key; `LibProdTokenConfigTest` pins that
-/// alignment. Strings are reproduced EXACTLY, including quirks that exist on
+/// alignment over every row Base carries. The table may run AHEAD of Base —
+/// a row is authored when a ticker is chosen and Base is pinned when its
+/// deploy lands, and `_selectMissing` reads only the rows Base carries — but
+/// never behind it. Strings are reproduced EXACTLY, including quirks that exist on
 /// Base — notably `SGOV`'s name has a leading space. Matching Base "exactly"
 /// means carrying that space forward; the parity pin would flag it as a
 /// divergence otherwise.
 library LibProdTokenConfig {
-    /// @notice The 56 production token deploy configs, Base table order.
+    /// @notice The 57 production token deploy configs, Base table order.
     /// @return configs The name/symbol table.
     function productionTokenConfigs() internal pure returns (TokenConfig[] memory configs) {
-        configs = new TokenConfig[](56);
+        configs = new TokenConfig[](57);
         configs[0] = TokenConfig("MSTR", "MicroStrategy Incorporated ST0x", "tMSTR");
         configs[1] = TokenConfig("TSLA", "Tesla Inc ST0x", "tTSLA");
         configs[2] = TokenConfig("COIN", "Coinbase Global Inc ST0x", "tCOIN");
@@ -111,5 +114,9 @@ library LibProdTokenConfig {
         configs[53] = TokenConfig("TR", "Tootsie Roll Industries, Inc. ST0x", "tTR");
         configs[54] = TokenConfig("WEN", "The Wendy's Company ST0x", "tWEN");
         configs[55] = TokenConfig("FGI", "FGI Industries Ltd. ST0x", "tFGI");
+        // tBIRD — Smartbird, Inc. is the former Allbirds, Inc. (renamed 2026, same
+        // Nasdaq listing); name derived the way sft-ops derives it
+        // (`"<metadata.name> ST0x"`, `"t<code>"`) from sft-ops `metadata/bird.json`.
+        configs[56] = TokenConfig("BIRD", "Smartbird, Inc. ST0x", "tBIRD");
     }
 }

--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -536,14 +536,22 @@ library LibTokenInvariants {
     /// https://basescan.org/address/0x6aed8b1aCfb04F4e0e6db580F12fF41438a394e5
     address internal constant FGI_WRAPPED_TOKEN_VAULT = address(0x6aed8b1aCfb04F4e0e6db580F12fF41438a394e5);
 
-    /// @notice Returns the 56 production token instance triples on Base, in
+    // ---- tBIRD / wtBIRD — Smartbird, Inc. ST0x ----
+    /// https://basescan.org/address/0x5ae4611fD6944613E2947A44fd76ad4B48551F6A
+    address internal constant BIRD_RECEIPT = address(0x5ae4611fD6944613E2947A44fd76ad4B48551F6A);
+    /// https://basescan.org/address/0x22E99389f5ef6FA110317e2Aec0a95d8AA39eFD4
+    address internal constant BIRD_RECEIPT_VAULT = address(0x22E99389f5ef6FA110317e2Aec0a95d8AA39eFD4);
+    /// https://basescan.org/address/0x95d46fC0faf4141C508D037469F472366093415a
+    address internal constant BIRD_WRAPPED_TOKEN_VAULT = address(0x95d46fC0faf4141C508D037469F472366093415a);
+
+    /// @notice Returns the 57 production token instance triples on Base, in
     /// the order they were deployed. This is the structured source of truth
     /// the flat `productionReceiptVaults()` accessor derives from; consumers
     /// that need the receipt / wrapped-vault legs or the underlying join key
     /// (cross-chain parity, per-token config checks) iterate this instead.
-    /// @return tokens The 56 production token instances on Base.
+    /// @return tokens The 57 production token instances on Base.
     function productionTokensBase() internal pure returns (TokenInstance[] memory tokens) {
-        tokens = new TokenInstance[](56);
+        tokens = new TokenInstance[](57);
         tokens[0] = TokenInstance("MSTR", MSTR_RECEIPT, MSTR_RECEIPT_VAULT, MSTR_WRAPPED_TOKEN_VAULT);
         tokens[1] = TokenInstance("TSLA", TSLA_RECEIPT, TSLA_RECEIPT_VAULT, TSLA_WRAPPED_TOKEN_VAULT);
         tokens[2] = TokenInstance("COIN", COIN_RECEIPT, COIN_RECEIPT_VAULT, COIN_WRAPPED_TOKEN_VAULT);
@@ -627,6 +635,11 @@ library LibTokenInvariants {
         tokens[53] = TokenInstance("TR", TR_RECEIPT, TR_RECEIPT_VAULT, TR_WRAPPED_TOKEN_VAULT);
         tokens[54] = TokenInstance("WEN", WEN_RECEIPT, WEN_RECEIPT_VAULT, WEN_WRAPPED_TOKEN_VAULT);
         tokens[55] = TokenInstance("FGI", FGI_RECEIPT, FGI_RECEIPT_VAULT, FGI_WRAPPED_TOKEN_VAULT);
+        // tBIRD — deployed on Base 2026-09-11 by sft-ops CD (run 34614696472),
+        // wired onto the V4 authoriser and handed to the Base token-owner Safe.
+        // Copied onto the four other chains by `20260807-deploy-missing-tokens`;
+        // see each chain's table for its run id.
+        tokens[56] = TokenInstance("BIRD", BIRD_RECEIPT, BIRD_RECEIPT_VAULT, BIRD_WRAPPED_TOKEN_VAULT);
     }
 
     /// @notice Returns the production token instance triples on Ethereum
@@ -2097,13 +2110,13 @@ library LibTokenInvariants {
         );
     }
 
-    /// @notice Returns the 56 production receipt vault addresses on Base, in
+    /// @notice Returns the 57 production receipt vault addresses on Base, in
     /// the order they were deployed. Provided so consumers (e.g. invariant
     /// assertions, migration scripts) can iterate without hardcoding the
     /// list inline.
     /// @dev Derived from `productionTokensBase()` so the token table is the
     /// single source of truth and the two accessors cannot drift.
-    /// @return vaults The 56 production receipt vault addresses on Base.
+    /// @return vaults The 57 production receipt vault addresses on Base.
     function productionReceiptVaults() internal pure returns (address[] memory vaults) {
         TokenInstance[] memory tokens = productionTokensBase();
         vaults = new address[](tokens.length);

--- a/src/lib/LibTokenInvariants.sol
+++ b/src/lib/LibTokenInvariants.sol
@@ -645,7 +645,7 @@ library LibTokenInvariants {
     /// @notice Returns the production token instance triples on Ethereum
     /// mainnet — Base's underlyings in Base row order, so the tables pair by
     /// index as well as by key.
-    /// @return tokens The 56 production token instances on Ethereum.
+    /// @return tokens The 57 production token instances on Ethereum.
     function productionTokensEthereum() internal pure returns (TokenInstance[] memory tokens) {
         // Deployed on Ethereum mainnet 2026-07-22 by
         // `20260706-deploy-tokens-ethereum` (manual-broadcast run
@@ -655,7 +655,7 @@ library LibTokenInvariants {
         // run's logged (underlying, receipt, receiptVault, wrapped) tuples.
         // Order and underlyings match Base row-for-row (the cross-chain
         // parity pin asserts this).
-        tokens = new TokenInstance[](56);
+        tokens = new TokenInstance[](57);
         tokens[0] = TokenInstance(
             "MSTR",
             address(0xE3772C8695c2cf3dcAA2Dd29759f4Bb91a342763),
@@ -1022,12 +1022,22 @@ library LibTokenInvariants {
             address(0xfEa217600e2b00bBB2172a99345016a0cEb7d29f),
             address(0x685DFd386968B58D895F934485820C479C79a8bB)
         );
+        // tBIRD — copied from Base 2026-09-11 15:24 UTC by `20260807-deploy-missing-tokens`
+        // on `ethereum` (manual-broadcast run 34615473964), the only token the
+        // selection found missing; wired onto this chain's V4 authoriser and
+        // handed to its token-owner Safe in the same broadcast.
+        tokens[56] = TokenInstance(
+            "BIRD",
+            address(0x34a8386fd0a943D4c1F182e9eb6b5e125509dFF2),
+            address(0x2E04C503ebd584C3c0Bb1d57E0C51E7B7EaE28E1),
+            address(0xe93A1Bb48e797dDa936f405A7A253f55040584D5)
+        );
     }
 
-    /// @notice Returns the 56 production token instance triples on HyperEVM,
+    /// @notice Returns the 57 production token instance triples on HyperEVM,
     /// in the same row order as `productionTokensBase()` (the cross-chain
     /// parity pin asserts the alignment).
-    /// @return tokens The 56 production token instances on HyperEVM.
+    /// @return tokens The 57 production token instances on HyperEVM.
     function productionTokensHyperEvm() internal pure returns (TokenInstance[] memory tokens) {
         // Deployed on HyperEVM 2026-07-24 (manual-broadcast run 30114307165):
         // all 29 tokens via the 0.1.1 unified deployer, each wired onto the
@@ -1036,7 +1046,7 @@ library LibTokenInvariants {
         // (underlying, receipt, receiptVault, wrapped) tuples. The script that
         // ran it was per-chain and has since been superseded by
         // `20260807-deploy-missing-tokens`, so this is the record of the run.
-        tokens = new TokenInstance[](56);
+        tokens = new TokenInstance[](57);
         tokens[0] = TokenInstance(
             "MSTR",
             0xE3772C8695c2cf3dcAA2Dd29759f4Bb91a342763,
@@ -1398,6 +1408,16 @@ library LibTokenInvariants {
             0xfEa217600e2b00bBB2172a99345016a0cEb7d29f,
             0x685DFd386968B58D895F934485820C479C79a8bB
         );
+        // tBIRD — copied from Base 2026-09-11 15:26 UTC by `20260807-deploy-missing-tokens`
+        // on `hyperevm` (manual-broadcast run 34615476787), the only token the
+        // selection found missing; wired onto this chain's V4 authoriser and
+        // handed to its token-owner Safe in the same broadcast.
+        tokens[56] = TokenInstance(
+            "BIRD",
+            0x34a8386fd0a943D4c1F182e9eb6b5e125509dFF2,
+            0x2E04C503ebd584C3c0Bb1d57E0C51E7B7EaE28E1,
+            0xe93A1Bb48e797dDa936f405A7A253f55040584D5
+        );
     }
 
     /// @notice Returns the production token instance triples on Robinhood
@@ -1411,9 +1431,9 @@ library LibTokenInvariants {
     /// onto this chain's V4 authoriser and handed to its token-owner Safe in
     /// the same broadcast. Addresses pinned from the run's logged
     /// (underlying, receipt, receiptVault, wrapped) tuples.
-    /// @return tokens The 56 production token instances on Robinhood Chain.
+    /// @return tokens The 57 production token instances on Robinhood Chain.
     function productionTokensRobinhood() internal pure returns (TokenInstance[] memory tokens) {
-        tokens = new TokenInstance[](56);
+        tokens = new TokenInstance[](57);
         tokens[0] = TokenInstance(
             "MSTR",
             0xE3772C8695c2cf3dcAA2Dd29759f4Bb91a342763,
@@ -1753,6 +1773,16 @@ library LibTokenInvariants {
             0xfEa217600e2b00bBB2172a99345016a0cEb7d29f,
             0x685DFd386968B58D895F934485820C479C79a8bB
         );
+        // tBIRD — copied from Base 2026-09-11 15:24 UTC by `20260807-deploy-missing-tokens`
+        // on `robinhood` (manual-broadcast run 34615482230), the only token the
+        // selection found missing; wired onto this chain's V4 authoriser and
+        // handed to its token-owner Safe in the same broadcast.
+        tokens[56] = TokenInstance(
+            "BIRD",
+            0x34a8386fd0a943D4c1F182e9eb6b5e125509dFF2,
+            0x2E04C503ebd584C3c0Bb1d57E0C51E7B7EaE28E1,
+            0xe93A1Bb48e797dDa936f405A7A253f55040584D5
+        );
     }
 
     /// @notice Returns the production token instance triples on BNB Smart
@@ -1766,9 +1796,9 @@ library LibTokenInvariants {
     /// onto this chain's V4 authoriser and handed to its token-owner Safe in
     /// the same broadcast. Addresses pinned from the run's logged
     /// (underlying, receipt, receiptVault, wrapped) tuples.
-    /// @return tokens The 56 production token instances on BNB Smart Chain.
+    /// @return tokens The 57 production token instances on BNB Smart Chain.
     function productionTokensBsc() internal pure returns (TokenInstance[] memory tokens) {
-        tokens = new TokenInstance[](56);
+        tokens = new TokenInstance[](57);
         tokens[0] = TokenInstance(
             "MSTR",
             0x8Ea1ba9Fc0CF7338B41DdDa5B778a9118274AEA8,
@@ -2107,6 +2137,16 @@ library LibTokenInvariants {
             0xE05a93a2d1D0E8bA13F2bC0D1017Cb0D93308F4e,
             0x042Dfd33De6766a8858f188DFcf207D311da6488,
             0x5A5c3b64907823b1c5ea9d75D5AF44dFD06b03ea
+        );
+        // tBIRD — copied from Base 2026-09-11 15:24 UTC by `20260807-deploy-missing-tokens`
+        // on `bsc` (manual-broadcast run 34615479611), the only token the
+        // selection found missing; wired onto this chain's V4 authoriser and
+        // handed to its token-owner Safe in the same broadcast.
+        tokens[56] = TokenInstance(
+            "BIRD",
+            0x6cFDdBddbCe10Cda74329F5B85FAa01d9d8081F8,
+            0x21a53882B0023c1F4D98087564e91ae6CEA0b4Ec,
+            0x9253907626f6FB9685c58e1C2cB2bF0AE6337A40
         );
     }
 

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
@@ -59,13 +59,13 @@ contract UpgradeFleetTest is Test {
         vm.chainId(LibSafeInvariants.BASE_CHAIN_ID);
         assertEq(harness.callActiveChainTokens().length, 57, "Base table");
         vm.chainId(LibSafeInvariants.ETHEREUM_CHAIN_ID);
-        assertEq(harness.callActiveChainTokens().length, 56, "Ethereum table");
+        assertEq(harness.callActiveChainTokens().length, 57, "Ethereum table");
         vm.chainId(LibSafeInvariants.HYPEREVM_CHAIN_ID);
-        assertEq(harness.callActiveChainTokens().length, 56, "HyperEVM table");
+        assertEq(harness.callActiveChainTokens().length, 57, "HyperEVM table");
         vm.chainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID);
-        assertEq(harness.callActiveChainTokens().length, 56, "Robinhood Chain table");
+        assertEq(harness.callActiveChainTokens().length, 57, "Robinhood Chain table");
         vm.chainId(LibSafeInvariants.BSC_CHAIN_ID);
-        assertEq(harness.callActiveChainTokens().length, 56, "BNB Smart Chain table");
+        assertEq(harness.callActiveChainTokens().length, 57, "BNB Smart Chain table");
     }
 
     /// A chain with no table is refused rather than handed another chain's

--- a/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
+++ b/test/script/20260825-upgrade-fleet-to-0-1-30.t.sol
@@ -57,7 +57,7 @@ contract UpgradeFleetTest is Test {
     /// a valid (empty) snapshot rather than a wrong-network dispatch.
     function testActiveChainTokensResolvesPerChain() external {
         vm.chainId(LibSafeInvariants.BASE_CHAIN_ID);
-        assertEq(harness.callActiveChainTokens().length, 56, "Base table");
+        assertEq(harness.callActiveChainTokens().length, 57, "Base table");
         vm.chainId(LibSafeInvariants.ETHEREUM_CHAIN_ID);
         assertEq(harness.callActiveChainTokens().length, 56, "Ethereum table");
         vm.chainId(LibSafeInvariants.HYPEREVM_CHAIN_ID);

--- a/test/src/lib/LibProdTokenConfig.t.sol
+++ b/test/src/lib/LibProdTokenConfig.t.sol
@@ -18,14 +18,35 @@ import {LibTokenInvariants, TokenInstance} from "../../../src/lib/LibTokenInvari
 /// the parity pin asserts every chain against this table, and this test
 /// asserts the table against live Base.
 contract LibProdTokenConfigTest is Test {
-    /// The config table and the Base address table pair by index: same
-    /// length, same `underlying` in the same order.
+    /// The config table and the Base address table pair by index over every
+    /// row Base carries: same `underlying` in the same order. The config table
+    /// may run AHEAD of Base — a row is authored when a ticker is chosen and
+    /// Base is pinned when its deploy lands, and `_selectMissing` reads only
+    /// the rows Base carries — but a config table SHORTER than Base would
+    /// leave a deployed token with no name/symbol to copy, so that is the
+    /// failure.
     function testConfigAlignsWithBaseTokenTable() external pure {
         TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
         TokenInstance[] memory tokens = LibTokenInvariants.productionTokensBase();
-        assertEq(configs.length, tokens.length, "config/table length mismatch");
-        for (uint256 i = 0; i < configs.length; i++) {
+        assertGe(configs.length, tokens.length, "config table shorter than Base table");
+        for (uint256 i = 0; i < tokens.length; i++) {
             assertEq(configs[i].underlying, tokens[i].underlying, "underlying order/key mismatch");
+        }
+    }
+
+    /// No `underlying` appears twice in the config table — guards the
+    /// ahead-of-Base window, where a ticker authored early could be appended
+    /// a second time when its Base deploy is pinned.
+    function testConfigHasNoDuplicateUnderlyings() external pure {
+        TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
+        for (uint256 i = 0; i < configs.length; i++) {
+            for (uint256 j = i + 1; j < configs.length; j++) {
+                assertNotEq(
+                    keccak256(bytes(configs[i].underlying)),
+                    keccak256(bytes(configs[j].underlying)),
+                    string.concat("duplicate config underlying: ", configs[i].underlying)
+                );
+            }
         }
     }
 
@@ -36,7 +57,7 @@ contract LibProdTokenConfigTest is Test {
         vm.createSelectFork(LibRainDeploy.BASE);
         TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
         TokenInstance[] memory tokens = LibTokenInvariants.productionTokensBase();
-        for (uint256 i = 0; i < configs.length; i++) {
+        for (uint256 i = 0; i < tokens.length; i++) {
             IERC20Metadata vault = IERC20Metadata(tokens[i].receiptVault);
             assertEq(
                 configs[i].name, vault.name(), string.concat(configs[i].underlying, ": config name != live Base name")
@@ -58,7 +79,7 @@ contract LibProdTokenConfigTest is Test {
         vm.createSelectFork(LibRainDeploy.BASE);
         TokenConfig[] memory configs = LibProdTokenConfig.productionTokenConfigs();
         TokenInstance[] memory tokens = LibTokenInvariants.productionTokensBase();
-        for (uint256 i = 0; i < configs.length; i++) {
+        for (uint256 i = 0; i < tokens.length; i++) {
             IERC20Metadata wrapped = IERC20Metadata(tokens[i].wrappedTokenVault);
             assertEq(
                 wrapped.name(),


### PR DESCRIPTION
Pins `tBIRD` (Smartbird, Inc. ST0x — the former Allbirds, Inc.) as Base row 56 and copies it onto the four other chains with `20260807-deploy-missing-tokens`, taking every table from 56 to 57 rows.

## Base pin (commit 1)

Deployed on Base by sft-ops CD [run 34614696472](https://github.com/ST0x-Technology/sft-ops/actions/runs/34614696472), 2026-09-11 15:14 UTC. Re-verified live with `cast` before pinning: vault `symbol()` tBIRD, `name()` "Smartbird, Inc. ST0x", 18 dec, `receipt()` == receipt, `owner()` == `0xe70d…d611` (Base token-owner Safe), `authorizer()` == `0x315b…f0cD` (V4 clone), certification live; wrapper `symbol()` wtBIRD, `asset()` == vault; receipt `manager()` == vault.

- `LibProdTokenConfig`: 56 → 57, `configs[56] = TokenConfig("BIRD", "Smartbird, Inc. ST0x", "tBIRD")`.
- `LibTokenInvariants`: `BIRD_RECEIPT` / `BIRD_RECEIPT_VAULT` / `BIRD_WRAPPED_TOKEN_VAULT` constants and `tokens[56]` in `productionTokensBase()`.
- `LibProdTokenConfigTest`: alignment is now `configs.length >= base.length` over Base's rows (the rollout the script documents — config leads Base), plus `testConfigHasNoDuplicateUnderlyings`.

## Copy (commit 2)

Commit 1 deliberately left the four non-Base tables at 56 rows without BIRD, so each `manual-broadcast` dispatch from this branch's ref (`--ref 2026-09-11-pin-bird`) pre-flighted `Copying 1 Base tokens` and deployed exactly BIRD. Each row below is read from its own run log, then re-verified live on its chain (`symbol()` tBIRD / wtBIRD, `receipt()` / `asset()` / `manager()` cross-consistent, `owner()` == `0x3840aeDaEc8e82f79d8F6a8F6ADCa271E13E0329`, `authorizer()` == `0x66566cc91dEAf818859bD4b09B7903ac48998157`, 18 dec).

| chain | receipt (ERC-1155) | receiptVault (tBIRD) | wrapper (wtBIRD) | run |
|---|---|---|---|---|
| Base (8453) | `0x5ae4611fD6944613E2947A44fd76ad4B48551F6A` | `0x22E99389f5ef6FA110317e2Aec0a95d8AA39eFD4` | `0x95d46fC0faf4141C508D037469F472366093415a` | sft-ops [34614696472](https://github.com/ST0x-Technology/sft-ops/actions/runs/34614696472) |
| Ethereum (1) | `0x34a8386fd0a943D4c1F182e9eb6b5e125509dFF2` | `0x2E04C503ebd584C3c0Bb1d57E0C51E7B7EaE28E1` | `0xe93A1Bb48e797dDa936f405A7A253f55040584D5` | [34615473964](https://github.com/S01-Issuer/st0x.deploy/actions/runs/34615473964) |
| HyperEVM (999) | `0x34a8386fd0a943D4c1F182e9eb6b5e125509dFF2` | `0x2E04C503ebd584C3c0Bb1d57E0C51E7B7EaE28E1` | `0xe93A1Bb48e797dDa936f405A7A253f55040584D5` | [34615476787](https://github.com/S01-Issuer/st0x.deploy/actions/runs/34615476787) |
| BSC (56) | `0x6cFDdBddbCe10Cda74329F5B85FAa01d9d8081F8` | `0x21a53882B0023c1F4D98087564e91ae6CEA0b4Ec` | `0x9253907626f6FB9685c58e1C2cB2bF0AE6337A40` | [34615479611](https://github.com/S01-Issuer/st0x.deploy/actions/runs/34615479611) (`rpc_throttle`) |
| Robinhood (4663) | `0x34a8386fd0a943D4c1F182e9eb6b5e125509dFF2` | `0x2E04C503ebd584C3c0Bb1d57E0C51E7B7EaE28E1` | `0xe93A1Bb48e797dDa936f405A7A253f55040584D5` | [34615482230](https://github.com/S01-Issuer/st0x.deploy/actions/runs/34615482230) |

Ethereum, HyperEVM and Robinhood share one triple because the deploy key's nonce was in lockstep on all three (as it already is for those tables' rows 41–55); BSC's differs for the reason recorded on `productionTokensBsc()`. Every row was verified on its own chain, not by analogy.

Transactions per chain (deploy via unified deployer `0x81d0…4bcc` → `setAuthorizer` → `transferOwnership`):

| chain | deploy | setAuthorizer | transferOwnership |
|---|---|---|---|
| Ethereum | `0xd590040e16dbc5d213666a5a60c7aa0d2226ba3f7ddf0ff1f3efeafa1ba58fc5` | `0x012fff81aac86aa5aa3aedf637f3ae80db1a1421a55e5725fdaea8e24a634535` | `0xe2715b6abaf0b8def5883f50eeeaeef45b6ae23aa94e8b01bb0953f3748f5057` |
| HyperEVM | `0x1a7b79c3184528333e50109f16cc92b4d88c9fc15f7f1c3bf686ce21c70e578d` | `0xceb6213c3287738bf385aec0ae4b14800f73ea55a1dc15939e96682ff8b6b9a9` | `0x6d238e738ff93114dc77a21dc88f397e34b9a243782c2b470680654fd1ce3cc8` |
| BSC | `0x7c434e4d61944ff3cf986dc1c71214ea3d42b74e085e71f59fbe2606f9ea7762` | `0xd31c6c5643bf48925ca3ce668b25d2d30339b271c75a9bb60464de782073b96b` | `0xc11fc0376545e9e25fa96c0ec6c5a1860cabe879e45fbffa6661d2c1814abef4` |
| Robinhood | `0xeb90573de08be584b14069dc2aeeaa50ce942b581d78ed8176c072adf8ea766d` | `0xf11f02febf062fd08cb1475d9765d7a9153890294a6beeabefdf638d21354d40` | `0x8bbe7d2ce08ff691eddfafe15a508e697d580509906c5ccfcc8b3cf96b55dad1` |

## Checks

- `rainix-sol` on commit 1 failed on exactly the five documented copy-window tests (`test{Ethereum,HyperEvm,Robinhood,Bsc}TokenTableMirrorsBaseUnderlyings` `56 != 57` and `testCrossChainParity` "token table lengths diverge (Ethereum): 57 != 56"); 1006/1011 otherwise passed. Commit 2 closes the window.
- Local on commit 2, live forks via public RPCs: `StoxCrossChainParity` `testCrossChainParity` PASS, all four `*TokenOwnerSafeParity` PASS, `UpgradeFleetProdTest` 3/3, `LibProdTokenConfigTest` 4/4 (two on a Base fork), `LibTokenInvariantsTest` 7/7, `DeployMissingTokensTest` 26/26, `UpgradeFleetTest` 9/9.
- `forge fmt --check` clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDVXNvDqgej1B2dYU7pmMA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the BIRD token from Smartbird, Inc.
  - BIRD is now available across Base, Ethereum, HyperEVM, Robinhood Chain, and BNB Smart Chain.
  - Production token listings now include 57 supported tokens.

- **Bug Fixes**
  - Improved validation to prevent duplicate token underlying assets and keep token configurations aligned across supported networks.

- **Tests**
  - Updated coverage to verify BIRD resolution and the expanded production token tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->