### PR TITLE
One chain-to-clone table: authoriserForChainId in LibAuthoriserInvariants

### DIFF
--- a/script/20260619-deploy-v4-authoriser-clone.s.sol
+++ b/script/20260619-deploy-v4-authoriser-clone.s.sol
@@ -42,12 +42,6 @@ error CloneFactoryCodehashMismatch(address factory, bytes32 expected, bytes32 ac
 /// script is done for that chain.
 error V4AuthoriserClonePinAlreadyHydrated(address pinned);
 
-/// @notice This chain has no V4 authoriser clone pin in `LibProdDeployV4`, so
-/// the script has no per-chain target to guard against. A typed revert rather
-/// than a silent fallback to another chain's clone.
-/// @param chainId The active chain id with no defined clone pin.
-error V4AuthoriserCloneUnsupportedChain(uint256 chainId);
-
 /// @notice The freshly-deployed clone's runtime codehash does not match the
 /// EIP-1167 minimal-proxy shape computed from the V4 impl. Either the factory
 /// deployed something other than an EIP-1167 clone, or the impl embedded in
@@ -139,31 +133,6 @@ contract DeployV4AuthoriserClone is Script {
     /// corporate-action admins from the override).
     uint256 internal constant AUTO_GRANTED_ADMIN_COUNT = 7;
 
-    /// @notice The V4 authoriser clone pin for the active chain, selected by
-    /// `block.chainid` from `LibProdDeployV4` — `address(0)` until that chain's
-    /// clone is deployed and the pin hydrated. Reverts for any chain without a
-    /// pin rather than falling back to another chain's clone (reading the wrong
-    /// chain's clone is the catastrophic failure this guard exists to prevent).
-    /// @return The active chain's clone pin.
-    function activeChainClonePin() internal view returns (address) {
-        if (block.chainid == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
-            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
-        }
-        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
-            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
-        }
-        if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
-            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
-        }
-        if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
-            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD;
-        }
-        if (block.chainid == LibSafeInvariants.BSC_CHAIN_ID) {
-            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC;
-        }
-        revert V4AuthoriserCloneUnsupportedChain(block.chainid);
-    }
-
     /// @notice Deploy + configure + admin-transfer the V4 authoriser clone
     /// in a single broadcast. Steps 1-4 in the contract-level NatSpec.
     /// Pre-flight covers the invariants the whole flow relies on: the
