### PR TITLE
test: the hydrated clone pin guard refuses a re-dispatch

### DIFF
--- a/test/script/20260619-deploy-v4-authoriser-clone.t.sol
+++ b/test/script/20260619-deploy-v4-authoriser-clone.t.sol
@@ -22,7 +22,8 @@ import {
     CloneFactoryCodehashMismatch,
     DeployerStillHoldsAdminRole,
     ExpectedGrantMissing,
-    CloneCodehashMismatch
+    CloneCodehashMismatch,
+    V4AuthoriserClonePinAlreadyHydrated
 } from "../../script/20260619-deploy-v4-authoriser-clone.s.sol";
 import {LibAuthoriserInvariants, RoleGrant} from "../../src/lib/LibAuthoriserInvariants.sol";
 import {LibProdDeployV4} from "../../src/generated/LibProdDeployV4.sol";
@@ -162,6 +163,21 @@ contract DeployV4AuthoriserCloneTest is Test {
         bytes32 expected = LibProdDeployV4.STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_CODEHASH_0_1_1;
         bytes32 actual = keccak256(bogusCode);
         vm.expectRevert(abi.encodeWithSelector(V4ImplCodehashMismatch.selector, v4Impl, expected, actual));
+        vm.prank(deployer, deployer);
+        script.run();
+    }
+
+    /// @notice Pre-flight refuses a chain whose clone pin is already
+    /// hydrated: a re-dispatch would mint a second clone the lib does not
+    /// know about. Every chain's pin is hydrated today, so this guard is
+    /// what stands between the dropdown and a stray clone.
+    function testRunRejectsHydratedClonePin() external {
+        selectBaseFork();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                V4AuthoriserClonePinAlreadyHydrated.selector, LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE
+            )
+        );
         vm.prank(deployer, deployer);
         script.run();
     }


### PR DESCRIPTION
From the #344 review. With every chain's V4 authoriser clone pin hydrated, `V4AuthoriserClonePinAlreadyHydrated` is the only pre-flight between a manual-broadcast re-dispatch of `20260619-deploy-v4-authoriser-clone` and a second, unpinned clone. No test exercised it: the four `run()` tests revert earlier and nothing imported the error.

## What changes
- `testRunRejectsHydratedClonePin`: Base fork, `run()` reverts `V4AuthoriserClonePinAlreadyHydrated(STOX_PROD_AUTHORISER_V4_CLONE)`. The guard sits before `vm.startBroadcast`, so no harness change.

## QA
- Discriminating tests: `testRunRejectsHydratedClonePin` (fails on base: the test does not exist; the error was not imported into the test file).
- Mutations applied (Base fork):
  - guard inverted to `pinned == address(0)` -> killed (run() proceeds to `vm.startBroadcast` under the prank instead of reverting)
  - Base arm of `activeChainClonePin` returns `address(0)` -> killed, same signal
- Oracle: `LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE`, the pin the script must refuse to re-deploy, and the script's own error selector.
- Category check: the finding asked for coverage of the hydrated-pin guard; covered. The stale "address(0) until hydrated" NatSpec it also mentioned is left for the doc cleanup finding.

## Checks
Local, Base fork: suite 13/13. `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8ViHcKLVk2YoS2joH4HdN