### PR TITLE
test: the four factory-derived clone pins equal CREATE(factory, nonce 1)

### DIFF
--- a/test/src/lib/LibAuthoriserInvariants.t.sol
+++ b/test/src/lib/LibAuthoriserInvariants.t.sol
@@ -20,6 +20,7 @@ import {LibProdDeployV4} from "../../../src/generated/LibProdDeployV4.sol";
 import {LibAuthoriserInvariantsHarness} from "./LibAuthoriserInvariantsHarness.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.4/src/lib/LibRainDeploy.sol";
 import {LibStoxDeployNetworks} from "../../../src/lib/LibStoxDeployNetworks.sol";
+import {LibCloneFactoryDeploy} from "rain-factory-0.1.1/src/lib/LibCloneFactoryDeploy.sol";
 
 /// @title LibAuthoriserInvariantsTest
 /// @notice Fork tests pinning the production V4 authoriser clone's state
@@ -54,6 +55,19 @@ contract LibAuthoriserInvariantsTest is Test {
     /// (orchestrator rows included, pointing at the not-yet-deployed
     /// instance pin). Live drift detector on an unpinned fork, same
     /// precedent as `testAssertAllPasses`.
+    /// @notice The four factory-derived clone pins are the first CREATE from
+    /// the canonical CloneFactory (nonce 1) on each chain, re-derived here so a
+    /// mistyped literal fails fork-free. Base's clone came from a factory with
+    /// history and is not derivable.
+    function testClonePinsMatchTheFactoryNonceOneDerivation() external pure {
+        address derived = vm.computeCreateAddress(LibCloneFactoryDeploy.CLONE_FACTORY_DEPLOYED_ADDRESS, 1);
+        assertEq(LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ETHEREUM, derived, "ethereum");
+        assertEq(LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_HYPEREVM, derived, "hyperevm");
+        assertEq(LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD, derived, "robinhood");
+        assertEq(LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC, derived, "bsc");
+        assertNotEq(LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE, derived, "base");
+    }
+
     /// @notice The one chain-to-clone table resolves every pinned chain to
     /// its slot and refuses the rest, fork-free.
     function testAuthoriserForChainIdResolvesEveryPinnedChain() external {


### PR DESCRIPTION
From the #344 review. The Ethereum, HyperEVM, Robinhood and BSC clone pins in `LibProdDeployV4` are hand-typed literals whose stated derivation (first `CloneFactory.clone`, a plain CREATE, from the canonical factory at nonce 1) nothing asserted. The repo's other literal pins carry a fork-free re-derivation test (orchestrator beacon, all five timelocks); these did not.

## What changes
- `testClonePinsMatchTheFactoryNonceOneDerivation`: pure; each of the four pins equals `vm.computeCreateAddress(CLONE_FACTORY_DEPLOYED_ADDRESS, 1)`, Base's does not.

## QA
- Discriminating tests: `testClonePinsMatchTheFactoryNonceOneDerivation` (fails on base: absent).
- Mutations applied:
  - Robinhood literal last byte `57 -> 58` (checksummed) -> killed fork-free by the new test; also by the Robinhood fork test, which is the RPC-gated path the finding wanted a fork-free twin for.
- Oracle: `vm.computeCreateAddress` over the rain-factory pinned factory address and nonce 1, independent of the generated literals.
- Category check: the finding asked for one pure test asserting the four pins against the derivation; covered.

## Checks
Local: `LibAuthoriserInvariantsTest` 15/15. `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8ViHcKLVk2YoS2joH4HdN