### PR TITLE
test: the revoked-orchestrator-grant check runs under all five production chain ids

### DIFF
--- a/test/src/lib/LibAuthoriserInvariants.t.sol
+++ b/test/src/lib/LibAuthoriserInvariants.t.sol
@@ -327,8 +327,13 @@ contract LibAuthoriserInvariantsTest is Test {
             abi.encodeWithSelector(IAccessControl.hasRole.selector, keccak256("WITHDRAW"), orchestrator),
             abi.encode(false)
         );
-        uint256[3] memory chainIds =
-            [LibSafeInvariants.BASE_CHAIN_ID, LibSafeInvariants.ETHEREUM_CHAIN_ID, LibSafeInvariants.HYPEREVM_CHAIN_ID];
+        uint256[5] memory chainIds = [
+            LibSafeInvariants.BASE_CHAIN_ID,
+            LibSafeInvariants.ETHEREUM_CHAIN_ID,
+            LibSafeInvariants.HYPEREVM_CHAIN_ID,
+            LibSafeInvariants.ROBINHOOD_CHAIN_ID,
+            LibSafeInvariants.BSC_CHAIN_ID
+        ];
         for (uint256 i = 0; i < chainIds.length; i++) {
             vm.chainId(chainIds[i]);
             vm.expectRevert(


### PR DESCRIPTION
From the #344 review. `testAssertExpectedGrantsRejectsARevokedOrchestratorGrant` claims strictness under every production chain id but looped over Base, Ethereum and HyperEVM only; #344 made Robinhood and BSC production authoriser chains without extending it.

## What changes
- The chain id array is five: Robinhood and BSC join.

## QA
- Discriminating tests: `testAssertExpectedGrantsRejectsARevokedOrchestratorGrant` (on base the Robinhood and BSC iterations do not run).
- Mutations applied:
  - `assertExpectedGrants` skips a missing orchestrator row when `block.chainid` is Robinhood -> killed (the Robinhood iteration no longer reverts); passes on base, which is the gap the finding named.
- Oracle: the lib's `ExpectedGrantMissing` selector and the mocked-false orchestrator `WITHDRAW` row.
- Category check: the finding asked for the array extended or the per-chain claim dropped; extended.

## Checks
Local: the test passes on the Base fork. `forge fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8ViHcKLVk2YoS2joH4HdN