### PR TITLE
test: activeChainAuthoriser's not-ready and unsupported-chain reverts

### DIFF
--- a/test/src/lib/LibAuthoriserInvariants.t.sol
+++ b/test/src/lib/LibAuthoriserInvariants.t.sol
@@ -7,6 +7,8 @@ import {IAccessControl} from "@openzeppelin-contracts-5.6.1/access/IAccessContro
 import {
     LibAuthoriserInvariants,
     RoleGrant,
+    AuthoriserNotReady,
+    UnsupportedChainForAuthoriser,
     ExpectedGrantMissing,
     UnexpectedDefaultAdmin,
     UnexpectedRetainedAdminGrant,
@@ -52,6 +54,38 @@ contract LibAuthoriserInvariantsTest is Test {
     /// (orchestrator rows included, pointing at the not-yet-deployed
     /// instance pin). Live drift detector on an unpinned fork, same
     /// precedent as `testAssertAllPasses`.
+    /// @notice A governed chain whose pin has no code here (no fork) is
+    /// refused as not ready rather than returned; the pin alone is not
+    /// enough.
+    function testActiveChainAuthoriserRefusesAPinWithoutCode() external {
+        vm.chainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID);
+        LibAuthoriserInvariantsHarness harness = new LibAuthoriserInvariantsHarness();
+        vm.expectRevert(
+            abi.encodeWithSelector(AuthoriserNotReady.selector, LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD)
+        );
+        harness.callActiveChainAuthoriser();
+    }
+
+    /// @notice A pin carrying bytecode other than the EIP-1167 clone is
+    /// refused: address and code presence are not enough either.
+    function testActiveChainAuthoriserRefusesForeignCode() external {
+        vm.chainId(LibSafeInvariants.BSC_CHAIN_ID);
+        address pin = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC;
+        vm.etch(pin, hex"FE");
+        LibAuthoriserInvariantsHarness harness = new LibAuthoriserInvariantsHarness();
+        vm.expectRevert(abi.encodeWithSelector(AuthoriserNotReady.selector, pin));
+        harness.callActiveChainAuthoriser();
+    }
+
+    /// @notice An unpinned chain reverts typed rather than resolving to
+    /// another chain's clone.
+    function testActiveChainAuthoriserRefusesAnUnknownChain() external {
+        vm.chainId(123456);
+        LibAuthoriserInvariantsHarness harness = new LibAuthoriserInvariantsHarness();
+        vm.expectRevert(abi.encodeWithSelector(UnsupportedChainForAuthoriser.selector, uint256(123456)));
+        harness.callActiveChainAuthoriser();
+    }
+
     function testRobinhoodAuthoriserIsLiveOnTheCanonicalMap() external {
         vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
         LibAuthoriserInvariantsHarness harness = new LibAuthoriserInvariantsHarness();


### PR DESCRIPTION
From the #344 review. Neither revert branch of `LibAuthoriserInvariants.activeChainAuthoriser` was tested: the fork tests all run where the pin is hydrated and correct, and #344's final commit dropped the fork-free tests its message still claims.

## What changes
Three fork-free tests in `LibAuthoriserInvariantsTest`:
- a governed chain id with no code at its pin -> `AuthoriserNotReady(pin)`
- foreign bytecode etched at the pin -> `AuthoriserNotReady(pin)`
- an unpinned chain id -> `UnsupportedChainForAuthoriser(chainId)`

## QA
- Discriminating tests: `testActiveChainAuthoriserRefusesAPinWithoutCode`, `testActiveChainAuthoriserRefusesForeignCode`, `testActiveChainAuthoriserRefusesAnUnknownChain` (fail on base: absent, and the two errors were not imported into the test file).
- Mutations applied:
  - drop the codehash clause -> killed by `testActiveChainAuthoriserRefusesForeignCode`
  - replace the unsupported-chain revert with a fallback to Base's clone -> killed by `testActiveChainAuthoriserRefusesAnUnknownChain`
  - drop the `code.length == 0` clause -> survives, equivalent: an account with no code never hashes to the clone codehash, so the codehash clause subsumes it. Left in place; removing it is a lib change outside this PR.
- Oracle: the lib's own error selectors; pins from `LibProdDeployV4`; chain ids from `LibSafeInvariants`.
- Category check: the finding asked for both revert branches to be covered fork-free; covered.

## Checks
Local: suite 13/13 (fork legs on Base, Robinhood, BSC public RPCs). `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8ViHcKLVk2YoS2joH4HdN