### PR TITLE
docs: the authoriser lib and its test span every production chain, not Base

### DIFF
--- a/src/lib/LibAuthoriserInvariants.sol
+++ b/src/lib/LibAuthoriserInvariants.sol
@@ -63,7 +63,8 @@ error UnsupportedChainForAuthoriser(uint256 chainId);
 error AuthoriserNotReady(address authoriser);
 
 /// @title LibAuthoriserInvariants
-/// @notice Reusable invariants for the ST0x production authoriser on Base:
+/// @notice Reusable invariants for the ST0x production authoriser on every
+/// chain:
 /// the grantee constants and the single master `(role, grantee)` map every
 /// consumer asserts. Each assertion either returns silently when the
 /// invariant holds against the live chain state or reverts with a typed

--- a/test/src/lib/LibAuthoriserInvariants.t.sol
+++ b/test/src/lib/LibAuthoriserInvariants.t.sol
@@ -30,8 +30,8 @@ import {LibCloneFactoryDeploy} from "rain-factory-0.1.1/src/lib/LibCloneFactoryD
 /// `expectedGrants()` map against the live clone. Any drift (a grant
 /// missing on-chain, or the clone's bytecode changing) surfaces as a typed
 /// error here.
-/// @dev Uses an unpinned Base head fork (same precedent as the other
-/// prod-state drift detectors in this repo). Pinning would freeze the
+/// @dev Uses unpinned head forks of each production chain (same precedent
+/// as the other prod-state drift detectors in this repo). Pinning would freeze the
 /// invariant assertions against a stale snapshot and let new drift slip
 /// through unnoticed.
 contract LibAuthoriserInvariantsTest is Test {


### PR DESCRIPTION
From the #344 review, the last item. Two headers #344 left false: the test file said it uses an unpinned Base head fork while forking five chains, and the lib title said authoriser on Base over a five-chain switch. The stale not-yet-deployed status prose and the BuildPointers run ids it also named were removed in #374 and #372.

Comments only.

## QA
- Discriminating tests: n/a, comment-only diff; `forge build` clean.
- Mutations applied: n/a, no executable change.
- Oracle: the test file forks five chains and `authoriserForChainId` has five arms.
- Category check: the finding asked for the two headers corrected and the status prose and run ids dropped; the headers here, the rest already landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8ViHcKLVk2YoS2joH4HdN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that authoriser invariants apply to the production authoriser across every supported chain.
  - Updated test documentation to reflect coverage using current head forks for each production chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->