@@ -203,7 +172,7 @@ contract DeployV4AuthoriserClone is Script {
         // running this script would deploy a SECOND clone the lib
         // doesn't know about — same behaviour as re-running any
         // deterministic deploy after it has already landed.
-        address pinned = activeChainClonePin();
+        address pinned = LibAuthoriserInvariants.authoriserForChainId(block.chainid);
         if (pinned != address(0)) revert V4AuthoriserClonePinAlreadyHydrated(pinned);
 
         // The grant map parameterised on THIS chain's Safe: the map's

--- a/src/lib/LibAuthoriserInvariants.sol
+++ b/src/lib/LibAuthoriserInvariants.sol
@@ -81,23 +81,36 @@ error AuthoriserNotReady(address authoriser);
 /// and `LibTokenInvariants`; individually callable via `assertAll()` for
 /// the focused authoriser drift detector.
 library LibAuthoriserInvariants {
+    /// @notice A chain's V4 authoriser clone pin, raw: `address(0)` while the
+    /// slot is a placeholder. Reverts for a chain without a slot rather than
+    /// falling back to another chain's clone. The one chain-to-clone table;
+    /// the deploy script and every invariant read it.
+    /// @param chainId The chain id.
+    /// @return The pinned clone, or zero for a placeholder slot.
+    function authoriserForChainId(uint256 chainId) internal pure returns (address) {
+        if (chainId == LibSafeInvariants.BASE_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
+        }
+        if (chainId == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
+        }
+        if (chainId == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
+        }
+        if (chainId == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD;
+        }
+        if (chainId == LibSafeInvariants.BSC_CHAIN_ID) {
+            return LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC;
+        }
+        revert UnsupportedChainForAuthoriser(chainId);
+    }
+
     /// @notice The active chain's hydrated V4 authoriser clone, asserted
     /// deployed with the shared EIP-1167 codehash.
     /// @return authoriser The validated authoriser address.
     function activeChainAuthoriser() internal view returns (address authoriser) {
-        if (block.chainid == LibSafeInvariants.BASE_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE;
-        } else if (block.chainid == LibSafeInvariants.ETHEREUM_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM;
-        } else if (block.chainid == LibSafeInvariants.HYPEREVM_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM;
-        } else if (block.chainid == LibSafeInvariants.ROBINHOOD_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD;
-        } else if (block.chainid == LibSafeInvariants.BSC_CHAIN_ID) {
-            authoriser = LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC;
-        } else {
-            revert UnsupportedChainForAuthoriser(block.chainid);
-        }
+        authoriser = authoriserForChainId(block.chainid);
         if (
             authoriser == address(0) || authoriser.code.length == 0
                 || authoriser.codehash != LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_CODEHASH

--- a/test/src/lib/LibAuthoriserInvariants.t.sol
+++ b/test/src/lib/LibAuthoriserInvariants.t.sol
@@ -54,6 +54,39 @@ contract LibAuthoriserInvariantsTest is Test {
     /// (orchestrator rows included, pointing at the not-yet-deployed
     /// instance pin). Live drift detector on an unpinned fork, same
     /// precedent as `testAssertAllPasses`.
+    /// @notice The one chain-to-clone table resolves every pinned chain to
+    /// its slot and refuses the rest, fork-free.
+    function testAuthoriserForChainIdResolvesEveryPinnedChain() external {
+        assertEq(
+            LibAuthoriserInvariants.authoriserForChainId(LibSafeInvariants.BASE_CHAIN_ID),
+            LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE,
+            "base"
+        );
+        assertEq(
+            LibAuthoriserInvariants.authoriserForChainId(LibSafeInvariants.ETHEREUM_CHAIN_ID),
+            LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM,
+            "ethereum"
+        );
+        assertEq(
+            LibAuthoriserInvariants.authoriserForChainId(LibSafeInvariants.HYPEREVM_CHAIN_ID),
+            LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM,
+            "hyperevm"
+        );
+        assertEq(
+            LibAuthoriserInvariants.authoriserForChainId(LibSafeInvariants.ROBINHOOD_CHAIN_ID),
+            LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD,
+            "robinhood"
+        );
+        assertEq(
+            LibAuthoriserInvariants.authoriserForChainId(LibSafeInvariants.BSC_CHAIN_ID),
+            LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC,
+            "bsc"
+        );
+        LibAuthoriserInvariantsHarness harness = new LibAuthoriserInvariantsHarness();
+        vm.expectRevert(abi.encodeWithSelector(UnsupportedChainForAuthoriser.selector, uint256(123456)));
+        harness.callAuthoriserForChainId(123456);
+    }
+
     /// @notice A governed chain whose pin has no code here (no fork) is
     /// refused as not ready rather than returned; the pin alone is not
     /// enough.

--- a/test/src/lib/LibAuthoriserInvariantsHarness.sol
+++ b/test/src/lib/LibAuthoriserInvariantsHarness.sol
@@ -13,6 +13,10 @@ contract LibAuthoriserInvariantsHarness {
         LibAuthoriserInvariants.assertAll();
     }
 
+    function callAuthoriserForChainId(uint256 chainId) external pure returns (address) {
+        return LibAuthoriserInvariants.authoriserForChainId(chainId);
+    }
+
     function callActiveChainAuthoriser() external view returns (address) {
         return LibAuthoriserInvariants.activeChainAuthoriser();
     }


### PR DESCRIPTION
From the #344 review. `20260619-deploy-v4-authoriser-clone` kept its own chain-id -> clone-pin switch (`activeChainClonePin`, private error) parallel to `LibAuthoriserInvariants.activeChainAuthoriser`. #344 extended both in lockstep with different arm order and a different error, and the script's arms had no test. The next chain could land in one table and not the other.

## What changes
- `LibAuthoriserInvariants.authoriserForChainId(uint256)`: pure, returns the raw pin per chain id (zero for a placeholder slot), reverts `UnsupportedChainForAuthoriser` otherwise. Mirrors `safeForChainId` / `timelockForChainId`.
- `activeChainAuthoriser()` is that lookup plus the existing readiness guard.
- The deploy script reads the lib for its hydrated-pin guard; its private switch and `V4AuthoriserCloneUnsupportedChain` are deleted.
- `testAuthoriserForChainIdResolvesEveryPinnedChain`: every pinned chain resolves to its slot, an unknown chain reverts. Harness gains `callAuthoriserForChainId`.

## QA
- Discriminating tests: `testAuthoriserForChainIdResolvesEveryPinnedChain` (fails on base: the function does not exist). Existing `testRunRejectsHydratedClonePin` now exercises the script through the lib.
- Mutations applied:
  - unknown chain returns Base's clone instead of reverting -> killed by `testAuthoriserForChainIdResolvesEveryPinnedChain` and `testActiveChainAuthoriserRefusesAnUnknownChain`
  - Robinhood arm returns the BSC slot -> survives, equivalent today: both slots hold the same literal (`0x66566cc9…`). Discriminating the day a chain's clone lands elsewhere.
- Oracle: the `LibProdDeployV4` slot constants and `LibSafeInvariants` chain ids; the lib's error selector.
- Category check: the finding asked for one lookup the script and every invariant call, the script's switch and private error removed; covered.

## Checks
Local: `LibAuthoriserInvariantsTest` 14/14, `DeployV4AuthoriserCloneTest` 13/13 (Base, Robinhood, BSC public RPCs). `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8ViHcKLVk2YoS2joH4HdN