### PR TITLE
test: one chain-resolved canonical-map leg per production chain

### DIFF
--- a/test/src/lib/LibAuthoriserInvariants.t.sol
+++ b/test/src/lib/LibAuthoriserInvariants.t.sol
@@ -49,12 +49,6 @@ contract LibAuthoriserInvariantsTest is Test {
         LibAuthoriserInvariants.assertAll();
     }
 
-    /// @notice Robinhood Chain's arm resolves to its hydrated pin, the clone
-    /// is live at it with the pinned EIP-1167 codehash, and the ceremony
-    /// left it on the canonical grant map keyed to that chain's Safe
-    /// (orchestrator rows included, pointing at the not-yet-deployed
-    /// instance pin). Live drift detector on an unpinned fork, same
-    /// precedent as `testAssertAllPasses`.
     /// @notice The four factory-derived clone pins are the first CREATE from
     /// the canonical CloneFactory (nonce 1) on each chain, re-derived here so a
     /// mistyped literal fails fork-free. Base's clone came from a factory with
@@ -133,21 +127,40 @@ contract LibAuthoriserInvariantsTest is Test {
         harness.callActiveChainAuthoriser();
     }
 
-    function testRobinhoodAuthoriserIsLiveOnTheCanonicalMap() external {
-        vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
-        LibAuthoriserInvariantsHarness harness = new LibAuthoriserInvariantsHarness();
-        address authoriser = harness.callActiveChainAuthoriser();
-        assertEq(authoriser, LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_ROBINHOOD, "Robinhood arm != pin");
-        LibAuthoriserInvariants.assertExpectedGrants(authoriser, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_ROBINHOOD);
+    /// @notice The active fork's arm resolves to a live clone with the pinned
+    /// EIP-1167 codehash, on the canonical grant map keyed to that chain's
+    /// Safe. Both resolve from `block.chainid`, as the scripts do, so a leg
+    /// forking the wrong chain or an arm pointing at the wrong slot fails
+    /// here. Live drift detector on an unpinned fork.
+    function assertAuthoriserLiveOnCanonicalMap() internal view {
+        LibAuthoriserInvariants.assertExpectedGrants(
+            LibAuthoriserInvariants.activeChainAuthoriser(), LibSafeInvariants.safeForChainId(block.chainid)
+        );
     }
 
-    /// @notice Same for BNB Smart Chain.
+    function testBaseAuthoriserIsLiveOnTheCanonicalMap() external {
+        selectBaseFork();
+        assertAuthoriserLiveOnCanonicalMap();
+    }
+
+    function testEthereumAuthoriserIsLiveOnTheCanonicalMap() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ETHEREUM);
+        assertAuthoriserLiveOnCanonicalMap();
+    }
+
+    function testHyperEvmAuthoriserIsLiveOnTheCanonicalMap() external {
+        vm.createSelectFork(LibStoxDeployNetworks.HYPEREVM);
+        assertAuthoriserLiveOnCanonicalMap();
+    }
+
+    function testRobinhoodAuthoriserIsLiveOnTheCanonicalMap() external {
+        vm.createSelectFork(LibStoxDeployNetworks.ROBINHOOD);
+        assertAuthoriserLiveOnCanonicalMap();
+    }
+
     function testBscAuthoriserIsLiveOnTheCanonicalMap() external {
         vm.createSelectFork(LibStoxDeployNetworks.BSC);
-        LibAuthoriserInvariantsHarness harness = new LibAuthoriserInvariantsHarness();
-        address authoriser = harness.callActiveChainAuthoriser();
-        assertEq(authoriser, LibProdDeployV4.STOX_PROD_AUTHORISER_V4_CLONE_BSC, "BSC arm != pin");
-        LibAuthoriserInvariants.assertExpectedGrants(authoriser, LibSafeInvariants.STOX_TOKEN_OWNER_SAFE_BSC);
+        assertAuthoriserLiveOnCanonicalMap();
     }
 
     /// @notice `assertAll` reverts `AuthoriserImplCodehashMismatch` when the


### PR DESCRIPTION
From the #344 review. The Robinhood and BSC canonical-map tests were verbatim copies whose address assert could not discriminate (every non-Base clone pin is the same literal) and whose Safe was hand-named rather than resolved from the chain id the way the script under test does.

## What changes
- `assertAuthoriserLiveOnCanonicalMap()`: resolves authoriser and Safe from `block.chainid` via `activeChainAuthoriser()` and `safeForChainId()`, then asserts the canonical grant map.
- Five one-line legs: Base, Ethereum, HyperEVM, Robinhood, BSC. Base, Ethereum and HyperEVM gain arm-to-map coverage this file lacked.
- The two copies and their dangling NatSpec are gone. The harness shim stays: the fork-free revert tests from #370 need it for `vm.expectRevert`.

## QA
- Discriminating tests: the five `test*AuthoriserIsLiveOnTheCanonicalMap` legs (the Ethereum, HyperEVM and Base legs fail on base as absent; the Robinhood and BSC legs exist on base but pass the two mutations below).
- Mutations applied (live forks):
  - `authoriserForChainId` Robinhood arm returns Base's clone -> killed by the Robinhood leg (`AuthoriserNotReady(0x315b…)`, no code on 4663) and two fork-free tests
  - `safeForChainId` Robinhood arm returns Base's Safe -> killed by the Robinhood leg alone (`ExpectedGrantMissing(…, 0xe70d…)`); the old copy passed it, its Safe was hand-named
- Oracle: live grant state on each chain's clone, keyed to the chain's pinned Safe.
- Category check: the finding asked for a shared chain-resolved helper, the non-discriminating assertEq dropped, and the other three chains covered; all covered.

## Checks
Local: `LibAuthoriserInvariantsTest` 18/18 across five public RPC forks. `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8ViHcKLVk2YoS2joH4HdN