### PR TITLE
Hold Robinhood and BSC to the direct-signer retirement deadline

### DIFF
--- a/test/script/20260831-retire-direct-signer-roles.prod.t.sol
+++ b/test/script/20260831-retire-direct-signer-roles.prod.t.sol
@@ -42,7 +42,9 @@ contract RetireDirectSignerRolesProdTest is Test {
     /// @notice Walk the active fork's retirement state (see the contract
     /// NatSpec) and assert it.
     /// @param label Human chain name, surfaced in logs and messages.
-    function assertRetireRollout(string memory label) internal {
+    /// @param chainId The chain the leg must be forked on.
+    function assertRetireRollout(string memory label, uint256 chainId) internal {
+        assertEq(block.chainid, chainId, string.concat(label, ": fork"));
         RetireDirectSignerRolesHarness script = new RetireDirectSignerRolesHarness();
         address orchestrator = LibOrchestratorInvariants.ST0X_ORCHESTRATOR_INSTANCE;
         address signer = LibAuthoriserInvariants.GRANTEE_SERVICE_3D0C;
@@ -116,40 +118,40 @@ contract RetireDirectSignerRolesProdTest is Test {
 
     function testRetireRolloutBase() external {
         vm.createSelectFork(LibRainDeploy.BASE);
-        assertRetireRollout("base");
+        assertRetireRollout("base", LibSafeInvariants.BASE_CHAIN_ID);
     }
 
     function testRetireRolloutEthereum() external {
         vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
-        assertRetireRollout("ethereum");
+        assertRetireRollout("ethereum", LibSafeInvariants.ETHEREUM_CHAIN_ID);
     }
 
     function testRetireRolloutHyperEvm() external {
         vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
-        assertRetireRollout("hyperevm");
+        assertRetireRollout("hyperevm", LibSafeInvariants.HYPEREVM_CHAIN_ID);
     }
 
     function testRetireRolloutRobinhood() external {
         vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
-        assertRetireRollout("robinhood");
+        assertRetireRollout("robinhood", LibSafeInvariants.ROBINHOOD_CHAIN_ID);
     }
 
     function testRetireRolloutBsc() external {
         vm.createSelectFork(LibStoxDeployNetworks.BSC);
-        assertRetireRollout("bsc");
+        assertRetireRollout("bsc", LibSafeInvariants.BSC_CHAIN_ID);
     }
 
-    /// @notice A chain still without its orchestrator is overdue at the
-    /// deadline like any other pending chain.
-    function testRetireRolloutOverdueWithoutAnOrchestrator() external {
+    /// @notice A new chain still in burn-in is overdue at the deadline like
+    /// any other.
+    function testRetireRolloutOverdueOnANewChain() external {
         vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
         vm.warp(RETIRE_DEADLINE);
         vm.expectRevert(abi.encodeWithSelector(RetirementOverdue.selector, "robinhood"));
-        this.externalAssertRetireRollout("robinhood");
+        this.externalAssertRetireRollout("robinhood", LibSafeInvariants.ROBINHOOD_CHAIN_ID);
     }
 
     /// @notice External shim so `vm.expectRevert` can see the helper's revert.
-    function externalAssertRetireRollout(string memory label) external {
-        assertRetireRollout(label);
+    function externalAssertRetireRollout(string memory label, uint256 chainId) external {
+        assertRetireRollout(label, chainId);
     }
 }

--- a/test/script/20260831-retire-direct-signer-roles.prod.t.sol
+++ b/test/script/20260831-retire-direct-signer-roles.prod.t.sol
@@ -128,4 +128,28 @@ contract RetireDirectSignerRolesProdTest is Test {
         vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
         assertRetireRollout("hyperevm");
     }
+
+    function testRetireRolloutRobinhood() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
+        assertRetireRollout("robinhood");
+    }
+
+    function testRetireRolloutBsc() external {
+        vm.createSelectFork(LibStoxDeployNetworks.BSC);
+        assertRetireRollout("bsc");
+    }
+
+    /// @notice A chain still without its orchestrator is overdue at the
+    /// deadline like any other pending chain.
+    function testRetireRolloutOverdueWithoutAnOrchestrator() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
+        vm.warp(RETIRE_DEADLINE);
+        vm.expectRevert(abi.encodeWithSelector(RetirementOverdue.selector, "robinhood"));
+        this.externalAssertRetireRollout("robinhood");
+    }
+
+    /// @notice External shim so `vm.expectRevert` can see the helper's revert.
+    function externalAssertRetireRollout(string memory label) external {
+        assertRetireRollout(label);
+    }
 }


### PR DESCRIPTION
From the #344 review. `RetireDirectSignerRolesProdTest` walked Base, Ethereum and HyperEVM only, so the 2026-10-15 `RETIRE_DEADLINE` could never fire on the two clones #344 pinned: the direct signer's DEPOSIT/WITHDRAW rows sit on Robinhood and BSC with no forcing function.

## What changes
- `testRetireRolloutRobinhood` and `testRetireRolloutBsc` walk the same states as the other three legs. Both are in burn-in today (orchestrator live, path enabled, direct roles still held), so both drive `run()` end to end and go `RetirementOverdue` at the deadline.
- `testRetireRolloutOverdueOnANewChain` warps a Robinhood fork to `RETIRE_DEADLINE` and expects `RetirementOverdue("robinhood")`.
- `assertRetireRollout` takes the expected chain id and asserts the fork, so a leg forking the wrong alias fails instead of passing on a sibling chain's identical state.

## QA
- Discriminating tests: `testRetireRolloutRobinhood`, `testRetireRolloutBsc`, `testRetireRolloutOverdueOnANewChain` (fail on base: they do not exist there, and the helper had no chain-id parameter).
- Mutations applied (live forks):
  - delete the `RETIRE_DEADLINE` check in the burn-in branch -> killed by `testRetireRolloutOverdueOnANewChain`
  - `testRetireRolloutRobinhood` forks `BSC` instead of `ROBINHOOD` -> killed by the helper's chain assert (`robinhood: fork: 56 != 4663`); survived before the assert was added
- Oracle: live chain state (the orchestrator at `0x3A7387a4…` has code and holds the vault roles on 4663 and 56; the signer still holds direct DEPOSIT/WITHDRAW), and `RETIRE_DEADLINE` from the retire script.
- Category check: the finding asked that the retirement deadline be enforced on Robinhood and BSC; covered. The enable prod test named in the same finding has no deadline, so it is unchanged.

## Checks
Local, live forks: suite 6/6 (one run saw a transient `invalid block height` from the public HyperEVM RPC; that leg is unchanged and passed on the other runs). `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8ViHcKLVk2YoS2joH4HdN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded retirement rollout coverage across supported chains by validating each fork’s expected chain ID.
  * Added coverage for overdue retirement behavior on a newly supported chain.
  * Improved failure messages to identify the affected chain when assertions fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->